### PR TITLE
Replaced some magic numbers with preprocessor directives

### DIFF
--- a/programs/daytime_server.c
+++ b/programs/daytime_server.c
@@ -49,6 +49,10 @@
 #endif
 #include <usrsctp.h>
 
+#define PORT 13
+#define DAYTIME_PPID 40
+#define SLEEP 1
+
 void
 debug_printf(const char *format, ...)
 {
@@ -59,7 +63,6 @@ debug_printf(const char *format, ...)
 	va_end(ap);
 }
 
-#define DAYTIME_PPID 40
 int
 main(int argc, char *argv[])
 {
@@ -97,7 +100,7 @@ main(int argc, char *argv[])
 	addr.sin_len = sizeof(struct sockaddr_in);
 #endif
 	addr.sin_family = AF_INET;
-	addr.sin_port = htons(13);
+	addr.sin_port = htons(PORT);
 	addr.sin_addr.s_addr = htonl(INADDR_ANY);
 	if (usrsctp_bind(sock, (struct sockaddr *)&addr, sizeof(struct sockaddr_in)) < 0) {
 		perror("usrsctp_bind");
@@ -130,9 +133,9 @@ main(int argc, char *argv[])
 	usrsctp_close(sock);
 	while (usrsctp_finish() != 0) {
 #ifdef _WIN32
-		Sleep(1000);
+		Sleep(SLEEP * 1000);
 #else
-		sleep(1);
+		sleep(SLEEP);
 #endif
 	}
 	return (0);

--- a/programs/discard_server.c
+++ b/programs/discard_server.c
@@ -48,7 +48,9 @@
 #endif
 #include <usrsctp.h>
 
+#define PORT 9
 #define BUFFER_SIZE 10240
+#define SLEEP 1
 
 const int use_cb = 0;
 
@@ -189,7 +191,7 @@ main(int argc, char *argv[])
 	addr.sin6_len = sizeof(struct sockaddr_in6);
 #endif
 	addr.sin6_family = AF_INET6;
-	addr.sin6_port = htons(9);
+	addr.sin6_port = htons(PORT);
 	addr.sin6_addr = in6addr_any;
 	if (usrsctp_bind(sock, (struct sockaddr *)&addr, sizeof(struct sockaddr_in6)) < 0) {
 		perror("usrsctp_bind");
@@ -200,9 +202,9 @@ main(int argc, char *argv[])
 	while (1) {
 		if (use_cb) {
 #ifdef _WIN32
-			Sleep(1*1000);
+			Sleep(SLEEP * 1000);
 #else
-			sleep(1);
+			sleep(SLEEP);
 #endif
 		} else {
 			from_len = (socklen_t)sizeof(struct sockaddr_in6);
@@ -239,9 +241,9 @@ main(int argc, char *argv[])
 	usrsctp_close(sock);
 	while (usrsctp_finish() != 0) {
 #ifdef _WIN32
-		Sleep(1000);
+		Sleep(SLEEP * 1000);
 #else
-		sleep(1);
+		sleep(SLEEP);
 #endif
 	}
 	return (0);

--- a/programs/echo_server.c
+++ b/programs/echo_server.c
@@ -48,7 +48,9 @@
 #endif
 #include <usrsctp.h>
 
+#define PORT 7
 #define BUFFER_SIZE 10240
+#define SLEEP 1
 
 const int use_cb = 0;
 
@@ -204,7 +206,7 @@ main(int argc, char *argv[])
 	addr.sin6_len = sizeof(struct sockaddr_in6);
 #endif
 	addr.sin6_family = AF_INET6;
-	addr.sin6_port = htons(7);
+	addr.sin6_port = htons(PORT);
 	addr.sin6_addr = in6addr_any;
 	if (usrsctp_bind(sock, (struct sockaddr *)&addr, sizeof(struct sockaddr_in6)) < 0) {
 		perror("usrsctp_bind");
@@ -215,9 +217,9 @@ main(int argc, char *argv[])
 	while (1) {
 		if (use_cb) {
 #ifdef _WIN32
-			Sleep(1*1000);
+		Sleep(SLEEP * 1000);
 #else
-			sleep(1);
+		sleep(SLEEP);
 #endif
 		} else {
 			from_len = (socklen_t)sizeof(struct sockaddr_in6);
@@ -269,9 +271,9 @@ main(int argc, char *argv[])
 	usrsctp_close(sock);
 	while (usrsctp_finish() != 0) {
 #ifdef _WIN32
-		Sleep(1000);
+		Sleep(SLEEP * 1000);
 #else
-		sleep(1);
+		sleep(SLEEP);
 #endif
 	}
 	return (0);

--- a/programs/ekr_server.c
+++ b/programs/ekr_server.c
@@ -50,7 +50,9 @@
 #endif
 #include <usrsctp.h>
 
+#define PORT 5001
 #define MAX_PACKET_SIZE (1<<16)
+#define SLEEP 1
 
 #ifdef _WIN32
 static DWORD WINAPI
@@ -264,7 +266,7 @@ main(int argc, char *argv[])
 #ifdef HAVE_SCONN_LEN
 	sconn.sconn_len = sizeof(struct sockaddr_conn);
 #endif
-	sconn.sconn_port = htons(5001);
+	sconn.sconn_port = htons(PORT);
 	sconn.sconn_addr = (void *)&fd;
 	if (usrsctp_bind(s, (struct sockaddr *)&sconn, sizeof(struct sockaddr_conn)) < 0) {
 		perror("usrsctp_bind");
@@ -281,9 +283,9 @@ main(int argc, char *argv[])
 	usrsctp_deregister_address((void *)&fd);
 	while (usrsctp_finish() != 0) {
 #ifdef _WIN32
-		Sleep(1000);
+		Sleep(SLEEP * 1000);
 #else
-		sleep(1);
+		sleep(SLEEP);
 #endif
 	}
 #ifdef _WIN32


### PR DESCRIPTION
Replaced some magic numbers (e.g. port, sleeptime) with preprocessor directives (macros).
(This may be helpful for users who still do not know the usual service-ports.)