### PR TITLE
memset-call replacement

### DIFF
--- a/programs/client.c
+++ b/programs/client.c
@@ -297,11 +297,11 @@ main(int argc, char *argv[])
 {
 	struct socket *sock;
 	struct sockaddr *addr, *addrs;
-	struct sockaddr_in addr4;
-	struct sockaddr_in6 addr6;
-	struct sctp_udpencaps encaps;
-	struct sctpstat stat;
-	struct sctp_event event;
+	struct sockaddr_in addr4 = {0};
+	struct sockaddr_in6 addr6 = {0};
+	struct sctp_udpencaps encaps = {0};
+	struct sctpstat stat = {0};
+	struct sctp_event event = {0};
 	uint16_t event_types[] = {SCTP_ASSOC_CHANGE,
 	                          SCTP_PEER_ADDR_CHANGE,
 	                          SCTP_SEND_FAILED_EVENT};
@@ -325,7 +325,7 @@ main(int argc, char *argv[])
 	if ((sock = usrsctp_socket(AF_INET6, SOCK_STREAM, IPPROTO_SCTP, receive_cb, NULL, 0, NULL)) == NULL) {
 		perror("usrsctp_socket");
 	}
-	memset(&event, 0, sizeof(event));
+	
 	event.se_assoc_id = SCTP_ALL_ASSOC;
 	event.se_on = 1;
 	for (i = 0; i < sizeof(event_types)/sizeof(uint16_t); i++) {
@@ -334,8 +334,7 @@ main(int argc, char *argv[])
 			perror("setsockopt SCTP_EVENT");
 		}
 	}
-	if (argc > 3) {
-		memset((void *)&addr6, 0, sizeof(struct sockaddr_in6));
+	if (argc > 3) {		
 #ifdef HAVE_SIN6_LEN
 		addr6.sin6_len = sizeof(struct sockaddr_in6);
 #endif
@@ -346,16 +345,13 @@ main(int argc, char *argv[])
 			perror("bind");
 		}
 	}
-	if (argc > 5) {
-		memset(&encaps, 0, sizeof(struct sctp_udpencaps));
+	if (argc > 5) {		
 		encaps.sue_address.ss_family = AF_INET6;
 		encaps.sue_port = htons(atoi(argv[5]));
 		if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_REMOTE_UDP_ENCAPS_PORT, (const void*)&encaps, (socklen_t)sizeof(struct sctp_udpencaps)) < 0) {
 			perror("setsockopt");
 		}
-	}
-	memset((void *)&addr4, 0, sizeof(struct sockaddr_in));
-	memset((void *)&addr6, 0, sizeof(struct sockaddr_in6));
+	}	
 #ifdef HAVE_SIN_LEN
 	addr4.sin_len = sizeof(struct sockaddr_in);
 #endif

--- a/programs/client.c
+++ b/programs/client.c
@@ -279,7 +279,7 @@ receive_cb(struct socket *sock, union sctp_sockstore addr, void *data,
 		}
 		free(data);
 	}
-	return (1);
+	return (0);
 }
 
 void

--- a/programs/daytime_server.c
+++ b/programs/daytime_server.c
@@ -71,12 +71,12 @@ int
 main(int argc, char *argv[])
 {
 	struct socket *sock, *conn_sock;
-	struct sockaddr_in addr;
-	struct sctp_udpencaps encaps;
+	struct sockaddr_in addr = {0};
+	struct sctp_udpencaps encaps = {0};
 	socklen_t addr_len;
 	char buffer[80];
 	time_t now;
-	struct sctp_sndinfo sndinfo;
+	struct sctp_sndinfo sndinfo = {0};
 
 	if (argc > 1) {
 		usrsctp_init(atoi(argv[1]), NULL, debug_printf);
@@ -91,15 +91,13 @@ main(int argc, char *argv[])
 	if ((sock = usrsctp_socket(AF_INET, SOCK_STREAM, IPPROTO_SCTP, NULL, NULL, 0, NULL)) == NULL) {
 		perror("usrsctp_socket");
 	}
-	if (argc > 2) {
-		memset(&encaps, 0, sizeof(struct sctp_udpencaps));
+	if (argc > 2) {		
 		encaps.sue_address.ss_family = AF_INET;
 		encaps.sue_port = htons(atoi(argv[2]));
 		if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_REMOTE_UDP_ENCAPS_PORT, (const void*)&encaps, (socklen_t)sizeof(struct sctp_udpencaps)) < 0) {
 			perror("setsockopt");
 		}
-	}
-	memset((void *)&addr, 0, sizeof(struct sockaddr_in));
+	}	
 #ifdef HAVE_SIN_LEN
 	addr.sin_len = sizeof(struct sockaddr_in);
 #endif

