### PR TITLE
SCTP_DEBUG_ALL

### DIFF
--- a/programs/client.c
+++ b/programs/client.c
@@ -319,7 +319,7 @@ main(int argc, char *argv[])
 		usrsctp_init(9899, NULL, debug_printf);
 	}
 #ifdef SCTP_DEBUG
-	usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_NONE);
+	usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_ALL);
 #endif
 	usrsctp_sysctl_set_sctp_blackhole(2);
 	if ((sock = usrsctp_socket(AF_INET6, SOCK_STREAM, IPPROTO_SCTP, receive_cb, NULL, 0, NULL)) == NULL) {

--- a/programs/daytime_server.c
+++ b/programs/daytime_server.c
@@ -84,7 +84,7 @@ main(int argc, char *argv[])
 		usrsctp_init(9899, NULL, debug_printf);
 	}
 #ifdef SCTP_DEBUG
-	usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_NONE);
+	usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_ALL);
 #endif
 	usrsctp_sysctl_set_sctp_blackhole(2);
 

--- a/programs/echo_server.c
+++ b/programs/echo_server.c
@@ -168,7 +168,7 @@ main(int argc, char *argv[])
 		usrsctp_init(9899, NULL, debug_printf);
 	}
 #ifdef SCTP_DEBUG
-	usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_NONE);
+	usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_ALL);
 #endif
 	usrsctp_sysctl_set_sctp_blackhole(2);
 


### PR DESCRIPTION
Does it make sense to 
```
#ifdef SCTP_DEBUG
	usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_NONE);
#endif
```

?