### PR TITLE
Fixed notify happening before association is added to accept queue

### DIFF
--- a/usrsctplib/netinet/sctp_input.c
+++ b/usrsctplib/netinet/sctp_input.c
@@ -3096,11 +3096,6 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 			SCTP_INP_DECR_REF(inp);
 			/* Switch over to the new guy */
 			*inp_p = inp;
-			sctp_ulp_notify(notification, *stcb, 0, NULL, SCTP_SO_NOT_LOCKED);
-			if (send_int_conf) {
-				sctp_ulp_notify(SCTP_NOTIFY_INTERFACE_CONFIRMED,
-				                (*stcb), 0, (void *)netl, SCTP_SO_NOT_LOCKED);
-			}
 
 			/* Pull it from the incomplete queue and wake the guy */
 #if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
@@ -3114,6 +3109,11 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 			atomic_subtract_int(&(*stcb)->asoc.refcnt, 1);
 			SCTP_SOCKET_UNLOCK(so, 1);
 #endif
+			sctp_ulp_notify(notification, *stcb, 0, NULL, SCTP_SO_NOT_LOCKED);
+			if (send_int_conf) {
+				sctp_ulp_notify(SCTP_NOTIFY_INTERFACE_CONFIRMED,
+				                (*stcb), 0, (void *)netl, SCTP_SO_NOT_LOCKED);
+			}
 			return (m);
 		}
 	}


### PR DESCRIPTION
When the server socket is operating in non-blocking mode, we wait for
the COMM_UP notification, and then call accept. However, the
association is not added to the accept queue until after the COMM_UP
notification is triggered. This causes the application to have to wait an
indeterminate amount of time and can cause race conditions when the
application calls accept before usrSCTP adds the association to the
accept queue.