### PR TITLE
join user thread by checking flag

### DIFF
--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -317,6 +317,7 @@ struct sctp_base_info {
 #if defined(INET) || defined(INET6)
 	int userspace_route;
 	userland_thread_t recvthreadroute;
+	int recvthreadroute_should_exit;
 #endif
 #endif
 #ifdef INET
@@ -329,6 +330,9 @@ struct sctp_base_info {
 #endif
 	userland_thread_t recvthreadraw;
 	userland_thread_t recvthreadudp;
+	int recvthreadraw_should_exit;
+	int recvthreadudp_should_exit;
+
 #endif
 #ifdef INET6
 #if defined(__Userspace_os_Windows)
@@ -340,6 +344,8 @@ struct sctp_base_info {
 #endif
 	userland_thread_t recvthreadraw6;
 	userland_thread_t recvthreadudp6;
+	int recvthreadraw6_should_exit;
+	int recvthreadudp6_should_exit;
 #endif
 	int (*conn_output)(void *addr, void *buffer, size_t length, uint8_t tos, uint8_t set_df);
 	void (*debug_printf)(const char *format, ...);

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -136,15 +136,20 @@ sctp_init(void)
 #if !defined(__Userspace_os_Windows)
 #if defined(INET) || defined(INET6)
 	SCTP_BASE_VAR(userspace_route) = -1;
+	SCTP_BASE_VAR(recvthreadroute_should_exit) = 0;
 #endif
 #endif
 #ifdef INET
 	SCTP_BASE_VAR(userspace_rawsctp) = -1;
 	SCTP_BASE_VAR(userspace_udpsctp) = -1;
+	SCTP_BASE_VAR(recvthreadraw_should_exit) = 0;
+	SCTP_BASE_VAR(recvthreadudp_should_exit) = 0;
 #endif
 #ifdef INET6
 	SCTP_BASE_VAR(userspace_rawsctp6) = -1;
 	SCTP_BASE_VAR(userspace_udpsctp6) = -1;
+	SCTP_BASE_VAR(recvthreadraw6_should_exit) = 0;
+	SCTP_BASE_VAR(recvthreadudp6_should_exit) = 0;
 #endif
 	SCTP_BASE_VAR(timer_thread_should_exit) = 0;
 	SCTP_BASE_VAR(conn_output) = conn_output;
@@ -192,13 +197,13 @@ sctp_finish(void)
 #endif
 #if !defined(__Userspace_os_Windows)
 #if defined(INET) || defined(INET6)
-	if (SCTP_BASE_VAR(userspace_route) != -1) {
+	if (atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadroute_should_exit), 1, 0)) {
 		pthread_join(SCTP_BASE_VAR(recvthreadroute), NULL);
 	}
 #endif
 #endif
 #ifdef INET
-	if (SCTP_BASE_VAR(userspace_rawsctp) != -1) {
+	if (atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadraw_should_exit), 1, 0)) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadraw), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadraw));
@@ -206,7 +211,7 @@ sctp_finish(void)
 		pthread_join(SCTP_BASE_VAR(recvthreadraw), NULL);
 #endif
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp) != -1) {
+	if (atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadudp_should_exit), 1, 0)) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadudp), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadudp));
@@ -216,7 +221,7 @@ sctp_finish(void)
 	}
 #endif
 #ifdef INET6
-	if (SCTP_BASE_VAR(userspace_rawsctp6) != -1) {
+	if (atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadraw6_should_exit), 1, 0)) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadraw6), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadraw6));
@@ -224,7 +229,7 @@ sctp_finish(void)
 		pthread_join(SCTP_BASE_VAR(recvthreadraw6), NULL);
 #endif
 	}
