### PR TITLE
implemented config.h in all builders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,23 @@ programs/ekr_peer
 programs/ekr_server
 programs/rtcweb
 programs/tsctp
+programs/datachan_serv
+programs/test_libmgmt
 
 # callgrind
 callgrind.out*
+
+# cmake
+CMakeCache.txt
+CMakeFiles
+cmake_install.cmake
+
+# autohell
+AUTHORS
+COPYING
+ChangeLog
+INSTALL
+NEWS
+README
+usrsctp_config.h
+usrsctp_config.h.in

--- a/configure.ac
+++ b/configure.ac
@@ -32,41 +32,51 @@ AC_INIT([libusrsctp], [0.9.2.1])
 AM_INIT_AUTOMAKE
 
 AC_PROG_CC
+AC_CONFIG_HEADERS([usrsctplib/usrsctp_config.h])
 AC_PROG_LIBTOOL
 AC_CANONICAL_HOST
 AC_CONFIG_MACRO_DIR([m4])
 
-LIBCFLAGS="-DSCTP_PROCESS_LEVEL_LOCKS -DSCTP_SIMPLE_ALLOCATOR -D__Userspace__"
+AC_DEFINE(SCTP_PROCESS_LEVEL_LOCKS, 1, [Define this if the library has process level locks])
+AC_DEFINE(SCTP_SIMPLE_ALLOCATOR, 1, [Define this if the library has simple allocator])
+AC_DEFINE(__Userspace__, 1, [Define this if the library is used in user space])
 case $host_os in
 darwin*)
-  CFLAGS="$CFLAGS -std=c99 -D__APPLE_USE_RFC_2292"
-  LIBCFLAGS="$LIBCFLAGS -U__APPLE__ -D__Userspace_os_Darwin"
+  AC_DEFINE(__APPLE_USE_RFC_2292, 1, [Define this if the library uses RFC 2292])
+  AC_DEFINE(__Userspace_os_Darwin, 1, [apple specific])
+  CFLAGS="$CFLAGS -std=c99"
+  LIBCFLAGS="$LIBCFLAGS -U__APPLE__"
   ;;
 dragonfly*)
   CFLAGS="$CFLAGS -std=c99 -pthread"
-  LIBCFLAGS="$LIBCFLAGS -U__DragonFly__ -D__Userspace_os_DragonFly"
+  AC_DEFINE(__Userspace_os_DragonFly, 1, [DragonFly specific])
+  LIBCFLAGS="$LIBCFLAGS -U__DragonFly__"
   ;;
 freebsd*)
   CFLAGS="$CFLAGS -std=c99 -pthread"
   if $CC --version | grep -q clang; then
     LDFLAGS="$LDFLAGS -Qunused-arguments"
   fi
-  LIBCFLAGS="$LIBCFLAGS -U__FreeBSD__ -D__Userspace_os_FreeBSD"
+  AC_DEFINE(__Userspace_os_FreeBSD, 1, [FreeBSD specific])
+  LIBCFLAGS="$LIBCFLAGS -U__FreeBSD__"
   ;;
 linux*)
-  CFLAGS="$CFLAGS -std=c99 -pthread -D_GNU_SOURCE"
-  LIBCFLAGS="$LIBCFLAGS -D__Userspace_os_Linux"
+  AC_DEFINE(__Userspace_os_Linux, 1, [Linux specific])
+  AC_DEFINE(_GNU_SOURCE, 1, [Linux specific])
+  CFLAGS="$CFLAGS -std=c99 -pthread"
   ;;
 netbsd*)
+  AC_DEFINE(__Userspace_os_NetBSD, 1, [NetBSD specific])
   CFLAGS="$CFLAGS -std=c99 -pthread"
-  LIBCFLAGS="$LIBCFLAGS -U__NetBSD__ -D__Userspace_os_NetBSD"
+  LIBCFLAGS="$LIBCFLAGS -U__NetBSD__"
   ;;
 openbsd*)
+  AC_DEFINE(__Userspace_os_OpenBSD, 1, [OpenBSD specific])
   CFLAGS="$CFLAGS -std=c99 -pthread"
