### PR TITLE
GCC5 Support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ if test "x$GCC" = "xyes" -o "x$CC" = "xclang" ; then
 fi
 
 if test "x$ac_supports_gcc_flags" = "xyes" ; then
-        CFLAGS="$CFLAGS -pedantic -Wall"
+        CFLAGS="$CFLAGS -Wall"
 fi
 
 AC_MSG_CHECKING(whether we should treat compiler warnings as errors)


### PR DESCRIPTION
gcc-5 adjusted the gcc interpretation of pedantic, which usrsctp violates.

Temporarily removed the pedantic flag until this can be resolved.