--- a/programs/discard_server.c
+++ b/programs/discard_server.c
@@ -126,9 +126,9 @@ int
 main(int argc, char *argv[])
 {
 	struct socket *sock;
-	struct sockaddr_in6 addr;
-	struct sctp_udpencaps encaps;
-	struct sctp_event event;
+	struct sockaddr_in6 addr = {0};
+	struct sctp_udpencaps encaps = {0};
+	struct sctp_event event = {0};
 	uint16_t event_types[] = {SCTP_ASSOC_CHANGE,
 	                          SCTP_PEER_ADDR_CHANGE,
 	                          SCTP_REMOTE_ERROR,
@@ -136,7 +136,7 @@ main(int argc, char *argv[])
 	                          SCTP_ADAPTATION_INDICATION,
 	                          SCTP_PARTIAL_DELIVERY_EVENT};
 	unsigned int i;
-	struct sctp_assoc_value av;
+	struct sctp_assoc_value av = {0};
 	const int on = 1;
 	ssize_t n;
 	int flags;
@@ -144,7 +144,7 @@ main(int argc, char *argv[])
 	char buffer[BUFFER_SIZE];
 	char name[INET6_ADDRSTRLEN];
 	socklen_t infolen;
-	struct sctp_rcvinfo rcv_info;
+	struct sctp_rcvinfo rcv_info = {0};
 	unsigned int infotype;
 
 	if (argc > 1) {
@@ -163,7 +163,7 @@ main(int argc, char *argv[])
 	if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_I_WANT_MAPPED_V4_ADDR, (const void*)&on, (socklen_t)sizeof(int)) < 0) {
 		perror("usrsctp_setsockopt SCTP_I_WANT_MAPPED_V4_ADDR");
 	}
-	memset(&av, 0, sizeof(struct sctp_assoc_value));
+	
 	av.assoc_id = SCTP_ALL_ASSOC;
 	av.assoc_value = 47;
 
@@ -174,14 +174,13 @@ main(int argc, char *argv[])
 		perror("usrsctp_setsockopt SCTP_RECVRCVINFO");
 	}
 	if (argc > 2) {
-		memset(&encaps, 0, sizeof(struct sctp_udpencaps));
+		
 		encaps.sue_address.ss_family = AF_INET6;
 		encaps.sue_port = htons(atoi(argv[2]));
 		if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_REMOTE_UDP_ENCAPS_PORT, (const void*)&encaps, (socklen_t)sizeof(struct sctp_udpencaps)) < 0) {
 			perror("usrsctp_setsockopt SCTP_REMOTE_UDP_ENCAPS_PORT");
 		}
-	}
-	memset(&event, 0, sizeof(event));
+	}	
 	event.se_assoc_id = SCTP_FUTURE_ASSOC;
 	event.se_on = 1;
 	for (i = 0; i < (unsigned int)(sizeof(event_types)/sizeof(uint16_t)); i++) {
@@ -189,8 +188,7 @@ main(int argc, char *argv[])
 		if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_EVENT, &event, sizeof(struct sctp_event)) < 0) {
 			perror("usrsctp_setsockopt SCTP_EVENT");
 		}