-  LIBCFLAGS="$LIBCFLAGS -U__OpenBSD__ -D__Userspace_os_OpenBSD"
+  LIBCFLAGS="$LIBCFLAGS -U__OpenBSD__"
   ;;
 solaris*)
-  CFLAGS="$CFLAGS -D_XPG4_2"
+  AC_DEFINE(_XPG4_2, 1, [Solaris specific])
   ;;
 esac
 

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -70,45 +70,6 @@ check_include_file(netinet/ip_icmp.h HAVE_NETINET_IP_ICMP_H)
 check_include_file(usrsctp.h HAVE_USRSCTP_H)
 
 
-#################################################
-# CHECK STRUCT MEMBERS
-#################################################
-
-check_struct_has_member("struct sockaddr" "sa_len" "sys/types.h;sys/socket.h" HAVE_SA_LEN)
-if(HAVE_SA_LEN)
-	add_definitions(-DHAVE_SA_LEN)
-endif()
-
-check_struct_has_member("struct sockaddr_in" "sin_len" "sys/types.h;netinet/in.h" HAVE_SIN_LEN)
-if(HAVE_SIN_LEN)
-	add_definitions(-DHAVE_SIN_LEN)
-endif()
-
-check_struct_has_member("struct sockaddr_in6" "sin6_len" "sys/types.h;netinet/in.h" HAVE_SIN6_LEN)
-if(HAVE_SIN6_LEN)
-	add_definitions(-DHAVE_SIN6_LEN)
-endif()
-
-
-#################################################
-# CHECK OPTIONS
-#################################################
-
-option(SCTP_DEBUG "Provide debug information" 1)
-if (SCTP_DEBUG)
-	add_definitions(-DSCTP_DEBUG)
-endif()
-
-option(INET "Support IPv4 " 1)
-if (INET)
-	add_definitions(-DINET)
-endif()
-
-option(INET6 "Support IPv6 " 1)
-if (INET6)
-	add_definitions(-DINET6)
-endif()
-
 option(LINK_STATIC "Link static" 0)
 # xxx enable W32 support for shared lib ...
 if (LINK_STATIC OR WIN32)
@@ -118,28 +79,6 @@ else()
 endif()
 
 option(WERROR "Warning as error" ON)
-
-#################################################
-# OS DEPENDENT
-#################################################
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-	add_definitions(-D_GNU_SOURCE)
-endif()
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-	add_definitions(-DHAVE_SCONN_LEN)
-endif()
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	add_definitions(-DHAVE_SCONN_LEN)
-	add_definitions(-D__APPLE_USE_RFC_2292)
-endif()
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
-	add_definitions(-DHAVE_SCONN_LEN)
-endif()
-
 
 #################################################
 # MISC
@@ -188,6 +127,7 @@ IF ("x${CMAKE_C_COMPILER_ID}" STREQUAL "xMSVC")
 	IF (WERROR)
 		SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX")
 	ENDIF()
+	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd\"4267\" /wd\"4244\"")
 ENDIF ()
 
 FOREACH (source_file ${check_PROGRAMS})

--- a/programs/Makefile.nmake
+++ b/programs/Makefile.nmake
@@ -28,9 +28,7 @@
 # SUCH DAMAGE.
 #
 
-CFLAGS=/W3 /WX /I..\usrsctplib
-
-CVARSDLL=-DINET -DINET6
+CFLAGS=/W3 /WX /I..\usrsctplib /wd"4267" /wd"4244"
 
 LINKFLAGS=/LIBPATH:..\usrsctplib usrsctp.lib
 

--- a/usrsctplib/CMakeLists.txt
+++ b/usrsctplib/CMakeLists.txt
@@ -71,10 +71,11 @@ check_include_file(netinet/ip_icmp.h HAVE_NETINET_IP_ICMP_H)
 check_function_exists("socket" HAVE_SOCKET)
 check_function_exists("inet_addr" HAVE_INET_ADDR)
 
+file(WRITE "./usrsctp_config.h" "//THIS FILE IS GENERATED\n")
 
