### PR TITLE
Fix compile warnings for deprecated functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ programs/ekr_peer
 programs/ekr_server
 programs/rtcweb
 programs/tsctp
+
+# callgrind
+callgrind.out*

--- a/programs/ekr_client.c
+++ b/programs/ekr_client.c
@@ -187,7 +187,10 @@ main(int argc, char *argv[])
 	sin.sin_len = sizeof(struct sockaddr_in);
 #endif
 	sin.sin_port = htons(atoi(argv[2]));
-	sin.sin_addr.s_addr = inet_addr(argv[1]);
+	if(!inet_pton(AF_INET, argv[1], &sin.sin_addr.s_addr)){
+		printf("error: invalid address\n");
+		exit(1);
+	}
 #ifdef _WIN32
 	if (bind(fd, (struct sockaddr *)&sin, sizeof(struct sockaddr_in)) == SOCKET_ERROR) {
 		printf("bind() failed with error: %ld\n", WSAGetLastError());
@@ -203,7 +206,10 @@ main(int argc, char *argv[])
 	sin.sin_len = sizeof(struct sockaddr_in);
 #endif
 	sin.sin_port = htons(atoi(argv[4]));
-	sin.sin_addr.s_addr = inet_addr(argv[3]);
+	if(!inet_pton(AF_INET, argv[3], &sin.sin_addr.s_addr)){
+		printf("error: invalid address\n");
+		exit(1);
+	}
 #ifdef _WIN32
 	if (connect(fd, (struct sockaddr *)&sin, sizeof(struct sockaddr_in)) == SOCKET_ERROR) {
 		printf("connect() failed with error: %ld\n", WSAGetLastError());

--- a/programs/ekr_peer.c
+++ b/programs/ekr_peer.c
@@ -382,7 +382,10 @@ main(int argc, char *argv[])
 	sin.sin_len = sizeof(struct sockaddr_in);
 #endif
 	sin.sin_port = htons(atoi(argv[2]));
-	sin.sin_addr.s_addr = inet_addr(argv[1]);
+	if(!inet_pton(AF_INET, argv[1], &sin.sin_addr.s_addr)){
+		printf("error: invalid address\n");
+		exit(1);
+	}
 #ifdef _WIN32
 	if (bind(fd, (struct sockaddr *)&sin, sizeof(struct sockaddr_in)) == SOCKET_ERROR) {
 		printf("bind() failed with error: %ld\n", WSAGetLastError());
@@ -398,7 +401,10 @@ main(int argc, char *argv[])
 	sin.sin_len = sizeof(struct sockaddr_in);
 #endif
 	sin.sin_port = htons(atoi(argv[4]));
-	sin.sin_addr.s_addr = inet_addr(argv[3]);
+	if(!inet_pton(AF_INET, argv[3], &sin.sin_addr.s_addr)){
+		printf("error: invalid address\n");
+		exit(1);
+	}
 #ifdef _WIN32
 	if (connect(fd, (struct sockaddr *)&sin, sizeof(struct sockaddr_in)) == SOCKET_ERROR) {
 		printf("connect() failed with error: %ld\n", WSAGetLastError());

--- a/programs/ekr_server.c
+++ b/programs/ekr_server.c
@@ -183,7 +183,10 @@ main(int argc, char *argv[])
 	sin.sin_len = sizeof(struct sockaddr_in);
 #endif
 	sin.sin_port = htons(atoi(argv[2]));
-	sin.sin_addr.s_addr = inet_addr(argv[1]);
+	if(!inet_pton(AF_INET, argv[1], &sin.sin_addr.s_addr)){
+		printf("error: invalid address\n");
+		exit(1);
+	}
 #ifdef _WIN32
 	if (bind(fd, (struct sockaddr *)&sin, sizeof(struct sockaddr_in)) == SOCKET_ERROR) {
 		printf("bind() failed with error: %ld\n", WSAGetLastError());
@@ -199,7 +202,10 @@ main(int argc, char *argv[])
 	sin.sin_len = sizeof(struct sockaddr_in);
 #endif
 	sin.sin_port = htons(atoi(argv[4]));
-	sin.sin_addr.s_addr = inet_addr(argv[3]);
+	if(!inet_pton(AF_INET, argv[3], &sin.sin_addr.s_addr)){
+		printf("error: invalid address\n");
+		exit(1);
+	}
 #ifdef _WIN32
 	if (connect(fd, (struct sockaddr *)&sin, sizeof(struct sockaddr_in)) == SOCKET_ERROR) {
 		printf("connect() failed with error: %ld\n", WSAGetLastError());

--- a/programs/tsctp.c
+++ b/programs/tsctp.c
@@ -406,7 +406,7 @@ int main(int argc, char **argv)
 				fragpoint = atoi(optarg);
 				break;
 			case 'L':
-				srcAddr = inet_addr(optarg);
+				inet_pton(AF_INET, optarg, &srcAddr);
 				break;
 			case 'R':
 				rcvbufsize = atoi(optarg);
@@ -491,7 +491,7 @@ int main(int argc, char **argv)
 						exit(1);
 					}
 					opt = argv[optind];
-					srcAddr = inet_addr(opt);
+					inet_pton(AF_INET, opt, &srcAddr);
 					break;
 				case 'U':
 					if (++optind >= argc) {
@@ -658,7 +658,10 @@ int main(int argc, char **argv)
 #endif
 			}
 			if (verbose) {
-				printf("Connection accepted from %s:%d\n", inet_ntoa(remote_addr.sin_addr), ntohs(remote_addr.sin_port));
+				// const char *inet_ntop(int af, const void *src, char *dst, socklen_t size)
+				//inet_ntoa(remote_addr.sin_addr)
+				char addrbuf[INET_ADDRSTRLEN];
+				printf("Connection accepted from %s:%d\n", inet_ntop(AF_INET, &(remote_addr.sin_addr), addrbuf, INET_ADDRSTRLEN), ntohs(remote_addr.sin_port));
 			}
 		}
 		usrsctp_close(psock);
@@ -674,7 +677,10 @@ int main(int argc, char **argv)
 #ifdef HAVE_SIN_LEN
 		remote_addr.sin_len = sizeof(struct sockaddr_in);
 #endif
-		remote_addr.sin_addr.s_addr = inet_addr(argv[optind]);
+		if(!inet_pton(AF_INET, argv[optind], &remote_addr.sin_addr.s_addr)){
+			printf("error: invalid destination address\n");
+			exit(1);
+		}
 		remote_addr.sin_port = htons(remote_port);
 
 		/* TODO fragpoint stuff */


### PR DESCRIPTION
Removed deprecated functions like inet_addr() to get rid of compiler warnings.