-	if (SCTP_BASE_VAR(userspace_udpsctp6) != -1) {
+	if (atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadudp6_should_exit), 1, 0)) {
 #if defined(__Userspace_os_Windows)
 		WaitForSingleObject(SCTP_BASE_VAR(recvthreadudp6), INFINITE);
 		CloseHandle(SCTP_BASE_VAR(recvthreadudp6));

--- a/usrsctplib/user_recv_thread.c
+++ b/usrsctplib/user_recv_thread.c
@@ -142,7 +142,7 @@ recv_function_route(void *arg)
 
 	sctp_userspace_set_threadname("SCTP addr mon");
 
-	while (1) {
+	while (!atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadroute_should_exit), 1, 1)) {
 		memset(rt_buffer, 0, sizeof(rt_buffer));
 		ret = recv(SCTP_BASE_VAR(userspace_route), rt_buffer, sizeof(rt_buffer), 0);
 
@@ -298,7 +298,7 @@ recv_function_raw(void *arg)
 
 	recvmbuf = malloc(sizeof(struct mbuf *) * MAXLEN_MBUF_CHAIN);
 
-	while (1) {
+	while (!atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadraw_should_exit), 1, 1)) {
 		for (i = 0; i < to_fill; i++) {
 			/* Not getting the packet header. Tests with chain of one run
 			   as usual without having the packet header.
@@ -478,7 +478,7 @@ recv_function_raw6(void *arg)
 
 	recvmbuf6 = malloc(sizeof(struct mbuf *) * MAXLEN_MBUF_CHAIN);
 
-	for (;;) {
+	while (!atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadraw6_should_exit), 1, 1)) {
 		for (i = 0; i < to_fill; i++) {
 			/* Not getting the packet header. Tests with chain of one run
 			   as usual without having the packet header.
@@ -667,7 +667,7 @@ recv_function_udp(void *arg)
 
 	udprecvmbuf = malloc(sizeof(struct mbuf *) * MAXLEN_MBUF_CHAIN);
 
-	while (1) {
+	while (!atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadudp_should_exit), 1, 1)) {
 		for (i = 0; i < to_fill; i++) {
 			/* Not getting the packet header. Tests with chain of one run
 			   as usual without having the packet header.
@@ -868,7 +868,7 @@ recv_function_udp6(void *arg)
 	sctp_userspace_set_threadname("SCTP/UDP/IP6 rcv");
 
 	udprecvmbuf6 = malloc(sizeof(struct mbuf *) * MAXLEN_MBUF_CHAIN);
-	while (1) {
+	while (!atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadudp6_should_exit), 1, 1)) {
 		for (i = 0; i < to_fill; i++) {
 			/* Not getting the packet header. Tests with chain of one run
 			   as usual without having the packet header.

--- a/usrsctplib/user_recv_thread.c
+++ b/usrsctplib/user_recv_thread.c
@@ -1391,6 +1391,7 @@ recv_thread_init(void)
 			close(SCTP_BASE_VAR(userspace_route));
 			SCTP_BASE_VAR(userspace_route) = -1;
 		}
+		atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadroute_should_exit), 0, !rc);
 	}
 #endif
 #endif
@@ -1407,6 +1408,7 @@ recv_thread_init(void)
 #endif
 			SCTP_BASE_VAR(userspace_rawsctp) = -1;
 		}
+		atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadraw_should_exit), 0, !rc);
 	}
 	if (SCTP_BASE_VAR(userspace_udpsctp) != -1) {
 		int rc;
@@ -1420,6 +1422,7 @@ recv_thread_init(void)
 #endif
 			SCTP_BASE_VAR(userspace_udpsctp) = -1;
 		}
+		atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadudp_should_exit), 0, !rc);
 	}
 #endif
 #if defined(INET6)
@@ -1435,6 +1438,7 @@ recv_thread_init(void)
 #endif
 			SCTP_BASE_VAR(userspace_rawsctp6) = -1;
 		}
+		atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadraw6_should_exit), 0, !rc);
 	}
 	if (SCTP_BASE_VAR(userspace_udpsctp6) != -1) {
 		int rc;
@@ -1448,6 +1452,7 @@ recv_thread_init(void)
 #endif
 			SCTP_BASE_VAR(userspace_udpsctp6) = -1;
 		}
+		atomic_cmpset_int(&SCTP_BASE_VAR(recvthreadudp6_should_exit), 0, !rc);
 	}
 #endif
 }
@@ -1459,6 +1464,7 @@ recv_thread_destroy(void)
 #if defined(INET) || defined(INET6)
 	if (SCTP_BASE_VAR(userspace_route) != -1) {
 		close(SCTP_BASE_VAR(userspace_route));
+		SCTP_BASE_VAR(userspace_route) = -1;
 	}
 #endif
 #endif
@@ -1469,6 +1475,7 @@ recv_thread_destroy(void)
 #else
 		close(SCTP_BASE_VAR(userspace_rawsctp));
 #endif
+		SCTP_BASE_VAR(userspace_rawsctp) = -1;
 	}
 	if (SCTP_BASE_VAR(userspace_udpsctp) != -1) {
 #if defined(__Userspace_os_Windows)
@@ -1476,6 +1483,7 @@ recv_thread_destroy(void)
 #else
 		close(SCTP_BASE_VAR(userspace_udpsctp));
 #endif
+		SCTP_BASE_VAR(userspace_udpsctp) = -1;
 	}
 #endif
 #if defined(INET6)
@@ -1485,6 +1493,7 @@ recv_thread_destroy(void)
 #else
 		close(SCTP_BASE_VAR(userspace_rawsctp6));
 #endif
+		SCTP_BASE_VAR(userspace_rawsctp6) = -1;
 	}
 	if (SCTP_BASE_VAR(userspace_udpsctp6) != -1) {
 #if defined(__Userspace_os_Windows)
@@ -1492,6 +1501,7 @@ recv_thread_destroy(void)
 #else
 		close(SCTP_BASE_VAR(userspace_udpsctp6));
 #endif
+		SCTP_BASE_VAR(userspace_udpsctp6) = -1;
 	}
 #endif
 }


### PR DESCRIPTION
Invalidating socket was introduced by dd07478 to prevent
using closed socket in user thread, but it was reverted
by ec8cf8e because the socket descriptor is also used for
checking if user thread is created.

However, it sometimes happens that a new thread is created while
the existing thread is closing. Then, in user thread function, the
socket descriptor is regarded as valid so the loop in the function
has no chance to exit. To avoid replacing the socket descriptor
by repeating, the descriptor should be invalidated immediately.

Signed-off-by: Justin Kim <justin.kim@collabora.com>