-add_definitions(-D__Userspace__)
-add_definitions(-D__Userspace_os_${CMAKE_SYSTEM_NAME})
-add_definitions(-D_GNU_SOURCE)
+file(APPEND "./usrsctp_config.h" "#define __Userspace__ 1\n")
+file(APPEND "./usrsctp_config.h" "#define __Userspace_os_${CMAKE_SYSTEM_NAME} 1\n")
+file(APPEND "./usrsctp_config.h" "#define _GNU_SOURCE 1\n")
 
 #################################################
 # CHECK STRUCT MEMBERS
@@ -83,19 +84,19 @@ add_definitions(-D_GNU_SOURCE)
 check_struct_has_member("struct sockaddr" "sa_len" "sys/types.h;sys/socket.h" HAVE_SA_LEN)
 if(HAVE_SA_LEN)
 	message("HAVE_SA_LEN")
-	add_definitions(-DHAVE_SA_LEN)
+	file(APPEND "./usrsctp_config.h" "#define HAVE_SA_LEN 1\n")
 endif()
 
 check_struct_has_member("struct sockaddr_in" "sin_len" "sys/types.h;netinet/in.h" HAVE_SIN_LEN)
 if(HAVE_SIN_LEN)
 	message("HAVE_SIN_LEN")
-	add_definitions(-DHAVE_SIN_LEN)
+	file(APPEND "./usrsctp_config.h" "#define HAVE_SIN_LEN 1\n")
 endif()
 
 check_struct_has_member("struct sockaddr_in6" "sin6_len" "sys/types.h;netinet/in.h" HAVE_SIN6_LEN)
 if(HAVE_SIN6_LEN)
 	message("HAVE_SIN6_LEN")
-	add_definitions(-DHAVE_SIN6_LEN)
+	file(APPEND "./usrsctp_config.h" "#define HAVE_SIN6_LEN 1\n")
 endif()
 
 
@@ -104,18 +105,18 @@ endif()
 #################################################
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-	add_definitions(-D_GNU_SOURCE)
+	file(APPEND "./usrsctp_config.h" "#define _GNU_SOURCE 1\n")
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
 	add_definitions(-U__FreeBSD__)
-	add_definitions(-DHAVE_SCONN_LEN)
+	file(APPEND "./usrsctp_config.h" "#define HAVE_SCONN_LEN 1\n")
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	add_definitions(-DHAVE_SCONN_LEN)
 	add_definitions(-U__APPLE__)
-	add_definitions(-D__APPLE_USE_RFC_2292)
+	file(APPEND "./usrsctp_config.h" "#define HAVE_SCONN_LEN 1\n")
+	file(APPEND "./usrsctp_config.h" "#define __APPLE_USE_RFC_2292 1\n")
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "DragonFly")
@@ -127,8 +128,8 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "NetBSD")
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
-	add_definitions(-DHAVE_SCONN_LEN)
 	add_definitions(-U__OpenBSD__)
+	file(APPEND "./usrsctp_config.h" "#define HAVE_SCONN_LEN 1\n")
 endif()
 
 
@@ -138,62 +139,62 @@ endif()
 
 option(INVARIANTS "Add runtime checks" 0)
 if (INVARIANTS)
-	add_definitions(-DINVARIANTS)
+	file(APPEND "./usrsctp_config.h" "#define INVARIANTS 1\n")
 endif()
 
 option(SCTP_DEBUG "Provide debug information" 1)
 if (SCTP_DEBUG)
-	add_definitions(-DSCTP_DEBUG)
+	file(APPEND "./usrsctp_config.h" "#define SCTP_DEBUG 1\n")
 endif()
 
 option(INET "Support IPv4 " 1)
 if (INET)
-	add_definitions(-DINET)
+	file(APPEND "./usrsctp_config.h" "#define INET 1\n")
 endif()
 
 option(INET6 "Support IPv6 " 1)
 if (INET6)
-	add_definitions(-DINET6)
+	file(APPEND "./usrsctp_config.h" "#define INET6 1\n")
 endif()
 
 option(SCTP_SIMPLE_ALLOCATOR " " 1)
 if (SCTP_SIMPLE_ALLOCATOR)
