### PR TITLE
callout: assign the next pointer of callqueue in lock

### DIFF
--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -160,10 +160,10 @@ sctp_handle_tick(int delta)
 			c_func = c->c_func;
 			c_arg = c->c_arg;
 			c->c_flags &= ~SCTP_CALLOUT_PENDING;
+			c = sctp_os_timer_next;
 			SCTP_TIMERQ_UNLOCK();
 			c_func(c_arg);
 			SCTP_TIMERQ_LOCK();
-			c = sctp_os_timer_next;
 		} else {
 			c = TAILQ_NEXT(c, tqe);
 		}


### PR DESCRIPTION
Otherwise, the next pointer is able to be contaminated while
executing function pointer.

Signed-off-by: Justin Kim <justin.kim@collabora.com>