### PR TITLE
Fix cast in sctp_findassociation_ep_addr

### DIFF
--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -1487,7 +1487,7 @@ sctp_findassociation_ep_addr(struct sctp_inpcb **inp_p, struct sockaddr *remote,
 #endif
 #if defined(__Userspace__)
 	case AF_CONN:
-		rport = (((struct sockaddr_in6 *)remote)->sin6_port);
+		rport = (((struct sockaddr_conn *)remote)->sconn_port);
 		break;
 #endif
 	default:


### PR DESCRIPTION
In AF_CONN case cast to sockaddr_conn instead of sockaddr_in6