-	add_definitions(-DSCTP_SIMPLE_ALLOCATOR)
+	file(APPEND "./usrsctp_config.h" "#define SCTP_SIMPLE_ALLOCATOR 1\n")
 endif()
 
 option(SCTP_PROCESS_LEVEL_LOCKS " " 1)
 if (SCTP_PROCESS_LEVEL_LOCKS)
-	add_definitions(-DSCTP_PROCESS_LEVEL_LOCKS)
+	file(APPEND "./usrsctp_config.h" "#define SCTP_PROCESS_LEVEL_LOCKS 1\n")
 endif()
 
 option(SCTP_WITH_NO_CSUM "Disable SCTP checksum" 0)
 if (SCTP_WITH_NO_CSUM)
-	add_definitions(-DSCTP_WITH_NO_CSUM)
+	file(APPEND "./usrsctp_config.h" "#define SCTP_WITH_NO_CSUM 1\n")
 endif()
 
 option(SCTP_MBUF_LOGGING " " 0)
 if (SCTP_MBUF_LOGGING)
-	add_definitions(-DSCTP_MBUF_LOGGING)
+	file(APPEND "./usrsctp_config.h" "#define SCTP_MBUF_LOGGING 1\n")
 endif()
 
 option(SCTP_PACKET_LOGGING " " 0)
 if (SCTP_PACKET_LOGGING)
-	add_definitions(-DSCTP_PACKET_LOGGING)
+	file(APPEND "./usrsctp_config.h" "#define SCTP_PACKET_LOGGING 1\n")
 endif()
 
 option(SCTP_SO_LOCK_TESTING " " 0)
 if (SCTP_SO_LOCK_TESTING)
-	add_definitions(-DSCTP_SO_LOCK_TESTING)
+	file(APPEND "./usrsctp_config.h" "#define SCTP_SO_LOCK_TESTING 1\n")
 endif()
 
 option(SCTP_EMBEDDED_V6_SCOPE " " 0)
 if (SCTP_EMBEDDED_V6_SCOPE)
-	add_definitions(-DSCTP_EMBEDDED_V6_SCOPE)
+	file(APPEND "./usrsctp_config.h" "#define SCTP_EMBEDDED_V6_SCOPE 1\n")
 endif()
 
 option(SCTP_KAME " " 0)
 if (SCTP_KAME)
-	add_definitions(-DSCTP_KAME)
+	file(APPEND "./usrsctp_config.h" "#define SCTP_KAME 1\n")
 endif()
 
 option(WERROR "Warning as error" ON)
@@ -262,6 +263,7 @@ IF ("x${CMAKE_C_COMPILER_ID}" STREQUAL "xMSVC")
 	if (WERROR)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX")
 	endif()
+	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd\"4267\" /wd\"4244\"")
 ENDIF ()
 
 IF ("x${CMAKE_C_COMPILER_ID}" STREQUAL "xMSVC90" OR "x${CMAKE_C_COMPILER_ID}" STREQUAL "xMSVC10")
@@ -279,3 +281,4 @@ ENDIF ()
 
 INSTALL (TARGETS usrsctp usrsctp-static DESTINATION ${CMAKE_INSTALL_LIBDIR})
 INSTALL (FILES usrsctp.h DESTINATION include)
+INSTALL (FILES usrsctp_config.h DESTINATION include)

--- a/usrsctplib/Makefile.am
+++ b/usrsctplib/Makefile.am
@@ -77,5 +77,6 @@ libusrsctp_la_SOURCES  = user_atomic.h \
                          netinet6/sctp6_usrreq.c
 libusrsctp_la_CFLAGS = $(LIBCFLAGS)
 libusrsctp_la_LDFLAGS = -version-info 1:0:0
-include_HEADERS = usrsctp.h
+include_HEADERS = usrsctp.h \
+                  usrsctp_config.h
 

--- a/usrsctplib/Makefile.nmake
+++ b/usrsctplib/Makefile.nmake
@@ -28,12 +28,7 @@
 # SUCH DAMAGE.
 #
 
