### PR TITLE
Use '#pragma pack (pop)' instead of '#pragma pack ()'

### DIFF
--- a/programs/rtcweb.c
+++ b/programs/rtcweb.c
@@ -140,7 +140,7 @@ struct rtcweb_datachannel_ack {
 } SCTP_PACKED;
 
 #ifdef _WIN32
-#pragma pack()
+#pragma pack(pop)
 #endif
 
 #undef SCTP_PACKED

--- a/usrsctplib/netinet/sctp.h
+++ b/usrsctplib/netinet/sctp.h
@@ -609,7 +609,7 @@ struct sctp_error_auth_invalid_hmac {
 #define SCTP_SMALLEST_PMTU 512	 /* smallest pmtu allowed when disabling PMTU discovery */
 
 #if defined(__Userspace_os_Windows)
-#pragma pack()
+#pragma pack(pop)
 #endif
 #undef SCTP_PACKED
 

--- a/usrsctplib/user_ip_icmp.h
+++ b/usrsctplib/user_ip_icmp.h
@@ -65,7 +65,7 @@ struct icmp6_hdr {
 		u_int8_t icmp6_un_data8[4];
 	} icmp6_dataun;
 };
-#pragma pack()
+#pragma pack(pop)
 
 #define icmp6_data32 icmp6_dataun.icmp6_un_data32
 #define icmp6_mtu icmp6_data32[0]

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -102,7 +102,7 @@ struct sctp_common_header {
 } SCTP_PACKED;
 
 #if defined(_WIN32) && defined(_MSC_VER)
-#pragma pack()
+#pragma pack(pop)
 #endif
 #undef SCTP_PACKED
 


### PR DESCRIPTION
The code is setting the packing alignment with

`  #pragma pack (push, 1)`

and would then reset it with

`  #pragma pack ()`

The latter directive resets the packing alignment to the default value,
which means if some other packing alignment was in effect before the
'push', that is now lost.

This patch resets the packing alignment with

`  #pragma pack (pop)`

instead, to patch the 'push' operation.

(This problem was found in a Chromium build by a new Clang warning,
-Wpragma-pack.)