### PR TITLE
Fix calling convention mismatch for thread creation argument

### DIFF
--- a/usrsctplib/netinet/sctp_bsd_addr.c
+++ b/usrsctplib/netinet/sctp_bsd_addr.c
@@ -199,13 +199,9 @@ sctp_startup_iterator(void)
 #elif defined(__APPLE__)
 	kernel_thread_start((thread_continue_t)sctp_iterator_thread, NULL, &sctp_it_ctl.thread_proc);
 #elif defined(__Userspace__)
-#if defined(__Userspace_os_Windows)
-	if ((sctp_it_ctl.thread_proc = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)&sctp_iterator_thread, NULL, 0, NULL)) == NULL) {
-#else
-	if (pthread_create(&sctp_it_ctl.thread_proc, NULL, &sctp_iterator_thread, NULL)) {
-#endif
+	if (sctp_thread_create(&sctp_it_ctl.thread_proc, &sctp_iterator_thread)) {
 		SCTP_PRINTF("ERROR: Creating sctp_iterator_thread failed.\n");
-	}
+        }
 #endif
 }
 

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -213,18 +213,12 @@ sctp_start_timer(void)
 	 * No need to do SCTP_TIMERQ_LOCK_INIT();
 	 * here, it is being done in sctp_pcb_init()
 	 */
-#if defined (__Userspace_os_Windows)
-	if ((SCTP_BASE_VAR(timer_thread) = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)user_sctp_timer_iterate, NULL, 0, NULL)) == NULL) {
-		SCTP_PRINTF("ERROR; Creating ithread failed\n");
-	}
-#else
 	int rc;
 
-	rc = pthread_create(&SCTP_BASE_VAR(timer_thread), NULL, user_sctp_timer_iterate, NULL);
+	rc = sctp_thread_create(&SCTP_BASE_VAR(timer_thread), user_sctp_timer_iterate);
 	if (rc) {
-		SCTP_PRINTF("ERROR; return code from pthread_create() is %d\n", rc);
+		SCTP_PRINTF("ERROR; return code from sctp_thread_create() is %d\n", rc);
 	}
-#endif
 }
 
 #endif

--- a/usrsctplib/netinet/sctp_os_userspace.h
+++ b/usrsctplib/netinet/sctp_os_userspace.h
@@ -1040,6 +1040,11 @@ struct sockaddr_conn {
 	void *sconn_addr;
 };
 
+typedef void *(*start_routine_t)(void *);
+
+extern int
+sctp_thread_create(userland_thread_t *thread, start_routine_t start_routine);
+
 void
 sctp_userspace_set_threadname(const char *name);
 

--- a/usrsctplib/user_recv_thread.c
+++ b/usrsctplib/user_recv_thread.c
@@ -1406,13 +1406,12 @@ recv_thread_init(void)
 		}
 	}
 #endif