-CFLAGS=/I. /W3 /WX
-
-CVARSDLL=-DSCTP_DEBUG -DSCTP_SIMPLE_ALLOCATOR -DSCTP_PROCESS_LEVEL_LOCKS
-CVARSDLL=$(CVARSDLL) -D__Userspace__ -D__Userspace_os_Windows
-CVARSDLL=$(CVARSDLL) -DINET -DINET6
-CVARSDLL=$(CVARSDLL) -D_LIB
+CFLAGS=/I. /W3 /WX /wd"4267" /wd"4244"
 
 LINKFLAGS=/LIBPATH:. Ws2_32.lib
 
@@ -63,6 +58,7 @@ usrsctp_OBJECTS = \
 	sctp6_usrreq.obj
 
 usrsctp_HEADERS = \
+	usrsctp_config.h \
 	user_atomic.h \
 	user_environment.h \
 	user_inpcb.h \
@@ -104,6 +100,17 @@ usrsctp_HEADERS = \
 
 usrsctp.lib : $(usrsctp_OBJECTS)
 	lib /out:usrsctp.lib $(LINKFLAGS) $(usrsctp_OBJECTS)
+
+usrsctp_config.h:
+	@echo //THIS IS GENERATED >$@
+	@echo #define SCTP_DEBUG 1 >>$@
+	@echo #define SCTP_SIMPLE_ALLOCATOR 1 >>$@
+	@echo #define SCTP_PROCESS_LEVEL_LOCKS 1 >>$@
+	@echo #define __Userspace__ 1 >>$@
+	@echo #define __Userspace_os_Windows 1 >>$@
+	@echo #define INET 1 >>$@
+	@echo #define INET6 1 >>$@
+	@echo #define _LIB 1 >>$@
 
 user_environment.obj : user_environment.c $(usrsctp_HEADERS)
 	cl $(CVARSDLL) $(CFLAGS) -c user_environment.c
@@ -177,3 +184,4 @@ sctp6_usrreq.obj : netinet6\sctp6_usrreq.c $(usrsctp_HEADERS)
 clean:
 	del *.obj
 	del usrsctp.lib
+	del usrsctp_config.h

--- a/usrsctplib/netinet/sctp_asconf.c
+++ b/usrsctplib/netinet/sctp_asconf.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_asconf.c 295670 2016-02-16 20:33:18Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp_var.h>
 #include <netinet/sctp_sysctl.h>

--- a/usrsctplib/netinet/sctp_auth.c
+++ b/usrsctplib/netinet/sctp_auth.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_auth.c 289570 2015-10-19 11:17:54Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp.h>
 #include <netinet/sctp_header.h>

--- a/usrsctplib/netinet/sctp_bsd_addr.c
+++ b/usrsctplib/netinet/sctp_bsd_addr.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_bsd_addr.c 295670 2016-02-16 20:33:18Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp_var.h>
 #include <netinet/sctp_pcb.h>

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -30,6 +30,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <usrsctp_config.h>
 #if defined(__Userspace__)
 #include <sys/types.h>
 #if !defined (__Userspace_os_Windows)

--- a/usrsctplib/netinet/sctp_cc_functions.c
+++ b/usrsctplib/netinet/sctp_cc_functions.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_cc_functions.c 292384 2015-12-16 23:39:27Z markj $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp_var.h>
 #include <netinet/sctp_sysctl.h>

--- a/usrsctplib/netinet/sctp_crc32.c
+++ b/usrsctplib/netinet/sctp_crc32.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_crc32.c 235828 2012-05-23 11:26:28Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp.h>
 #include <netinet/sctp_crc32.h>

--- a/usrsctplib/netinet/sctp_indata.c
+++ b/usrsctplib/netinet/sctp_indata.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_indata.c 292558 2015-12-21 18:52:02Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp_var.h>
 #include <netinet/sctp_sysctl.h>

--- a/usrsctplib/netinet/sctp_input.c
+++ b/usrsctplib/netinet/sctp_input.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_input.c 295772 2016-02-18 21:21:45Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp_var.h>
 #include <netinet/sctp_sysctl.h>

--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_output.c 295773 2016-02-18 21:33:10Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #ifdef __FreeBSD__
 #include <sys/proc.h>

