### PR TITLE
Add compiler check "-Wstrict-prototypes" and fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,12 @@ if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_C_COMPILER_ID}" MATCHES
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unreachable-code")
 	endif ()
 
+	check_c_compiler_flag(-Wstrict-prototypes has_wstrict_prototypes)
+	if (has_wstrict_prototypes)
+		set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -Wstrict-prototypes")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-prototypes")
+	endif ()
+
 	if (sctp_werror)
 		set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -Werror")
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")

--- a/usrsctplib/user_atomic.h
+++ b/usrsctplib/user_atomic.h
@@ -78,9 +78,9 @@
 }
 #endif
 #if defined(__Userspace_os_Windows)
-static void atomic_init() {} /* empty when we are not using atomic_mtx */
+static void atomic_init(void) {} /* empty when we are not using atomic_mtx */
 #else
-static inline void atomic_init() {} /* empty when we are not using atomic_mtx */
+static inline void atomic_init(void) {} /* empty when we are not using atomic_mtx */
 #endif
 
 #else
@@ -132,7 +132,7 @@ static inline void atomic_init() {} /* empty when we are not using atomic_mtx */
 	} \
 }
 #endif
-static inline void atomic_init() {} /* empty when we are not using atomic_mtx */
+static inline void atomic_init(void) {} /* empty when we are not using atomic_mtx */
 #endif
 
 #if 0 /* using libatomic_ops */

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -376,9 +376,7 @@ soisdisconnecting(struct socket *so)
  * timeo identifier.
  */
 void
-wakeup(ident, so)
-	void *ident;
-	struct socket *so;
+wakeup(void *ident, struct socket *so)
 {
 	SOCK_LOCK(so);
 #if defined (__Userspace_os_Windows)
@@ -396,8 +394,7 @@ wakeup(ident, so)
  * swapped out.
  */
 void
-wakeup_one(ident)
-	void *ident;
+wakeup_one(void *ident)
 {
 	/* __Userspace__ Check: We are using accept_cond for wakeup_one.
 	  It seems that wakeup_one is only called within
@@ -683,10 +680,7 @@ out:
 
 /* Source: src/sys/kern/uipc_syscalls.c */
 int
-getsockaddr(namp, uaddr, len)
-	struct sockaddr **namp;
-	caddr_t uaddr;
-	size_t len;
+getsockaddr(struct sockaddr **namp, caddr_t uaddr, size_t len)
 {
 	struct sockaddr *sa;
 	int error;


### PR DESCRIPTION
This PR adds "-Wstrict-prototypes" check if supported and fixes related warnings.
See #207 