### PR TITLE
Abandoning chunks from the stream queue if their time is up

### DIFF
--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -9149,6 +9149,45 @@ again_one_more_time:
 						continue;
 					}
 				}
+
+				if (PR_SCTP_ENABLED(chk->flags)) {
+					if PR_SCTP_TTL_ENABLED(chk->flags){
+						if (*now_filled == 0) {
+							(void)SCTP_GETTIME_TIMEVAL(now);
+							*now_filled = 1;
+						}
+						/*
+						 * Chunk has not been sent but its time is already up
+						 */
+#ifndef __FreeBSD__
+						if (timercmp(now, &chk->rec.data.timetodrop, >)) {
+#else
+						if (timevalcmp(now, &chk->rec.data.timetodrop, >)) {
+#endif
+							/* Yes so drop it */
+							if (chk->data) {
+								if (chk->whoTo == NULL) {
+									chk->whoTo = net;
+									atomic_add_int(&net->ref_count, 1);
+								}
+#ifdef SCTP_DEBUG
+								SCTPDBG(SCTP_DEBUG_OUTPUT4, "found chunk to ABANDON "
+										"TSN:%10lu C:%d S:%d [ %ld.%06ld ] now:[ %ld.%06ld ]\n",
+										ntohl(chk->rec.data.tsn),
+										chk->snd_count, chk->sent,
+										chk->rec.data.timetodrop.tv_sec,
+										chk->rec.data.timetodrop.tv_usec,
+										now->tv_sec, now->tv_usec);
+#endif
+								(void)sctp_release_pr_sctp_chunk(stcb, chk,
+										1, SCTP_SO_LOCKED);
+								/* cnt_abandoned++; TODO */
+							}
+							continue;
+						}
+					}
+				}
+
 				if ((chk->send_size > omtu) && ((chk->flags & CHUNK_FLAGS_FRAGMENT_OK) == 0)) {
 					/*-
 					 * strange, we have a chunk that is

--- a/usrsctplib/netinet/sctputil.c
+++ b/usrsctplib/netinet/sctputil.c
@@ -5104,7 +5104,7 @@ sctp_release_pr_sctp_chunk(struct sctp_tcb *stcb, struct sctp_tmit_chunk *tp1,
 	do {
 		ret_sz += tp1->book_size;
 		if (tp1->data != NULL) {
-			if (tp1->sent < SCTP_DATAGRAM_RESEND) {
+			if (tp1->whoTo != NULL && tp1->sent < SCTP_DATAGRAM_RESEND) {
 				sctp_flight_size_decrease(tp1);
 				sctp_total_flight_decrease(stcb, tp1);
 			}


### PR DESCRIPTION
First attempt to fix #193 
It works in my setup on linux
I didn't bother with stats.

One thought:
sender buffer might still be blocked. If a new chunk comes in and the stream queue recognizes it as too late it's flagged for forward_tsn but potentially many chunks before that are not flagged because usually flagging only happens when handling a SACK.

@msvoelker I am happy for input/feedback. I am a bit limited in my non-generic test setup though.