### PR TITLE
Minor build system fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,11 @@
 # SUCH DAMAGE.
 #
 
-SUBDIRS = usrsctplib programs
+if COND_PROGRAMS
+MAYBEPROGRAMS = programs
+endif
+
+SUBDIRS = usrsctplib $(MAYBEPROGRAMS)
 EXTRA_DIST = bootstrap Makefile.nmake
 ACLOCAL_AMFLAGS = -I m4
 # pkgconfig_DATA = usrsctp.pc

--- a/configure.ac
+++ b/configure.ac
@@ -136,9 +136,7 @@ AC_ARG_ENABLE(programs,
   AC_HELP_STRING( [--enable-programs],
                   [build example programs @<:@default=yes@:>@]),
     enable_programs=$enableval,enable_programs=yes)
-if test x$enable_programs = xyes; then
-        AC_CONFIG_FILES(programs/Makefile)
-fi
+AM_CONDITIONAL([COND_PROGRAMS], [test "$enable_programs" = yes])
 
 AC_CHECK_TYPE(size_t)
 AC_CHECK_TYPE(ssize_t)
@@ -192,4 +190,5 @@ AC_C_BIGENDIAN
 AC_SUBST([LIBCFLAGS])
 AC_SUBST([APPCFLAGS])
 dnl AC_CONFIG_FILES([usrsctp.pc])
-AC_OUTPUT(Makefile usrsctplib/Makefile)
+AC_CONFIG_FILES(usrsctplib/Makefile programs/Makefile Makefile)
+AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ dnl SUCH DAMAGE.
 dnl
 
 AC_INIT([libusrsctp], [0.9.3.0])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 AC_PROG_CC
 AC_PROG_LIBTOOL


### PR DESCRIPTION
Hi,

These are some minor changes to the build system so that:

- Building the example programs can be disabled
- autoreconf can be used to initialise the build system instead of using the ./bootstrap script as autoreconf correctly uses the environment supplied by Yocto (and boostrap.sh does not)