### PR TITLE
Fix compilation with GCC 5

### DIFF
--- a/usrsctplib/netinet/sctp_auth.c
+++ b/usrsctplib/netinet/sctp_auth.c
@@ -560,7 +560,7 @@ sctp_auth_key_acquire(struct sctp_tcb *stcb, uint16_t key_id)
 		atomic_add_int(&skey->refcount, 1);
 		SCTPDBG(SCTP_DEBUG_AUTH2,
 			"%s: stcb %p key %u refcount acquire to %d\n",
-			__FUNCTION__, (void *)stcb, key_id, skey->refcount);
+			__func__, (void *)stcb, key_id, skey->refcount);
 	}
 }
 
@@ -580,7 +580,7 @@ sctp_auth_key_release(struct sctp_tcb *stcb, uint16_t key_id, int so_locked
 	if (skey) {
 		SCTPDBG(SCTP_DEBUG_AUTH2,
 			"%s: stcb %p key %u refcount release to %d\n",
-			__FUNCTION__, (void *)stcb, key_id, skey->refcount);
+			__func__, (void *)stcb, key_id, skey->refcount);
 
 		/* see if a notification should be generated */
 		if ((skey->refcount <= 2) && (skey->deactivated)) {
@@ -589,7 +589,7 @@ sctp_auth_key_release(struct sctp_tcb *stcb, uint16_t key_id, int so_locked
 					key_id, 0, so_locked);
 			SCTPDBG(SCTP_DEBUG_AUTH2,
 				"%s: stcb %p key %u no longer used, %d\n",
-				__FUNCTION__, (void *)stcb, key_id, skey->refcount);
+				__func__, (void *)stcb, key_id, skey->refcount);
 		}
 		sctp_free_sharedkey(skey);
 	}

--- a/usrsctplib/netinet/sctp_input.c
+++ b/usrsctplib/netinet/sctp_input.c
@@ -4757,7 +4757,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 			}
 		}
 		if (stcb == NULL) {
-			snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __FUNCTION__);
+			snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __func__);
 			op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 			                             msg);
 			/* no association, so it's out of the blue... */
@@ -4803,7 +4803,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 				if (locked_tcb) {
 					SCTP_TCB_UNLOCK(locked_tcb);
 				}
