### PR TITLE
Win ipv6 fix

### DIFF
--- a/usrsctplib/netinet/sctp_os_userspace.h
+++ b/usrsctplib/netinet/sctp_os_userspace.h
@@ -496,6 +496,7 @@ struct sx {int dummy;};
 #include <sys/types.h>
 #if !defined(__Userspace_os_Windows)
 #if defined(INET) || defined(INET6)
+#define INVALID_SOCKET -1
 #include <ifaddrs.h>
 #endif
 

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -317,6 +317,11 @@ struct sctp_base_info {
 	userland_thread_t recvthreadroute;
 #endif
 #endif
+
+#ifndef INVALID_SOCKET
+#define INVALID_SOCKET -1
+#endif
+
 #ifdef INET
 #if defined(__Userspace_os_Windows)
 	SOCKET userspace_rawsctp;

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -317,8 +317,6 @@ struct sctp_base_info {
 	userland_thread_t recvthreadroute;
 #endif
 #endif
-
-
 #ifdef INET
 #if defined(__Userspace_os_Windows)
 	SOCKET userspace_rawsctp;

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -318,9 +318,6 @@ struct sctp_base_info {
 #endif
 #endif
 
-#ifndef INVALID_SOCKET
-#define INVALID_SOCKET -1
-#endif
 
 #ifdef INET
 #if defined(__Userspace_os_Windows)

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -137,12 +137,12 @@ sctp_init(void)
 #endif
 #endif
 #ifdef INET
-	SCTP_BASE_VAR(userspace_rawsctp) = -1;
-	SCTP_BASE_VAR(userspace_udpsctp) = -1;
+	SCTP_BASE_VAR(userspace_rawsctp) = INVALID_SOCKET;
+	SCTP_BASE_VAR(userspace_udpsctp) = INVALID_SOCKET;
 #endif
 #ifdef INET6
-	SCTP_BASE_VAR(userspace_rawsctp6) = -1;
-	SCTP_BASE_VAR(userspace_udpsctp6) = -1;
+	SCTP_BASE_VAR(userspace_rawsctp6) = INVALID_SOCKET;
+	SCTP_BASE_VAR(userspace_udpsctp6) = INVALID_SOCKET;
 #endif
 	SCTP_BASE_VAR(timer_thread_should_exit) = 0;
 	SCTP_BASE_VAR(conn_output) = conn_output;
@@ -185,7 +185,7 @@ sctp_finish(void)
 #endif
 #endif
 #ifdef INET
-	if (SCTP_BASE_VAR(userspace_rawsctp) != -1) {
+	if (SCTP_BASE_VAR(userspace_rawsctp) != INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadraw), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadraw));
@@ -193,7 +193,7 @@ sctp_finish(void)
 		pthread_join(SCTP_BASE_VAR(recvthreadraw), NULL);
 #endif
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp) != -1) {
+	if (SCTP_BASE_VAR(userspace_udpsctp) != INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadudp), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadudp));
@@ -203,7 +203,7 @@ sctp_finish(void)
 	}
 #endif
 #ifdef INET6
-	if (SCTP_BASE_VAR(userspace_rawsctp6) != -1) {
+	if (SCTP_BASE_VAR(userspace_rawsctp6) != INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadraw6), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadraw6));
@@ -211,7 +211,7 @@ sctp_finish(void)
 		pthread_join(SCTP_BASE_VAR(recvthreadraw6), NULL);
 #endif
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp6) != -1) {
+	if (SCTP_BASE_VAR(userspace_udpsctp6) != INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadudp6), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadudp6));

--- a/usrsctplib/user_recv_thread.c
+++ b/usrsctplib/user_recv_thread.c
@@ -1145,8 +1145,8 @@ recv_thread_init(void)
 	}
 #endif
 #if defined(INET)
