### PR TITLE
Use pointer for time_entered field

### DIFF
--- a/usrsctplib/netinet/sctp_header.h
+++ b/usrsctplib/netinet/sctp_header.h
@@ -204,7 +204,7 @@ struct sctp_init {
 /* state cookie header */
 struct sctp_state_cookie {	/* this is our definition... */
 	uint8_t identification[SCTP_IDENTIFICATION_SIZE];/* id of who we are */
-	struct timeval time_entered;	/* the time I built cookie */
+	struct timeval *time_entered;	/* the time I built cookie */
 	uint32_t cookie_life;	/* life I will award this cookie */
 	uint32_t tie_tag_my_vtag;	/* my tag in old association */
 

--- a/usrsctplib/netinet/sctp_input.c
+++ b/usrsctplib/netinet/sctp_input.c
@@ -1731,7 +1731,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 				 */
 				net->hb_responded = 1;
 				net->RTO = sctp_calculate_rto(stcb, asoc, net,
-							      &cookie->time_entered,
+							      cookie->time_entered,
 							      sctp_align_unsafe_makecopy,
 							      SCTP_RTT_FROM_NON_DATA);
 
@@ -2483,7 +2483,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 	if ((netp != NULL) && (*netp != NULL)) {
 		/* calculate the RTT and set the encaps port */
 		(*netp)->RTO = sctp_calculate_rto(stcb, asoc, *netp,
-						  &cookie->time_entered, sctp_align_unsafe_makecopy,
+						  cookie->time_entered, sctp_align_unsafe_makecopy,
 						  SCTP_RTT_FROM_NON_DATA);
 	}
 	/* respond with a COOKIE-ACK */
@@ -2616,7 +2616,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 		SCTP_TCB_LOCK(l_stcb);
 	}
 	/* which cookie is it? */
-	if ((cookie->time_entered.tv_sec < (long)ep->time_of_secret_change) &&
+	if ((cookie->time_entered->tv_sec < (long)ep->time_of_secret_change) &&
 	    (ep->current_secret_number != ep->last_secret_number)) {
 		/* it's the old cookie */
 		(void)sctp_hmac_m(SCTP_HMAC,
@@ -2639,7 +2639,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 	/* compare the received digest with the computed digest */
 	if (memcmp(calc_sig, sig, SCTP_SIGNATURE_SIZE) != 0) {
 		/* try the old cookie? */
-		if ((cookie->time_entered.tv_sec == (long)ep->time_of_secret_change) &&
+		if ((cookie->time_entered->tv_sec == (long)ep->time_of_secret_change) &&
 		    (ep->current_secret_number != ep->last_secret_number)) {
 			/* compute digest with old */
 			(void)sctp_hmac_m(SCTP_HMAC,
@@ -2680,8 +2680,8 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 	 */
 	(void)SCTP_GETTIME_TIMEVAL(&now);
 	/* Expire time is in Ticks, so we convert to seconds */
-	time_expires.tv_sec = cookie->time_entered.tv_sec + TICKS_TO_SEC(cookie->cookie_life);
-	time_expires.tv_usec = cookie->time_entered.tv_usec;
+	time_expires.tv_sec = cookie->time_entered->tv_sec + TICKS_TO_SEC(cookie->cookie_life);
+	time_expires.tv_usec = cookie->time_entered->tv_usec;
         /* TODO sctp_constants.h needs alternative time macros when
          *  _KERNEL is undefined.
          */
@@ -2711,7 +2711,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 		tim = (now.tv_sec - time_expires.tv_sec) * 1000000;
 		/* add in usec */
 		if (tim == 0)
-			tim = now.tv_usec - cookie->time_entered.tv_usec;
+			tim = now.tv_usec - cookie->time_entered->tv_usec;
 		cause->stale_time = htonl(tim);
 		sctp_send_operr_to(src, dst, sh, cookie->peers_vtag, op_err,
 #if defined(__FreeBSD__)

--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -6005,7 +6005,7 @@ sctp_send_initiate_ack(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 	memset(&stc, 0, sizeof(struct sctp_state_cookie));
 
 	/* the time I built cookie */
-	(void)SCTP_GETTIME_TIMEVAL(&stc.time_entered);
+	(void)SCTP_GETTIME_TIMEVAL(stc.time_entered);
 
 	/* populate any tie tags */
 	if (asoc != NULL) {
@@ -8208,7 +8208,7 @@ sctp_fill_outqueue(struct sctp_tcb *stcb,
 	while ((goal_mtu > 0) && strq) {
 		giveup = 0;
 		bail = 0;
-		moved_how_much = sctp_move_to_outqueue(stcb, strq, goal_mtu, frag_point, 
+		moved_how_much = sctp_move_to_outqueue(stcb, strq, goal_mtu, frag_point,
 						       &giveup, eeor_mode, &bail, so_locked);
 		stcb->asoc.ss_functions.sctp_ss_scheduled(stcb, net, asoc, strq, moved_how_much);
 
@@ -10660,7 +10660,7 @@ do_it_again:
 			un_sent = ((stcb->asoc.total_output_queue_size - stcb->asoc.total_flight) +
 			           (stcb->asoc.stream_queue_cnt * sizeof(struct sctp_data_chunk)));
 			if ((un_sent < (int)(stcb->asoc.smallest_mtu - SCTP_MIN_OVERHEAD)) &&
-			    (stcb->asoc.total_flight > 0)) { 
+			    (stcb->asoc.total_flight > 0)) {
 /*	&&		     sctp_is_feature_on(inp, SCTP_PCB_FLAGS_EXPLICIT_EOR))) {*/
 				break;
 			}


### PR DESCRIPTION
Taking an address of a packed member "time_entered" of sctp_state_coockie may result in unaligned pointer value.
Besides since it's frequently passed by pointer anyways, it only makes more sense to store it using a pointer as well.

Fixes #108