-#if !defined(__Userspace_os_Windows)
 #if defined(__Userspace_os_Darwin) || defined(__Userspace_os_DragonFly) || defined(__Userspace_os_FreeBSD)
 #if defined(INET) || defined(INET6)
 	if (SCTP_BASE_VAR(userspace_route) != -1) {
 		int rc;
 
-		if ((rc = pthread_create(&SCTP_BASE_VAR(recvthreadroute), NULL, &recv_function_route, NULL))) {
+		if ((rc = sctp_thread_create(&SCTP_BASE_VAR(recvthreadroute), &recv_function_route))) {
 			SCTPDBG(SCTP_DEBUG_USR, "Can't start routing thread (%d).\n", rc);
 			close(SCTP_BASE_VAR(userspace_route));
 			SCTP_BASE_VAR(userspace_route) = -1;
@@ -1424,7 +1423,7 @@ recv_thread_init(void)
 	if (SCTP_BASE_VAR(userspace_rawsctp) != -1) {
 		int rc;
 
-		if ((rc = pthread_create(&SCTP_BASE_VAR(recvthreadraw), NULL, &recv_function_raw, NULL))) {
+		if ((rc = sctp_thread_create(&SCTP_BASE_VAR(recvthreadraw), &recv_function_raw))) {
 			SCTPDBG(SCTP_DEBUG_USR, "Can't start SCTP/IPv4 recv thread (%d).\n", rc);
 			close(SCTP_BASE_VAR(userspace_rawsctp));
 			SCTP_BASE_VAR(userspace_rawsctp) = -1;
@@ -1433,7 +1432,7 @@ recv_thread_init(void)
 	if (SCTP_BASE_VAR(userspace_udpsctp) != -1) {
 		int rc;
 
-		if ((rc = pthread_create(&SCTP_BASE_VAR(recvthreadudp), NULL, &recv_function_udp, NULL))) {
+		if ((rc = sctp_thread_create(&SCTP_BASE_VAR(recvthreadudp), &recv_function_udp))) {
 			SCTPDBG(SCTP_DEBUG_USR, "Can't start SCTP/UDP/IPv4 recv thread (%d).\n", rc);
 			close(SCTP_BASE_VAR(userspace_udpsctp));
 			SCTP_BASE_VAR(userspace_udpsctp) = -1;
@@ -1444,7 +1443,7 @@ recv_thread_init(void)
 	if (SCTP_BASE_VAR(userspace_rawsctp6) != -1) {
 		int rc;
 
-		if ((rc = pthread_create(&SCTP_BASE_VAR(recvthreadraw6), NULL, &recv_function_raw6, NULL))) {
+		if ((rc = sctp_thread_create(&SCTP_BASE_VAR(recvthreadraw6), &recv_function_raw6))) {
 			SCTPDBG(SCTP_DEBUG_USR, "Can't start SCTP/IPv6 recv thread (%d).\n", rc);
 			close(SCTP_BASE_VAR(userspace_rawsctp6));
 			SCTP_BASE_VAR(userspace_rawsctp6) = -1;
@@ -1453,46 +1452,12 @@ recv_thread_init(void)
 	if (SCTP_BASE_VAR(userspace_udpsctp6) != -1) {
 		int rc;
 
-		if ((rc = pthread_create(&SCTP_BASE_VAR(recvthreadudp6), NULL, &recv_function_udp6, NULL))) {
+		if ((rc = sctp_thread_create(&SCTP_BASE_VAR(recvthreadudp6), &recv_function_udp6))) {
 			SCTPDBG(SCTP_DEBUG_USR, "Can't start SCTP/UDP/IPv6 recv thread (%d).\n", rc);
 			close(SCTP_BASE_VAR(userspace_udpsctp6));
 			SCTP_BASE_VAR(userspace_udpsctp6) = -1;
 		}
 	}
-#endif
-#else
-#if defined(INET)
-	if (SCTP_BASE_VAR(userspace_rawsctp) != -1) {
-		if ((SCTP_BASE_VAR(recvthreadraw) = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)&recv_function_raw, NULL, 0, NULL)) == NULL) {
-			SCTPDBG(SCTP_DEBUG_USR, "Can't start SCTP/IPv4 recv thread.\n");
-			closesocket(SCTP_BASE_VAR(userspace_rawsctp));
-			SCTP_BASE_VAR(userspace_rawsctp) = -1;
-		}
-	}
-	if (SCTP_BASE_VAR(userspace_udpsctp) != -1) {
-		if ((SCTP_BASE_VAR(recvthreadudp) = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)&recv_function_udp, NULL, 0, NULL)) == NULL) {
-			SCTPDBG(SCTP_DEBUG_USR, "Can't start SCTP/UDP/IPv4 recv thread.\n");
-			closesocket(SCTP_BASE_VAR(userspace_udpsctp));
-			SCTP_BASE_VAR(userspace_udpsctp) = -1;
-		}
-	}
-#endif
-#if defined(INET6)
-	if (SCTP_BASE_VAR(userspace_rawsctp6) != -1) {
-		if ((SCTP_BASE_VAR(recvthreadraw6) = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)&recv_function_raw6, NULL, 0, NULL)) == NULL) {
-			SCTPDBG(SCTP_DEBUG_USR, "Can't start SCTP/IPv6 recv thread.\n");
-			closesocket(SCTP_BASE_VAR(userspace_rawsctp6));
-			SCTP_BASE_VAR(userspace_rawsctp6) = -1;
-		}
-	}
-	if (SCTP_BASE_VAR(userspace_udpsctp6) != -1) {
-		if ((SCTP_BASE_VAR(recvthreadudp6) = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)&recv_function_udp6, NULL, 0, NULL)) == NULL) {
-			SCTPDBG(SCTP_DEBUG_USR, "Can't start SCTP/UDP/IPv6 recv thread.\n");
-			closesocket(SCTP_BASE_VAR(userspace_udpsctp6));
-			SCTP_BASE_VAR(userspace_udpsctp6) = -1;
-		}
-	}
-#endif
 #endif
 }
 


### PR DESCRIPTION
The Windows CreateThread API expects a function that is __stdcall.
Passing it a normal function pointer that is __cdecl causes crashes in
some situations.

There are more instances of this bug in programs/, but they pass
arguments and so they are not easy to adapt through sctp_thread_create.

More context: http://crbug.com/562308