### PR TITLE
receive_cb returning 0 on success

### DIFF
--- a/programs/client.c
+++ b/programs/client.c
@@ -279,7 +279,7 @@ receive_cb(struct socket *sock, union sctp_sockstore addr, void *data,
 		}
 		free(data);
 	}
-	return (1);
+	return (0);
 }
 
 void


### PR DESCRIPTION
Shouldn't this function return 0 on success?
Same would go for http_client.c tsctp.c etc.