### PR TITLE
sctp_finish: wait thread join regardless socket status

### DIFF
--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -286,6 +286,13 @@ struct sctp_epinfo {
 #endif
 };
 
+enum sctp_base_thread {
+        SCTP_BASE_THREAD_RECV_ROUTE = 0,
+        SCTP_BASE_THREAD_RECV_RAW,
+        SCTP_BASE_THREAD_RECV_UDP,
+        SCTP_BASE_THREAD_RECV_RAW6,
+        SCTP_BASE_THREAD_RECV_UDP6,
+};
 
 struct sctp_base_info {
 	/* All static structures that
@@ -345,6 +352,7 @@ struct sctp_base_info {
 	void (*debug_printf)(const char *format, ...);
 	int crc32c_offloaded;
 #endif
+        int userland_thread_stats;
 };
 
 /*-

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -192,13 +192,13 @@ sctp_finish(void)
 #endif
 #if !defined(__Userspace_os_Windows)
 #if defined(INET) || defined(INET6)
-	if (SCTP_BASE_VAR(userspace_route) != -1) {
+	if (SCTP_BASE_VAR(userland_thread_stats) & (1 << SCTP_BASE_THREAD_RECV_ROUTE)) {
 		pthread_join(SCTP_BASE_VAR(recvthreadroute), NULL);
 	}
 #endif
 #endif
 #ifdef INET
-	if (SCTP_BASE_VAR(userspace_rawsctp) != -1) {
+	if (SCTP_BASE_VAR(userland_thread_stats) & (1 << SCTP_BASE_THREAD_RECV_RAW)) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadraw), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadraw));
@@ -206,7 +206,7 @@ sctp_finish(void)
 		pthread_join(SCTP_BASE_VAR(recvthreadraw), NULL);
 #endif
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp) != -1) {
+	if (SCTP_BASE_VAR(userland_thread_stats) & (1 << SCTP_BASE_THREAD_RECV_UDP)) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadudp), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadudp));
@@ -216,7 +216,7 @@ sctp_finish(void)
 	}
 #endif
 #ifdef INET6
-	if (SCTP_BASE_VAR(userspace_rawsctp6) != -1) {
+	if (SCTP_BASE_VAR(userland_thread_stats) & (1 << SCTP_BASE_THREAD_RECV_RAW6)) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadraw6), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadraw6));
@@ -224,7 +224,7 @@ sctp_finish(void)
 		pthread_join(SCTP_BASE_VAR(recvthreadraw6), NULL);
 #endif
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp6) != -1) {
+	if (SCTP_BASE_VAR(userland_thread_stats) & (1 << SCTP_BASE_THREAD_RECV_UDP6)) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadudp6), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadudp6));

--- a/usrsctplib/user_recv_thread.c
+++ b/usrsctplib/user_recv_thread.c
@@ -1081,6 +1081,7 @@ recv_thread_init(void)
 #else
 	unsigned int timeout = SOCKET_TIMEOUT; /* Timeout in milliseconds */
 #endif
+	SCTP_BASE_VAR(userland_thread_stats) = 0;
 #if defined(__Userspace_os_Darwin) || defined(__Userspace_os_DragonFly) || defined(__Userspace_os_FreeBSD)
 	if (SCTP_BASE_VAR(userspace_route) == -1) {
 		if ((SCTP_BASE_VAR(userspace_route) = socket(AF_ROUTE, SOCK_RAW, 0)) == -1) {
@@ -1390,7 +1391,9 @@ recv_thread_init(void)
 			SCTPDBG(SCTP_DEBUG_USR, "Can't start routing thread (%d).\n", rc);
 			close(SCTP_BASE_VAR(userspace_route));
 			SCTP_BASE_VAR(userspace_route) = -1;
+			SCTP_BASE_VAR(userland_thread_stats) ^= (1 << SCTP_BASE_THREAD_RECV_ROUTE);
 		}
+	        SCTP_BASE_VAR(userland_thread_stats) |= (1 << SCTP_BASE_THREAD_RECV_ROUTE);
 	}
 #endif
 #endif
@@ -1406,7 +1409,9 @@ recv_thread_init(void)
 			close(SCTP_BASE_VAR(userspace_rawsctp));
 #endif
 			SCTP_BASE_VAR(userspace_rawsctp) = -1;
+			SCTP_BASE_VAR(userland_thread_stats) ^= (1 << SCTP_BASE_THREAD_RECV_RAW);
 		}
+		SCTP_BASE_VAR(userland_thread_stats) |= (1 << SCTP_BASE_THREAD_RECV_RAW);
 	}
 	if (SCTP_BASE_VAR(userspace_udpsctp) != -1) {
 		int rc;
@@ -1419,7 +1424,9 @@ recv_thread_init(void)
 			close(SCTP_BASE_VAR(userspace_udpsctp));
 #endif
 			SCTP_BASE_VAR(userspace_udpsctp) = -1;
+			SCTP_BASE_VAR(userland_thread_stats) ^= (1 << SCTP_BASE_THREAD_RECV_UDP);
 		}
+		SCTP_BASE_VAR(userland_thread_stats) |= (1 << SCTP_BASE_THREAD_RECV_UDP);
 	}
 #endif
 #if defined(INET6)
@@ -1434,7 +1441,9 @@ recv_thread_init(void)
 			close(SCTP_BASE_VAR(userspace_rawsctp6));
 #endif
 			SCTP_BASE_VAR(userspace_rawsctp6) = -1;
+			SCTP_BASE_VAR(userland_thread_stats) ^= (1 << SCTP_BASE_THREAD_RECV_RAW6);
 		}
+		SCTP_BASE_VAR(userland_thread_stats) |= (1 << SCTP_BASE_THREAD_RECV_RAW6);
 	}
 	if (SCTP_BASE_VAR(userspace_udpsctp6) != -1) {
 		int rc;
@@ -1447,7 +1456,9 @@ recv_thread_init(void)
 			close(SCTP_BASE_VAR(userspace_udpsctp6));
 #endif
 			SCTP_BASE_VAR(userspace_udpsctp6) = -1;
+			SCTP_BASE_VAR(userland_thread_stats) ^= (1 << SCTP_BASE_THREAD_RECV_UDP6);
 		}
+		SCTP_BASE_VAR(userland_thread_stats) |= (1 << SCTP_BASE_THREAD_RECV_UDP6);
 	}
 #endif
 }


### PR DESCRIPTION
It has no chance to call tread join because of checking
sockets validity, but the sockets are already invalidated
by `recv_thread_destroy`