-	if (SCTP_BASE_VAR(userspace_rawsctp) == -1) {
-		if ((SCTP_BASE_VAR(userspace_rawsctp) = socket(AF_INET, SOCK_RAW, IPPROTO_SCTP)) == -1) {
+	if (SCTP_BASE_VAR(userspace_rawsctp) == INVALID_SOCKET) {
+		if ((SCTP_BASE_VAR(userspace_rawsctp) = socket(AF_INET, SOCK_RAW, IPPROTO_SCTP)) == INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 			SCTPDBG(SCTP_DEBUG_USR, "Can't create raw socket for IPv4 (errno = %d).\n", WSAGetLastError());
 #else
@@ -1162,7 +1162,7 @@ recv_thread_init(void)
 				SCTPDBG(SCTP_DEBUG_USR, "Can't set IP_HDRINCL (errno = %d).\n", errno);
 				close(SCTP_BASE_VAR(userspace_rawsctp));
 #endif
-				SCTP_BASE_VAR(userspace_rawsctp) = -1;
+				SCTP_BASE_VAR(userspace_rawsctp) = INVALID_SOCKET;
 			} else if (setsockopt(SCTP_BASE_VAR(userspace_rawsctp), SOL_SOCKET, SO_RCVTIMEO, (const void *)&timeout, sizeof(timeout)) < 0) {
 #if defined(__Userspace_os_Windows)
 				SCTPDBG(SCTP_DEBUG_USR, "Can't set timeout on socket for SCTP/IPv4 (errno = %d).\n", WSAGetLastError());
@@ -1171,7 +1171,7 @@ recv_thread_init(void)
 				SCTPDBG(SCTP_DEBUG_USR, "Can't set timeout on socket for SCTP/IPv4 (errno = %d).\n", errno);
 				close(SCTP_BASE_VAR(userspace_rawsctp));
 #endif
-				SCTP_BASE_VAR(userspace_rawsctp) = -1;
+				SCTP_BASE_VAR(userspace_rawsctp) = INVALID_SOCKET;
 			} else {
 				memset((void *)&addr_ipv4, 0, sizeof(struct sockaddr_in));
 #ifdef HAVE_SIN_LEN
@@ -1188,7 +1188,7 @@ recv_thread_init(void)
 					SCTPDBG(SCTP_DEBUG_USR, "Can't bind socket for SCTP/IPv4 (errno = %d).\n", errno);
 					close(SCTP_BASE_VAR(userspace_rawsctp));
 #endif
-					SCTP_BASE_VAR(userspace_rawsctp) = -1;
+					SCTP_BASE_VAR(userspace_rawsctp) = INVALID_SOCKET;
 				} else {
 					setReceiveBufferSize(SCTP_BASE_VAR(userspace_rawsctp), SB_RAW); /* 128K */
 					setSendBufferSize(SCTP_BASE_VAR(userspace_rawsctp), SB_RAW); /* 128K Is this setting net.inet.raw.maxdgram value? Should it be set to 64K? */
@@ -1196,8 +1196,8 @@ recv_thread_init(void)
 			}
 		}
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp) == -1) {
-		if ((SCTP_BASE_VAR(userspace_udpsctp) = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
+	if (SCTP_BASE_VAR(userspace_udpsctp) == INVALID_SOCKET) {
+		if ((SCTP_BASE_VAR(userspace_udpsctp) = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 			SCTPDBG(SCTP_DEBUG_USR, "Can't create socket for SCTP/UDP/IPv4 (errno = %d).\n", WSAGetLastError());
 #else
@@ -1224,7 +1224,7 @@ recv_thread_init(void)
 #endif
 				close(SCTP_BASE_VAR(userspace_udpsctp));
 #endif
-				SCTP_BASE_VAR(userspace_udpsctp) = -1;
+				SCTP_BASE_VAR(userspace_udpsctp) = INVALID_SOCKET;
 			} else if (setsockopt(SCTP_BASE_VAR(userspace_udpsctp), SOL_SOCKET, SO_RCVTIMEO, (const void *)&timeout, sizeof(timeout)) < 0) {
 #if defined(__Userspace_os_Windows)
 				SCTPDBG(SCTP_DEBUG_USR, "Can't set timeout on socket for SCTP/UDP/IPv4 (errno = %d).\n", WSAGetLastError());
@@ -1233,7 +1233,7 @@ recv_thread_init(void)
 				SCTPDBG(SCTP_DEBUG_USR, "Can't set timeout on socket for SCTP/UDP/IPv4 (errno = %d).\n", errno);
 				close(SCTP_BASE_VAR(userspace_udpsctp));
 #endif
-				SCTP_BASE_VAR(userspace_udpsctp) = -1;
+				SCTP_BASE_VAR(userspace_udpsctp) = INVALID_SOCKET;
 			} else {
 				memset((void *)&addr_ipv4, 0, sizeof(struct sockaddr_in));
 #ifdef HAVE_SIN_LEN
@@ -1250,7 +1250,7 @@ recv_thread_init(void)
 					SCTPDBG(SCTP_DEBUG_USR, "Can't bind socket for SCTP/UDP/IPv4 (errno = %d).\n", errno);
 					close(SCTP_BASE_VAR(userspace_udpsctp));
 #endif
-					SCTP_BASE_VAR(userspace_udpsctp) = -1;
+					SCTP_BASE_VAR(userspace_udpsctp) = INVALID_SOCKET;
 				} else {
 					setReceiveBufferSize(SCTP_BASE_VAR(userspace_udpsctp), SB_RAW); /* 128K */
 					setSendBufferSize(SCTP_BASE_VAR(userspace_udpsctp), SB_RAW); /* 128K Is this setting net.inet.raw.maxdgram value? Should it be set to 64K? */
@@ -1260,8 +1260,8 @@ recv_thread_init(void)
 	}
 #endif
 #if defined(INET6)
-	if (SCTP_BASE_VAR(userspace_rawsctp6) == -1) {
-		if ((SCTP_BASE_VAR(userspace_rawsctp6) = socket(AF_INET6, SOCK_RAW, IPPROTO_SCTP)) == -1) {
+	if (SCTP_BASE_VAR(userspace_rawsctp6) == INVALID_SOCKET) {
+		if ((SCTP_BASE_VAR(userspace_rawsctp6) = socket(AF_INET6, SOCK_RAW, IPPROTO_SCTP)) == INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 			SCTPDBG(SCTP_DEBUG_USR, "Can't create socket for SCTP/IPv6 (errno = %d).\n", WSAGetLastError());
 #else
@@ -1278,7 +1278,7 @@ recv_thread_init(void)
 				SCTPDBG(SCTP_DEBUG_USR, "Can't set IPV6_RECVPKTINFO on socket for SCTP/IPv6 (errno = %d).\n", errno);
 				close(SCTP_BASE_VAR(userspace_rawsctp6));
 #endif
-				SCTP_BASE_VAR(userspace_rawsctp6) = -1;
+				SCTP_BASE_VAR(userspace_rawsctp6) = INVALID_SOCKET;
 			} else {
 #else
 			if (setsockopt(SCTP_BASE_VAR(userspace_rawsctp6), IPPROTO_IPV6, IPV6_PKTINFO,(const void*)&on, sizeof(on)) < 0) {
@@ -1289,7 +1289,7 @@ recv_thread_init(void)
 				SCTPDBG(SCTP_DEBUG_USR, "Can't set IPV6_PKTINFO on socket for SCTP/IPv6 (errno = %d).\n", errno);
 				close(SCTP_BASE_VAR(userspace_rawsctp6));
 #endif
-				SCTP_BASE_VAR(userspace_rawsctp6) = -1;
+				SCTP_BASE_VAR(userspace_rawsctp6) = INVALID_SOCKET;
 			} else {
 #endif
 				if (setsockopt(SCTP_BASE_VAR(userspace_rawsctp6), IPPROTO_IPV6, IPV6_V6ONLY, (const void*)&on, (socklen_t)sizeof(on)) < 0) {
@@ -1307,7 +1307,7 @@ recv_thread_init(void)
 					SCTPDBG(SCTP_DEBUG_USR, "Can't set timeout on socket for SCTP/IPv6 (errno = %d).\n", errno);
 					close(SCTP_BASE_VAR(userspace_rawsctp6));
 #endif
-					SCTP_BASE_VAR(userspace_rawsctp6) = -1;
+					SCTP_BASE_VAR(userspace_rawsctp6) = INVALID_SOCKET;
 				} else {
 					memset((void *)&addr_ipv6, 0, sizeof(struct sockaddr_in6));
 #ifdef HAVE_SIN6_LEN
@@ -1324,7 +1324,7 @@ recv_thread_init(void)
 						SCTPDBG(SCTP_DEBUG_USR, "Can't bind socket for SCTP/IPv6 (errno = %d).\n", errno);
 						close(SCTP_BASE_VAR(userspace_rawsctp6));
 #endif
-						SCTP_BASE_VAR(userspace_rawsctp6) = -1;
+						SCTP_BASE_VAR(userspace_rawsctp6) = INVALID_SOCKET;
 					} else {
 						setReceiveBufferSize(SCTP_BASE_VAR(userspace_rawsctp6), SB_RAW); /* 128K */
 						setSendBufferSize(SCTP_BASE_VAR(userspace_rawsctp6), SB_RAW); /* 128K Is this setting net.inet.raw.maxdgram value? Should it be set to 64K? */
@@ -1333,8 +1333,8 @@ recv_thread_init(void)
 			}
 		}
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp6) == -1) {
-		if ((SCTP_BASE_VAR(userspace_udpsctp6) = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
+	if (SCTP_BASE_VAR(userspace_udpsctp6) == INVALID_SOCKET) {
+		if ((SCTP_BASE_VAR(userspace_udpsctp6) = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)) == INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 			SCTPDBG(SCTP_DEBUG_USR, "Can't create socket for SCTP/UDP/IPv6 (errno = %d).\n", WSAGetLastError());
 #else
@@ -1350,7 +1350,7 @@ recv_thread_init(void)
 			SCTPDBG(SCTP_DEBUG_USR, "Can't set IPV6_RECVPKTINFO on socket for SCTP/UDP/IPv6 (errno = %d).\n", errno);
 			close(SCTP_BASE_VAR(userspace_udpsctp6));
 #endif
-			SCTP_BASE_VAR(userspace_udpsctp6) = -1;
+			SCTP_BASE_VAR(userspace_udpsctp6) = INVALID_SOCKET;
 		} else {
 #else
 		if (setsockopt(SCTP_BASE_VAR(userspace_udpsctp6), IPPROTO_IPV6, IPV6_PKTINFO, (const void *)&on, (int)sizeof(int)) < 0) {
@@ -1361,7 +1361,7 @@ recv_thread_init(void)
 			SCTPDBG(SCTP_DEBUG_USR, "Can't set IPV6_PKTINFO on socket for SCTP/UDP/IPv6 (errno = %d).\n", errno);
 			close(SCTP_BASE_VAR(userspace_udpsctp6));
 #endif
-			SCTP_BASE_VAR(userspace_udpsctp6) = -1;
+			SCTP_BASE_VAR(userspace_udpsctp6) = INVALID_SOCKET;
 		} else {
 #endif
 			if (setsockopt(SCTP_BASE_VAR(userspace_udpsctp6), IPPROTO_IPV6, IPV6_V6ONLY, (const void *)&on, (socklen_t)sizeof(on)) < 0) {
@@ -1379,7 +1379,7 @@ recv_thread_init(void)
 				SCTPDBG(SCTP_DEBUG_USR, "Can't set timeout on socket for SCTP/UDP/IPv6 (errno = %d).\n", errno);
 				close(SCTP_BASE_VAR(userspace_udpsctp6));
 #endif
-				SCTP_BASE_VAR(userspace_udpsctp6) = -1;
+				SCTP_BASE_VAR(userspace_udpsctp6) = INVALID_SOCKET;
 			} else {
 				memset((void *)&addr_ipv6, 0, sizeof(struct sockaddr_in6));
 #ifdef HAVE_SIN6_LEN
@@ -1396,7 +1396,7 @@ recv_thread_init(void)
 					SCTPDBG(SCTP_DEBUG_USR, "Can't bind socket for SCTP/UDP/IPv6 (errno = %d).\n", errno);
 					close(SCTP_BASE_VAR(userspace_udpsctp6));
 #endif
-					SCTP_BASE_VAR(userspace_udpsctp6) = -1;
+					SCTP_BASE_VAR(userspace_udpsctp6) = INVALID_SOCKET;
 				} else {
 					setReceiveBufferSize(SCTP_BASE_VAR(userspace_udpsctp6), SB_RAW); /* 128K */
 					setSendBufferSize(SCTP_BASE_VAR(userspace_udpsctp6), SB_RAW); /* 128K Is this setting net.inet.raw.maxdgram value? Should it be set to 64K? */
@@ -1419,7 +1419,7 @@ recv_thread_init(void)
 #endif
 #endif
 #if defined(INET)
-	if (SCTP_BASE_VAR(userspace_rawsctp) != -1) {
+	if (SCTP_BASE_VAR(userspace_rawsctp) != INVALID_SOCKET) {
 		int rc;
 
 		if ((rc = sctp_userspace_thread_create(&SCTP_BASE_VAR(recvthreadraw), &recv_function_raw))) {
@@ -1429,10 +1429,10 @@ recv_thread_init(void)
 #else
 			close(SCTP_BASE_VAR(userspace_rawsctp));
 #endif
-			SCTP_BASE_VAR(userspace_rawsctp) = -1;
+			SCTP_BASE_VAR(userspace_rawsctp) = INVALID_SOCKET;
 		}
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp) != -1) {
+	if (SCTP_BASE_VAR(userspace_udpsctp) != INVALID_SOCKET) {
 		int rc;
 
 		if ((rc = sctp_userspace_thread_create(&SCTP_BASE_VAR(recvthreadudp), &recv_function_udp))) {
@@ -1442,12 +1442,12 @@ recv_thread_init(void)
 #else
 			close(SCTP_BASE_VAR(userspace_udpsctp));
 #endif
-			SCTP_BASE_VAR(userspace_udpsctp) = -1;
+			SCTP_BASE_VAR(userspace_udpsctp) = INVALID_SOCKET;
 		}
 	}
 #endif
 #if defined(INET6)
-	if (SCTP_BASE_VAR(userspace_rawsctp6) != -1) {
+	if (SCTP_BASE_VAR(userspace_rawsctp6) != INVALID_SOCKET) {
 		int rc;
 
 		if ((rc = sctp_userspace_thread_create(&SCTP_BASE_VAR(recvthreadraw6), &recv_function_raw6))) {
@@ -1457,10 +1457,10 @@ recv_thread_init(void)
 #else
 			close(SCTP_BASE_VAR(userspace_rawsctp6));
 #endif
-			SCTP_BASE_VAR(userspace_rawsctp6) = -1;
+			SCTP_BASE_VAR(userspace_rawsctp6) = INVALID_SOCKET;
 		}
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp6) != -1) {
+	if (SCTP_BASE_VAR(userspace_udpsctp6) != INVALID_SOCKET) {
 		int rc;
 
 		if ((rc = sctp_userspace_thread_create(&SCTP_BASE_VAR(recvthreadudp6), &recv_function_udp6))) {
@@ -1470,7 +1470,7 @@ recv_thread_init(void)
 #else
 			close(SCTP_BASE_VAR(userspace_udpsctp6));
 #endif
-			SCTP_BASE_VAR(userspace_udpsctp6) = -1;
+			SCTP_BASE_VAR(userspace_udpsctp6) = INVALID_SOCKET;
 		}
 	}
 #endif
@@ -1487,14 +1487,14 @@ recv_thread_destroy(void)
 #endif
 #endif
 #if defined(INET)
-	if (SCTP_BASE_VAR(userspace_rawsctp) != -1) {
+	if (SCTP_BASE_VAR(userspace_rawsctp) != INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 		closesocket(SCTP_BASE_VAR(userspace_rawsctp));
 #else
 		close(SCTP_BASE_VAR(userspace_rawsctp));
 #endif
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp) != -1) {
+	if (SCTP_BASE_VAR(userspace_udpsctp) != INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 		closesocket(SCTP_BASE_VAR(userspace_udpsctp));
 #else
@@ -1503,14 +1503,14 @@ recv_thread_destroy(void)
 	}
 #endif
 #if defined(INET6)
-	if (SCTP_BASE_VAR(userspace_rawsctp6) != -1) {
+	if (SCTP_BASE_VAR(userspace_rawsctp6) != INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 		closesocket(SCTP_BASE_VAR(userspace_rawsctp6));
 #else
 		close(SCTP_BASE_VAR(userspace_rawsctp6));
 #endif
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp6) != -1) {
+	if (SCTP_BASE_VAR(userspace_udpsctp6) != INVALID_SOCKET) {
 #if defined(__Userspace_os_Windows)
 		closesocket(SCTP_BASE_VAR(userspace_udpsctp6));
 #else

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -3013,14 +3013,14 @@ sctp_userspace_ip_output(int *result, struct mbuf *o_pak,
 	win_msg_hdr.Control = winbuf;
 	win_msg_hdr.dwFlags = 0;
 
-	if ((!use_udp_tunneling) && (SCTP_BASE_VAR(userspace_rawsctp) != -1)) {
+	if ((!use_udp_tunneling) && (SCTP_BASE_VAR(userspace_rawsctp) != INVALID_SOCKET)) {
 		if (WSASendTo(SCTP_BASE_VAR(userspace_rawsctp), (LPWSABUF) send_iovec, iovcnt, &win_sent_len, win_msg_hdr.dwFlags, win_msg_hdr.name, (int) win_msg_hdr.namelen, NULL, NULL) != 0) {
 			*result = WSAGetLastError();
 		} else if (win_sent_len != send_len) {
 			*result = WSAGetLastError();
 		}
 	}
-	if ((use_udp_tunneling) && (SCTP_BASE_VAR(userspace_udpsctp) != -1)) {
+	if ((use_udp_tunneling) && (SCTP_BASE_VAR(userspace_udpsctp) != INVALID_SOCKET)) {
 		if (WSASendTo(SCTP_BASE_VAR(userspace_udpsctp), (LPWSABUF) send_iovec, iovcnt, &win_sent_len, win_msg_hdr.dwFlags, win_msg_hdr.name, (int) win_msg_hdr.namelen, NULL, NULL) != 0) {
 			*result = WSAGetLastError();
 		} else if (win_sent_len != send_len) {
@@ -3171,14 +3171,14 @@ void sctp_userspace_ip6_output(int *result, struct mbuf *o_pak,
 	win_msg_hdr.Control = winbuf;
 	win_msg_hdr.dwFlags = 0;
 
-	if ((!use_udp_tunneling) && (SCTP_BASE_VAR(userspace_rawsctp6) > -1)) {
+	if ((!use_udp_tunneling) && (SCTP_BASE_VAR(userspace_rawsctp6) != INVALID_SOCKET)) {
 		if (WSASendTo(SCTP_BASE_VAR(userspace_rawsctp6), (LPWSABUF) send_iovec, iovcnt, &win_sent_len, win_msg_hdr.dwFlags, win_msg_hdr.name, (int) win_msg_hdr.namelen, NULL, NULL) != 0) {
 			*result = WSAGetLastError();
 		} else if (win_sent_len != send_len) {
 			*result = WSAGetLastError();
 		}
 	}
-	if ((use_udp_tunneling) && (SCTP_BASE_VAR(userspace_udpsctp6) > -1)) {
+	if ((use_udp_tunneling) && (SCTP_BASE_VAR(userspace_udpsctp6) != INVALID_SOCKET)) {
 		if (WSASendTo(SCTP_BASE_VAR(userspace_udpsctp6), (LPWSABUF) send_iovec, iovcnt, &win_sent_len, win_msg_hdr.dwFlags, win_msg_hdr.name, (int) win_msg_hdr.namelen, NULL, NULL) != 0) {
 			*result = WSAGetLastError();
 		} else if (win_sent_len != send_len) {

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -2993,12 +2993,12 @@ sctp_userspace_ip_output(int *result, struct mbuf *o_pak,
 	msg_hdr.msg_controllen = 0;
 	msg_hdr.msg_flags = 0;
 
-	if ((!use_udp_tunneling) && (SCTP_BASE_VAR(userspace_rawsctp) != -1)) {
+	if ((!use_udp_tunneling) && (SCTP_BASE_VAR(userspace_rawsctp) != INVALID_SOCKET)) {
 		if ((res = sendmsg(SCTP_BASE_VAR(userspace_rawsctp), &msg_hdr, MSG_DONTWAIT)) != send_len) {
 			*result = errno;
 		}
 	}
-	if ((use_udp_tunneling) && (SCTP_BASE_VAR(userspace_udpsctp) != -1)) {
+	if ((use_udp_tunneling) && (SCTP_BASE_VAR(userspace_udpsctp) != INVALID_SOCKET)) {
 		if ((res = sendmsg(SCTP_BASE_VAR(userspace_udpsctp), &msg_hdr, MSG_DONTWAIT)) != send_len) {
 			*result = errno;
 		}
@@ -3151,12 +3151,12 @@ void sctp_userspace_ip6_output(int *result, struct mbuf *o_pak,
 	msg_hdr.msg_controllen = 0;
 	msg_hdr.msg_flags = 0;
 
-	if ((!use_udp_tunneling) && (SCTP_BASE_VAR(userspace_rawsctp6) > -1)) {
+	if ((!use_udp_tunneling) && (SCTP_BASE_VAR(userspace_rawsctp6) != INVALID_SOCKET)) {
 		if ((res = sendmsg(SCTP_BASE_VAR(userspace_rawsctp6), &msg_hdr, MSG_DONTWAIT)) != send_len) {
 			*result = errno;
 		}
 	}
-	if ((use_udp_tunneling) && (SCTP_BASE_VAR(userspace_udpsctp6) > -1)) {
+	if ((use_udp_tunneling) && (SCTP_BASE_VAR(userspace_udpsctp6) != INVALID_SOCKET)) {
 		if ((res = sendmsg(SCTP_BASE_VAR(userspace_udpsctp6), &msg_hdr, MSG_DONTWAIT)) != send_len) {
 			*result = errno;
 		}


### PR DESCRIPTION
This PR fixes an issue with IPV6 for Windows.
Windows returns INVALID_SOCKET instead of -1 if an error occurs - Socket is unsigned in windowsland...
https://msdn.microsoft.com/en-us/library/windows/desktop/ms740516(v=vs.85).aspx

The first commit (7a2b27e) fixes the problem.
The second (4d6dd67) one defines INVALID_SOCKET as -1 for platforms where INVALID_SOCKET is not defined by default to have a consistent error handling.