### PR TITLE
Fix a build fails with gcc 4.5

### DIFF
--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -3519,7 +3519,7 @@ int usrsctp_sysctl_set_ ## __field(uint32_t value)   \
 	}                                            \
 }
 
-#if !defined(__Userspace_os_Windows)
+#if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wtype-limits"
 #endif
@@ -3592,7 +3592,7 @@ USRSCTP_SYSCTL_SET_DEF(sctp_initial_cwnd, SCTPCTL_INITIAL_CWND)
 #ifdef SCTP_DEBUG
 USRSCTP_SYSCTL_SET_DEF(sctp_debug_on, SCTPCTL_DEBUG)
 #endif
-#if !defined(__Userspace_os_Windows)
+#if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -3593,7 +3593,7 @@ USRSCTP_SYSCTL_SET_DEF(sctp_initial_cwnd, SCTPCTL_INITIAL_CWND)
 USRSCTP_SYSCTL_SET_DEF(sctp_debug_on, SCTPCTL_DEBUG)
 #endif
 #if !defined(__Userspace_os_Windows)
-#pragma GCC diagnostic push
+#pragma GCC diagnostic pop
 #endif
 
 #define USRSCTP_SYSCTL_GET_DEF(__field) \


### PR DESCRIPTION
`#pragma GCC diagnostic push` and `#pragma GCC diagnostic pop` were added in [gcc 4.6](https://gcc.gnu.org/gcc-4.6/changes.html). 

see also:
https://stackoverflow.com/questions/16555585/why-pragma-gcc-diagnostic-push-pop-warning-in-gcc-c
https://stackoverflow.com/questions/28681305/pragma-ignored-in-g-and-clang
