### PR TITLE
Add more systems for BSD-style struct sockaddr_conn

### DIFF
--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -91,7 +91,8 @@ typedef uint32_t sctp_assoc_t;
 /* The definition of struct sockaddr_conn MUST be in
  * tune with other sockaddr_* structures.
  */
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(__APPLE__) || defined(__Bitrig__) || defined(__DragonFly__) || \
+    defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 struct sockaddr_conn {
 	uint8_t sconn_len;
 	uint8_t sconn_family;


### PR DESCRIPTION
74d255f made the list of platforms with *_len as first member explicit. One has to adjust it every time a new BSD descendant is supported like in 2a986e7. DragonFly for some reason was missed.