### PR TITLE
Add support for being notified by fd

### DIFF
--- a/usrsctplib/netinet/sctp.h
+++ b/usrsctplib/netinet/sctp.h
@@ -139,6 +139,7 @@ struct sctp_paramhdr {
 #define SCTP_NRSACK_SUPPORTED           0x00000030
 #define SCTP_PKTDROP_SUPPORTED          0x00000031
 #define SCTP_MAX_CWND                   0x00000032
+#define SCTP_NOTIF_FD                   0x00000033
 
 /*
  * read-only options

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -597,6 +597,8 @@ struct sctp_inpcb {
                              struct sctp_rcvinfo, int, void *);
 	uint32_t send_sb_threshold;
 	int (*send_callback)(struct socket *, uint32_t);
+	char use_notif_fd;
+	int notif_fd;
 #endif
 };
 

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -4422,6 +4422,28 @@ sctp_getopt(struct socket *so, int optname, void *optval, size_t *optsize,
 		}
 		break;
 	}
+	case SCTP_NOTIF_FD:
+	{
+		int fd;
+
+		if (*optsize < sizeof(int)) {
+			SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_USRREQ, EINVAL);
+			error = EINVAL;
+		} else {
+			SCTP_INP_RLOCK(inp);
+			if (inp->use_notif_fd) {
+			    fd = inp->notif_fd;
+			} else {
+			    fd = -1;
+			}
+			SCTP_INP_RUNLOCK(inp);
+		}
+		if (error == 0) {
+		    *(int *)optval = fd;
+		    *optsize = sizeof(int);
+		}
+		break;
+	}
 	default:
 		SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_USRREQ, ENOPROTOOPT);
 		error = ENOPROTOOPT;
@@ -7651,6 +7673,21 @@ sctp_setopt(struct socket *so, int optname, void *optval, size_t optsize,
 				error = EINVAL;
 			}
 		}
+		break;
+	}
+	case SCTP_NOTIF_FD:
+	{
+		int *fd;
+
+		SCTP_CHECK_AND_CAST(fd, optval, int, optsize);
+		SCTP_INP_WLOCK(inp);
+		if (*fd > 0) {
+			inp->use_notif_fd = 1;
+			inp->notif_fd = *fd;
+		} else {
+			inp->use_notif_fd = 0;
+		}
+		SCTP_INP_WUNLOCK(inp);
 		break;
 	}
 	default:

--- a/usrsctplib/netinet/sctputil.c
+++ b/usrsctplib/netinet/sctputil.c
@@ -4780,6 +4780,14 @@ sctp_invoke_recv_callback(struct sctp_inpcb *inp,
 {
 	uint32_t pd_point, length;
 
+	if (inp->use_notif_fd &&
+	    (stcb != NULL) &&
+	    (stcb->sctp_socket != NULL)) {
+		char b = 1;
+		write(inp->notif_fd, &b, 1);
+		return;
+	}
+
 	if ((inp->recv_callback == NULL) ||
 	    (stcb == NULL) ||
 	    (stcb->sctp_socket == NULL)) {

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -540,6 +540,7 @@ struct sctp_event_subscribe {
 #define SCTP_DEFAULT_SNDINFO            0x00000021
 #define SCTP_DEFAULT_PRINFO             0x00000022
 #define SCTP_REMOTE_UDP_ENCAPS_PORT     0x00000024
+#define SCTP_NOTIF_FD                   0x00000033
 
 #define SCTP_ENABLE_STREAM_RESET        0x00000900 /* struct sctp_assoc_value */
 


### PR DESCRIPTION
When enabled, one byte will be written on the fd
to notify that the socket have something to be read.

I.e. create a pipe where you can do select(2) poll(2) on one side.
And when there are data ready to be read the fd are read ready.
Along with the usrsctp socket that also can be read.

This is used to hook in usrsctp into erlang / beam network driver
where select(2) or poll(2) are used to multiplex over the sockets.

This is something I use on macos to run erlang with sctp support.
Since it is a work in progress on the erlang beam side.
Maybe a notification for when the socket is ready to be written to could be good as well.