### PR TITLE
Fixed a race condition causing timer queue corruption.

### DIFF
--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -96,7 +96,11 @@ int sctp_os_timer_stop(sctp_os_timer_t *);
 #define SCTP_OS_TIMER_STOP_DRAIN SCTP_OS_TIMER_STOP
 #define	SCTP_OS_TIMER_PENDING(tmr) ((tmr)->c_flags & SCTP_CALLOUT_PENDING)
 #define	SCTP_OS_TIMER_ACTIVE(tmr) ((tmr)->c_flags & SCTP_CALLOUT_ACTIVE)
-#define	SCTP_OS_TIMER_DEACTIVATE(tmr) ((tmr)->c_flags &= ~SCTP_CALLOUT_ACTIVE)
+#define	SCTP_OS_TIMER_DEACTIVATE(tmr) do {				\
+	SCTP_TIMERQ_LOCK();						\
+	(tmr)->c_flags &= ~SCTP_CALLOUT_ACTIVE;				\
+	SCTP_TIMERQ_UNLOCK();						\
+} while (0)
 
 #if defined(__Userspace__)
 void sctp_start_timer(void);


### PR DESCRIPTION
The SCTP_OS_TIMER_DEACTIVATE macro was not locking the timer queue while
it modified the flags. If the timer fires as the read-modify-write
operation is happening, the timer will be reinserted into the queue
without the SCTP_CALLOUT_PENDING flag set. When the timer fires
subsequently, it gets added to the queue for the second time and its
prev/next pointers get overwritten - which can create a loop in the=
timer queue.

The fix is to lock the queue before modifying timer flags.
