### PR TITLE
Fix build with MinGW and the ucrtbase CRT

### DIFF
--- a/usrsctplib/user_malloc.h
+++ b/usrsctplib/user_malloc.h
@@ -41,7 +41,7 @@
 #include <strings.h>
 #include <stdint.h>
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1600
+#if (defined(_MSC_VER) && _MSC_VER >= 1600) || (defined(__MSVCRT_VERSION__) && __MSVCRT_VERSION__ >= 1400)
 #include <stdint.h>
 #elif defined(SCTP_STDINT_INCLUDE)
 #include SCTP_STDINT_INCLUDE


### PR DESCRIPTION
Fixes the following error when building with GCC and using MinGW's ucrtbase:
```
/home/andoni/mingw/linux/multilib/x86_64-w64-mingw32/sysroot/mingw/include/minwindef.h:173: note: this is the location of the previous definition
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 
In file included from user_mbuf.h:40,
                 from user_mbuf.c:44:
user_malloc.h:49:18: error: duplicate 'unsigned'
 #define uint32_t unsigned __int32
                  ^~~~~~~~
user_malloc.h:50:18: error: duplicate 'unsigned'
 #define uint64_t unsigned __int64
                  ^~~~~~~~
In file included from /home/andoni/mingw/linux/multilib/x86_64-w64-mingw32/sysroot/mingw/include/crtdefs.h:10,
                 from /home/andoni/mingw/linux/multilib/x86_64-w64-mingw32/sysroot/mingw/include/stdio.h:9,
                 from user_mbuf.c:38:
user_malloc.h:50:27: error: 'long long long' is too long for GCC
 #define uint64_t unsigned __int64
                           ^~~~~~~
user_malloc.h:50:27: error: 'long long long' is too long for GCC
 #define uint64_t unsigned __int64
                           ^~~~~~~
In file included from user_environment.c:38:
```

