### PR TITLE
Fixed the QMD_TAILQ_CHECK_TAIL invariant check.

### DIFF
--- a/usrsctplib/user_queue.h
+++ b/usrsctplib/user_queue.h
@@ -482,7 +482,8 @@ struct {								\
 } while (0)
 
 #define	QMD_TAILQ_CHECK_TAIL(head, field) do {					\
-	if (*(head)->tqh_last != NULL)						\
+	if (*(head)->tqh_last != NULL && 					\
+		  TAILQ_NEXT(*(head)->tqh_last, field) != NULL)			\
 	    	panic("Bad tailq NEXT(%p->tqh_last) != NULL", (void *)(head)); 	\
 } while (0)
 


### PR DESCRIPTION
The invariant check was incorrect, and could never succeed for a
non-empty queue. I have discovered this when I enabled invariant checks while debugging a timer queue corruption. 

The fix for the queue corruption is in a separate pull request.