-				snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __FUNCTION__);
+				snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __func__);
 				op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 				                             msg);
 				sctp_handle_ootb(m, iphlen, *offset, src, dst,
@@ -5978,7 +5978,7 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 			 */
 			SCTP_TCB_UNLOCK(stcb);
 			stcb = NULL;
-			snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __FUNCTION__);
+			snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __func__);
 			op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 			                             msg);
 			sctp_handle_ootb(m, iphlen, offset, src, dst, sh, inp, op_err,
@@ -6034,7 +6034,7 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 		}
 		if (stcb == NULL) {
 			/* out of the blue DATA chunk */
-			snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __FUNCTION__);
+			snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __func__);
 			op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 			                             msg);
 			sctp_handle_ootb(m, iphlen, offset, src, dst, sh, inp, op_err,
@@ -6109,7 +6109,7 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 			/*
 			 * We consider OOTB any data sent during asoc setup.
 			 */
-			snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __FUNCTION__);
+			snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __func__);
 			op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 			                             msg);
 			sctp_handle_ootb(m, iphlen, offset, src, dst, sh, inp, op_err,

--- a/usrsctplib/netinet/sctp_os_userspace.h
+++ b/usrsctplib/netinet/sctp_os_userspace.h
@@ -1129,7 +1129,7 @@ sctp_get_mbuf_for_msg(unsigned int space_needed, int want_header, int how, int a
 #endif
 #define I_AM_HERE \
                 do { \
-			SCTP_PRINTF("%s:%d at %s\n", __FILE__, __LINE__ , __FUNCTION__); \
+			SCTP_PRINTF("%s:%d at %s\n", __FILE__, __LINE__ , __func__); \
 		} while (0)
 
 #ifndef timevalsub

--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -2470,7 +2470,7 @@ sctp_is_addr_restricted(struct sctp_tcb *stcb, struct sctp_ifa *ifa)
 	LIST_FOREACH(laddr, &stcb->asoc.sctp_restricted_addrs, sctp_nxt_addr) {
 		if (laddr->ifa == NULL) {
 			SCTPDBG(SCTP_DEBUG_OUTPUT1, "%s: NULL ifa\n",
-				__FUNCTION__);
+				__func__);
 			continue;
 		}
 		if (laddr->ifa == ifa) {
@@ -2492,7 +2492,7 @@ sctp_is_addr_in_ep(struct sctp_inpcb *inp, struct sctp_ifa *ifa)
 	LIST_FOREACH(laddr, &inp->sctp_addr_list, sctp_nxt_addr) {
 		if (laddr->ifa == NULL) {
 			SCTPDBG(SCTP_DEBUG_OUTPUT1, "%s: NULL ifa\n",
-				__FUNCTION__);
+				__func__);
 			continue;
 		}
 		if ((laddr->ifa == ifa) && laddr->action == 0)
@@ -5891,7 +5891,7 @@ sctp_send_initiate_ack(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 		if (op_err == NULL) {
 			char msg[SCTP_DIAG_INFO_LEN];
 
-			snprintf(msg, sizeof(msg), "%s:%d at %s", __FILE__, __LINE__, __FUNCTION__);
+			snprintf(msg, sizeof(msg), "%s:%d at %s", __FILE__, __LINE__, __func__);
 			op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 			                             msg);
 		}
@@ -7107,7 +7107,7 @@ sctp_sendall_iterator(struct sctp_inpcb *inp, struct sctp_tcb *stcb, void *ptr,
 
 					abort_anyway:
 						snprintf(msg, sizeof(msg),
-						         "%s:%d at %s", __FILE__, __LINE__, __FUNCTION__);
+						         "%s:%d at %s", __FILE__, __LINE__, __func__);
 						op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 						                             msg);
 						atomic_add_int(&stcb->asoc.refcnt, 1);
@@ -14415,7 +14415,7 @@ dataless_eof:
 						free_cnt_applied = 0;
 					}
 					snprintf(msg, sizeof(msg),
-					         "%s:%d at %s", __FILE__, __LINE__, __FUNCTION__);
+					         "%s:%d at %s", __FILE__, __LINE__, __func__);
 					op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 					                             msg);
 					sctp_abort_an_association(stcb->sctp_ep, stcb,

--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -1285,7 +1285,7 @@ sctp_tcb_special_locate(struct sctp_inpcb **inp_p, struct sockaddr *from,
 			LIST_FOREACH(laddr, &inp->sctp_addr_list, sctp_nxt_addr) {
 
 				if (laddr->ifa == NULL) {
-					SCTPDBG(SCTP_DEBUG_PCB1, "%s: NULL ifa\n", __FUNCTION__);
+					SCTPDBG(SCTP_DEBUG_PCB1, "%s: NULL ifa\n", __func__);
 					continue;
 				}
 				if (laddr->ifa->localifa_flags & SCTP_BEING_DELETED) {
@@ -2084,7 +2084,7 @@ sctp_endpoint_probe(struct sockaddr *nam, struct sctppcbhead *head,
 		LIST_FOREACH(laddr, &inp->sctp_addr_list, sctp_nxt_addr) {
 			if (laddr->ifa == NULL) {
 				SCTPDBG(SCTP_DEBUG_PCB1, "%s: NULL ifa\n",
-					__FUNCTION__);
+					__func__);
 				continue;
 			}
 			SCTPDBG(SCTP_DEBUG_PCB1, "Ok laddr->ifa:%p is possible, ",
@@ -2693,7 +2693,7 @@ sctp_findassociation_ep_asconf(struct mbuf *m, int offset,
 				   &parm_buf, sizeof(struct sctp_paramhdr));
 	if (phdr == NULL) {
 		SCTPDBG(SCTP_DEBUG_INPUT3, "%s: failed to get asconf lookup addr\n",
-			__FUNCTION__);
+			__func__);
 		return NULL;
 	}
 	ptype = (int)((uint32_t) ntohs(phdr->param_type));
@@ -2713,7 +2713,7 @@ sctp_findassociation_ep_asconf(struct mbuf *m, int offset,
 								       &p6_buf.ph, sizeof(*p6));
 		if (p6 == NULL) {
 			SCTPDBG(SCTP_DEBUG_INPUT3, "%s: failed to get asconf v6 lookup addr\n",
-				__FUNCTION__);
+				__func__);
 			return (NULL);
 		}
 		sin6 = &remote_store.sin6;
@@ -2742,7 +2742,7 @@ sctp_findassociation_ep_asconf(struct mbuf *m, int offset,
 								       &p4_buf.ph, sizeof(*p4));
 		if (p4 == NULL) {
 			SCTPDBG(SCTP_DEBUG_INPUT3, "%s: failed to get asconf v4 lookup addr\n",
-				__FUNCTION__);
+				__func__);
 			return (NULL);
 		}
 		sin = &remote_store.sin;
@@ -6102,7 +6102,7 @@ sctp_update_ep_vflag(struct sctp_inpcb *inp)
 	LIST_FOREACH(laddr, &inp->sctp_addr_list, sctp_nxt_addr) {
 		if (laddr->ifa == NULL) {
 			SCTPDBG(SCTP_DEBUG_PCB1, "%s: NULL ifa\n",
-				__FUNCTION__);
+				__func__);
 			continue;
 		}
 
@@ -7292,7 +7292,7 @@ sctp_load_addresses_from_init(struct sctp_tcb *stcb, struct mbuf *m,
 
 							/* in setup state we abort this guy */
 							snprintf(msg, sizeof(msg),
-							         "%s:%d at %s", __FILE__, __LINE__, __FUNCTION__);
+							         "%s:%d at %s", __FILE__, __LINE__, __func__);
 							op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 							         msg);
 							sctp_abort_an_association(stcb_tmp->sctp_ep,
@@ -7386,7 +7386,7 @@ sctp_load_addresses_from_init(struct sctp_tcb *stcb, struct mbuf *m,
 
 							/* in setup state we abort this guy */
 							snprintf(msg, sizeof(msg),
-							         "%s:%d at %s", __FILE__, __LINE__, __FUNCTION__);
+							         "%s:%d at %s", __FILE__, __LINE__, __func__);
 							op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 							         msg);
 							sctp_abort_an_association(stcb_tmp->sctp_ep,

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -6655,7 +6655,7 @@ sctp_setopt(struct socket *so, int optname, void *optval, size_t optsize,
 				LIST_FOREACH(laddr, &inp->sctp_addr_list, sctp_nxt_addr) {
 					if (laddr->ifa == NULL) {
 						SCTPDBG(SCTP_DEBUG_OUTPUT1, "%s: NULL ifa\n",
-							__FUNCTION__);
+							__func__);
 						continue;
 					}
 					if (laddr->ifa == ifa) {

--- a/usrsctplib/netinet/sctputil.c
+++ b/usrsctplib/netinet/sctputil.c
@@ -2299,13 +2299,13 @@ sctp_timer_start(int t_type, struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 		break;
 	default:
 		SCTPDBG(SCTP_DEBUG_TIMER1, "%s: Unknown timer type %d\n",
-			__FUNCTION__, t_type);
+			__func__, t_type);
 		return;
 		break;
 	}
 	if ((to_ticks <= 0) || (tmr == NULL)) {
 		SCTPDBG(SCTP_DEBUG_TIMER1, "%s: %d:software error to_ticks:%d tmr:%p not set ??\n",
-			__FUNCTION__, t_type, to_ticks, (void *)tmr);
+			__func__, t_type, to_ticks, (void *)tmr);
 		return;
 	}
 	if (SCTP_OS_TIMER_PENDING(&tmr->timer)) {
@@ -2465,7 +2465,7 @@ sctp_timer_stop(int t_type, struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 		break;
 	default:
 		SCTPDBG(SCTP_DEBUG_TIMER1, "%s: Unknown timer type %d\n",
-			__FUNCTION__, t_type);
+			__func__, t_type);
 		break;
 	}
 	if (tmr == NULL) {
@@ -3942,7 +3942,7 @@ sctp_ulp_notify(uint32_t notification, struct sctp_tcb *stcb,
 		break;
 	default:
 		SCTPDBG(SCTP_DEBUG_UTIL1, "%s: unknown notification %xh (%u)\n",
-			__FUNCTION__, notification, notification);
+			__func__, notification, notification);
 		break;
 	}			/* end switch */
 }


### PR DESCRIPTION
GCC 5 only allows the use of `__FUNCTION__` as an extension. so
it must be prefixed by `__extension__`, though the standard (since C99)
`__func__` is preferred. So use the latter since -std=c99 is required anyway.

Fixes the following errors:

~~~~
In file included from ./netinet/sctp_os.h:72:0,
                 from netinet/sctp_auth.c:38:
netinet/sctp_auth.c: In function 'sctp_auth_key_acquire':
netinet/sctp_auth.c:563:4: error: ISO C does not support '__FUNCTION__' predefined identifier [-Werror=pedantic]
    __FUNCTION__, (void *)stcb, key_id, skey->refcount);
    ^
./netinet/sctp_os_userspace.h:560:31: note: in definition of macro 'SCTP_PRINTF'
   SCTP_BASE_VAR(debug_printf)(__VA_ARGS__); \
                               ^
netinet/sctp_auth.c:561:3: note: in expansion of macro 'SCTPDBG'
   SCTPDBG(SCTP_DEBUG_AUTH2,
   ^
netinet/sctp_auth.c: In function 'sctp_auth_key_release':
netinet/sctp_auth.c:583:4: error: ISO C does not support '__FUNCTION__' predefined identifier [-Werror=pedantic]
    __FUNCTION__, (void *)stcb, key_id, skey->refcount);
    ^
./netinet/sctp_os_userspace.h:560:31: note: in definition of macro 'SCTP_PRINTF'
   SCTP_BASE_VAR(debug_printf)(__VA_ARGS__); \
                               ^
netinet/sctp_auth.c:581:3: note: in expansion of macro 'SCTPDBG'
   SCTPDBG(SCTP_DEBUG_AUTH2,
   ^
netinet/sctp_auth.c:592:5: error: ISO C does not support '__FUNCTION__' predefined identifier [-Werror=pedantic]
     __FUNCTION__, (void *)stcb, key_id, skey->refcount);
     ^
./netinet/sctp_os_userspace.h:560:31: note: in definition of macro 'SCTP_PRINTF'
   SCTP_BASE_VAR(debug_printf)(__VA_ARGS__); \
                               ^
netinet/sctp_auth.c:590:4: note: in expansion of macro 'SCTPDBG'
    SCTPDBG(SCTP_DEBUG_AUTH2,
    ^
cc1: all warnings being treated as errors
~~~~