-	}
-	memset((void *)&addr, 0, sizeof(struct sockaddr_in6));
+	}	
 #ifdef HAVE_SIN6_LEN
 	addr.sin6_len = sizeof(struct sockaddr_in6);
 #endif

--- a/programs/echo_server.c
+++ b/programs/echo_server.c
@@ -141,17 +141,18 @@ int
 main(int argc, char *argv[])
 {
 	struct socket *sock;
-	struct sockaddr_in6 addr;
-	struct sctp_udpencaps encaps;
-	struct sctp_event event;
+	struct sockaddr_in6 addr = {0};
+	struct sctp_udpencaps encaps = {0};
+	struct sctp_event event = {0};
+    struct sctp_assoc_value av = {0};
+    struct sctp_rcvinfo rcv_info = {0};
 	uint16_t event_types[] = {SCTP_ASSOC_CHANGE,
 	                          SCTP_PEER_ADDR_CHANGE,
 	                          SCTP_REMOTE_ERROR,
 	                          SCTP_SHUTDOWN_EVENT,
 	                          SCTP_ADAPTATION_INDICATION,
 	                          SCTP_PARTIAL_DELIVERY_EVENT};
-	unsigned int i;
-	struct sctp_assoc_value av;
+	unsigned int i;	
 	const int on = 1;
 	ssize_t n;
 	int flags;
@@ -159,7 +160,7 @@ main(int argc, char *argv[])
 	char buffer[BUFFER_SIZE];
 	char name[INET6_ADDRSTRLEN];
 	socklen_t infolen;
-	struct sctp_rcvinfo rcv_info;
+	
 	unsigned int infotype;
 
 	if (argc > 1) {
@@ -178,7 +179,7 @@ main(int argc, char *argv[])
 	if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_I_WANT_MAPPED_V4_ADDR, (const void*)&on, (socklen_t)sizeof(int)) < 0) {
 		perror("usrsctp_setsockopt SCTP_I_WANT_MAPPED_V4_ADDR");
 	}
-	memset(&av, 0, sizeof(struct sctp_assoc_value));
+	
 	av.assoc_id = SCTP_ALL_ASSOC;
 	av.assoc_value = 47;
 
@@ -188,15 +189,13 @@ main(int argc, char *argv[])
 	if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_RECVRCVINFO, &on, sizeof(int)) < 0) {
 		perror("usrsctp_setsockopt SCTP_RECVRCVINFO");
 	}
-	if (argc > 2) {
-		memset(&encaps, 0, sizeof(struct sctp_udpencaps));
+	if (argc > 2) {		
 		encaps.sue_address.ss_family = AF_INET6;
 		encaps.sue_port = htons(atoi(argv[2]));
 		if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_REMOTE_UDP_ENCAPS_PORT, (const void*)&encaps, (socklen_t)sizeof(struct sctp_udpencaps)) < 0) {
 			perror("usrsctp_setsockopt SCTP_REMOTE_UDP_ENCAPS_PORT");
 		}
-	}
-	memset(&event, 0, sizeof(event));
+	}	
 	event.se_assoc_id = SCTP_FUTURE_ASSOC;
 	event.se_on = 1;
 	for (i = 0; i < (unsigned int)(sizeof(event_types)/sizeof(uint16_t)); i++) {
@@ -205,7 +204,7 @@ main(int argc, char *argv[])
 			perror("usrsctp_setsockopt SCTP_EVENT");
 		}
 	}
-	memset((void *)&addr, 0, sizeof(struct sockaddr_in6));
+	
 #ifdef HAVE_SIN6_LEN
 	addr.sin6_len = sizeof(struct sockaddr_in6);
 #endif


### PR DESCRIPTION
With this pull request, I suggest using
`  struct STRUCT = {0};`

instead of
   ` memset(&STRUCT, 0 ...);`