### PR TITLE
Data racing fix on reading ticks in sctp_callout.

### DIFF
--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -56,10 +56,17 @@
  * Callout/Timer routines for OS that doesn't have them
  */
 #if defined(__APPLE__) || defined(__Userspace__)
-int ticks = 0;
+static int ticks = 0;
 #else
 extern int ticks;
 #endif
+
+int sctp_get_tick_count() {
+    SCTP_TIMERQ_LOCK();
+    int ret = ticks;
+    SCTP_TIMERQ_UNLOCK();
+    return ret;
+}
 
 /*
  * SCTP_TIMERQ_LOCK protects:

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -63,8 +63,9 @@ __FBSDID("$FreeBSD$");
 #define SCTP_TIMERQ_LOCK_DESTROY()  (void)pthread_mutex_destroy(&SCTP_BASE_VAR(timer_mtx))
 #endif
 
-extern int ticks;
 #endif
+
+int sctp_get_tick_count();
 
 TAILQ_HEAD(calloutlist, sctp_callout);
 

--- a/usrsctplib/netinet/sctp_os_userspace.h
+++ b/usrsctplib/netinet/sctp_os_userspace.h
@@ -809,8 +809,6 @@ sctp_hashfreedestroy(void *vhashtbl, struct malloc_type *type, u_long hashmask);
 /*__Userspace__ defining KTR_SUBSYS 1 as done in sctp_os_macosx.h */
 #define KTR_SUBSYS 1
 
-#define sctp_get_tick_count() (ticks)
-
 /* The packed define for 64 bit platforms */
 #if !defined(__Userspace_os_Windows)
 #define SCTP_PACKED __attribute__((packed))


### PR DESCRIPTION
Caught by a data race detector.