### PR TITLE
Fix tsctp sender when using callbacks

### DIFF
--- a/programs/tsctp.c
+++ b/programs/tsctp.c
@@ -747,7 +747,7 @@ int main(int argc, char **argv)
 		}
 
 		if (use_cb) {
-			while (!done && (messages < (number_of_messages - 1))) {
+			while (done < 2 && (messages < (number_of_messages - 1))) {
 #ifdef _WIN32
 				Sleep(1000);
 #else


### PR DESCRIPTION
Only checking for !done could cause a close before sending EOF.
https://github.com/sctplab/usrsctp/blob/master/programs/tsctp.c#L275

tsctp should wait until the last message has been sent.