--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_pcb.c 295805 2016-02-19 11:25:18Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #ifdef __FreeBSD__
 #include <sys/proc.h>

--- a/usrsctplib/netinet/sctp_peeloff.c
+++ b/usrsctplib/netinet/sctp_peeloff.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_peeloff.c 279859 2015-03-10 19:49:25Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp_pcb.h>
 #include <netinet/sctputil.h>

--- a/usrsctplib/netinet/sctp_sha1.c
+++ b/usrsctplib/netinet/sctp_sha1.c
@@ -31,6 +31,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_sha1.h>
 
 #if defined(SCTP_USE_NSS_SHA1)

--- a/usrsctplib/netinet/sctp_ss_functions.c
+++ b/usrsctplib/netinet/sctp_ss_functions.c
@@ -31,6 +31,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_ss_functions.c 235828 2012-05-23 11:26:28Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_pcb.h>
 #if defined(__Userspace__)
 #include <netinet/sctp_os_userspace.h>

--- a/usrsctplib/netinet/sctp_sysctl.c
+++ b/usrsctplib/netinet/sctp_sysctl.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_sysctl.c 295541 2016-02-11 18:35:46Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp.h>
 #include <netinet/sctp_constants.h>

--- a/usrsctplib/netinet/sctp_timer.c
+++ b/usrsctplib/netinet/sctp_timer.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_timer.c 295709 2016-02-17 18:04:22Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #define _IP_VHL
 #include <netinet/sctp_os.h>
 #include <netinet/sctp_pcb.h>

--- a/usrsctplib/netinet/sctp_userspace.c
+++ b/usrsctplib/netinet/sctp_userspace.c
@@ -27,6 +27,7 @@
  */
 
 
+#include <usrsctp_config.h>
 #ifdef _WIN32
 #include <netinet/sctp_pcb.h>
 #include <sys/timeb.h>

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_usrreq.c 296588 2016-03-10 00:27:10Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #ifdef __FreeBSD__
 #include <sys/proc.h>

--- a/usrsctplib/netinet/sctputil.c
+++ b/usrsctplib/netinet/sctputil.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctputil.c 295670 2016-02-16 20:33:18Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp_pcb.h>
 #include <netinet/sctputil.h>

--- a/usrsctplib/netinet6/sctp6_usrreq.c
+++ b/usrsctplib/netinet6/sctp6_usrreq.c
@@ -35,6 +35,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet6/sctp6_usrreq.c 295929 2016-02-23 18:50:34Z tuexen $");
 #endif
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #ifdef INET6
 #ifdef __FreeBSD__

--- a/usrsctplib/user_environment.c
+++ b/usrsctplib/user_environment.c
@@ -30,6 +30,7 @@
 
 /* __Userspace__ */
 
+#include <usrsctp_config.h>
 #include <stdlib.h>
 #if !defined (__Userspace_os_Windows)
 #include <stdint.h>

--- a/usrsctplib/user_mbuf.c
+++ b/usrsctplib/user_mbuf.c
@@ -35,6 +35,7 @@
  *
  */
 
+#include <usrsctp_config.h>
 #include <stdio.h>
 #include <string.h>
 /* #include <sys/param.h> This defines MSIZE 256 */

--- a/usrsctplib/user_recv_thread.c
+++ b/usrsctplib/user_recv_thread.c
@@ -28,6 +28,7 @@
  *
  */
 
+#include <usrsctp_config.h>
 #if defined(INET) || defined(INET6)
 #include <sys/types.h>
 #if !defined(__Userspace_os_Windows)

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -32,6 +32,7 @@
  *
  */
 
+#include <usrsctp_config.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp_pcb.h>
 #include <netinet/sctputil.h>

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -35,6 +35,7 @@
 extern "C" {
 #endif
 
+#include <usrsctp_config.h>
 #include <errno.h>
 #include <sys/types.h>
 #ifdef _WIN32


### PR DESCRIPTION
Implemented `usrsctp_config.h` file generation for all builders (autohell, cmake, nmake). This way all `-DXXX` defines are isolated into the config file and the user of the library will not be required to find out and inherit all those defines, prior to include `usrsctp.h`.