### PR TITLE
Suppress new Clang warning: -Waddress-of-packed-member

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ APPCFLAGS=""
 
 case $host_os in
 darwin*)
-  CFLAGS="$CFLAGS -std=c99 -Wno-deprecated-declarations -D__APPLE_USE_RFC_2292"
+  CFLAGS="$CFLAGS -std=c99 -Wno-deprecated-declarations -D__APPLE_USE_RFC_2292 -Wno-address-of-packed-member"
   LIBCFLAGS="$LIBCFLAGS -U__APPLE__ -D__Userspace_os_Darwin"
   ;;
 dragonfly*)


### PR DESCRIPTION
When i try to compile it under macOS 10.12.4, it is failed with error below. Add  a suppress cflag can bypass it.

netinet/sctp_input.c:1734:15: error: taking address of packed member 'time_entered' of class or structure
      'sctp_state_cookie' may result in an unaligned pointer value [-Werror,-Waddress-of-packed-member]
                                                              &cookie->time_entered,
                                                               ^~~~~~~~~~~~~~~~~~~~
netinet/sctp_input.c:2486:10: error: taking address of packed member 'time_entered' of class or structure
      'sctp_state_cookie' may result in an unaligned pointer value [-Werror,-Waddress-of-packed-member]
                                                  &cookie->time_entered, sctp_align_unsafe_makecopy,