### PR TITLE
add usrsctp prefix to mbuf_init()

### DIFF
--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -6844,7 +6844,7 @@ sctp_pcb_init()
 	TAILQ_INIT(&SCTP_BASE_INFO(callqueue));
 #endif
 #if defined(__Userspace__)
-	mbuf_init(NULL);
+	usrsctp_mbuf_init(NULL);
 	atomic_init();
 #if defined(INET) || defined(INET6)
 	recv_thread_init();

--- a/usrsctplib/user_mbuf.c
+++ b/usrsctplib/user_mbuf.c
@@ -328,11 +328,11 @@ m_tag_setup(struct m_tag *t, u_int32_t cookie, int type, int len)
 /************ End functions to substitute umem_cache_alloc and umem_cache_free **************/
 
 /* __Userspace__
- * TODO: mbuf_init must be called in the initialization routines
+ * TODO: usrsctp_mbuf_init must be called in the initialization routines
  * of userspace stack.
  */
 void
-mbuf_init(void *dummy)
+usrsctp_mbuf_init(void *dummy)
 {
 
 	/*

--- a/usrsctplib/user_mbuf.h
+++ b/usrsctplib/user_mbuf.h
@@ -58,7 +58,7 @@ void m_clget(struct mbuf *m, int how);
 
 
 /* mbuf initialization function */
-void mbuf_init(void *);
+void usrsctp_mbuf_init(void *);
 
 #define	M_MOVE_PKTHDR(to, from)	m_move_pkthdr((to), (from))
 #define	MGET(m, how, type)	((m) = m_get((how), (type)))


### PR DESCRIPTION
my program is using both usrsctp and libre SIP stack (https://github.com/creytiv/re).
both libraries define the symbol `mbuf_init` and when building, the linker fails
with duplicated symbols.

To avoid this, I suggest that usrsctp adds the `usrsctp` prefix to the mbuf_init function.
