### PR TITLE
Fixed compile error if both inet and inet6 are disabled

### DIFF
--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -3859,7 +3859,10 @@ sctp_findassociation_cmsgs(struct sctp_inpcb **inp_p,
 #ifdef INET6
 	struct sockaddr_in6 sin6;
 #endif
-	int tot_len, rem_len, cmsg_data_len, cmsg_data_off, off;
+	int tot_len, rem_len, off;
+#if defined(INET) || defined(INET6)
+    int cmsg_data_len, cmsg_data_off;
+#endif
 
 	tot_len = SCTP_BUF_LEN(control);
 	for (off = 0; off < tot_len; off += CMSG_ALIGN(cmh.cmsg_len)) {
@@ -3880,8 +3883,10 @@ sctp_findassociation_cmsgs(struct sctp_inpcb **inp_p,
 			*error = EINVAL;
 			return (NULL);
 		}
+#if defined(INET) || defined(INET6)
 		cmsg_data_len = (int)cmh.cmsg_len - CMSG_ALIGN(sizeof(cmh));
 		cmsg_data_off = off + CMSG_ALIGN(sizeof(cmh));
+#endif
 		if (cmh.cmsg_level == IPPROTO_SCTP) {
 			switch (cmh.cmsg_type) {
 #ifdef INET


### PR DESCRIPTION
When compiling usrSCTP with INET and INET6 disabled, the build fails with the following errors:

<pre>
libtool: compile:  gcc -DPACKAGE_NAME=\"libusrsctp\" -DPACKAGE_TARNAME=\"libusrsctp\" -DPACKAGE_VERSION=\"0.9.3.0\" "-DPACKAGE_STRING=\"libusrsctp 0.9.3.0\"" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE
=\"libusrsctp\" -DVERSION=\"0.9.3.0\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHA
VE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_SOCKET=1 -DHAVE_INET_ADDR=1 -DHAVE_STDATOMIC_H=1 -DHAVE_SYS_QUEUE_H=1 -DHAVE_LINUX_IF_ADDR_H=1 -DHAVE_LINUX_RTNETLINK_H=1 -DHAVE_NETINET_IP_ICMP_H=1 -
I. -DSCTP_PROCESS_LEVEL_LOCKS -DSCTP_SIMPLE_ALLOCATOR -D__Userspace__ -D__Userspace_os_Linux -g -O2 -std=c99 -pthread -D_GNU_SOURCE -pedantic -Wall -Werror -MT netinet/libusrsctp_la-sctp_output.lo -MD -MP -MF ne
tinet/.deps/libusrsctp_la-sctp_output.Tpo -c netinet/sctp_output.c  -fPIC -DPIC -o netinet/.libs/libusrsctp_la-sctp_output.o                                                                                       
netinet/sctp_output.c: In function \u2018sctp_findassociation_cmsgs\u2019:                                                                                                                                                   
netinet/sctp_output.c:3862:39: error: variable \u2018cmsg_data_off\u2019 set but not used [-Werror=unused-but-set-variable]                                                                                                  
  int tot_len, rem_len, cmsg_data_len, cmsg_data_off, off;                                                                                                                                                         
                                       ^~~~~~~~~~~~~                                                                                                                                                               
netinet/sctp_output.c:3862:24: error: variable \u2018cmsg_data_len\u2019 set but not used [-Werror=unused-but-set-variable]                                                                                                  
  int tot_len, rem_len, cmsg_data_len, cmsg_data_off, off;                                                                                                                                                         
                        ^~~~~~~~~~~~~
</pre>