### PR TITLE
Free pAdapterAddrs with GlobalFree in sctp_init_ifns_for_vrf()

### DIFF
--- a/usrsctplib/netinet/sctp_bsd_addr.c
+++ b/usrsctplib/netinet/sctp_bsd_addr.c
@@ -306,14 +306,6 @@ sctp_is_vmware_interface(struct ifnet *ifn)
 #endif
 
 #if defined(__Userspace_os_Windows)
-#ifdef MALLOC
-#undef MALLOC
-#define MALLOC(x) HeapAlloc(GetProcessHeap(), 0, (x))
-#endif
-#ifdef FREE
-#undef FREE
-#define FREE(x) HeapFree(GetProcessHeap(), 0, (x))
-#endif
 static void
 sctp_init_ifns_for_vrf(int vrfid)
 {
@@ -343,7 +335,7 @@ sctp_init_ifns_for_vrf(int vrfid)
 	/* Get actual adapter information */
 	if ((Err = GetAdaptersAddresses(AF_INET, 0, NULL, pAdapterAddrs, &AdapterAddrsSize)) != ERROR_SUCCESS) {
 		SCTP_PRINTF("GetAdaptersV4Addresses() failed with error code %d\n", Err);
-		FREE(pAdapterAddrs);
+		GlobalFree(pAdapterAddrs);
 		return;
 	}
 	/* Enumerate through each returned adapter and save its information */
@@ -368,7 +360,7 @@ sctp_init_ifns_for_vrf(int vrfid)
 			}
 		}
 	}
-	FREE(pAdapterAddrs);
+	GlobalFree(pAdapterAddrs);
 #endif
 #ifdef INET6
 	AdapterAddrsSize = 0;
@@ -388,7 +380,7 @@ sctp_init_ifns_for_vrf(int vrfid)
 	/* Get actual adapter information */
 	if ((Err = GetAdaptersAddresses(AF_INET6, 0, NULL, pAdapterAddrs, &AdapterAddrsSize)) != ERROR_SUCCESS) {
 		SCTP_PRINTF("GetAdaptersV6Addresses() failed with error code %d\n", Err);
-		FREE(pAdapterAddrs);
+		GlobalFree(pAdapterAddrs);
 		return;
 	}
 	/* Enumerate through each returned adapter and save its information */
@@ -410,7 +402,7 @@ sctp_init_ifns_for_vrf(int vrfid)
 			}
 		}
 	}
-	FREE(pAdapterAddrs);
+	GlobalFree(pAdapterAddrs);
 #endif
 }
 #elif defined(__Userspace__)


### PR DESCRIPTION
Until da6f8ba, sctp_init_ifns_for_vrf() was using the MALLOC and FREE
macros, using respectively HeapAlloc and HeapFree. da6f8ba changed the
allocations to use GlobalAlloc, but didn't change the deallocations to
use the symmetric GlobalFree.

This doesn't seem to cause direct problems, but when wrapping one family
of allocation functions, the dissymmetry causes allocator mismatch
problems.

Moreover, the MALLOC macro being unused, it might as well be removed,
along the FREE macro, so that both allocations and deallocations use one
API explicitly.

It should be noted, for a precedent, that sctp_userspace.c uses
GlobalAlloc/GlobalFree too, with no wrapping with macros.