### PR TITLE
Improved error handling for examples and fixed a compiler warning

### DIFF
--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -258,6 +258,8 @@ main(int argc, char *argv[])
 
 		if (errno == ECONNREFUSED) {
 			result = RETVAL_ECONNREFUSED;
+		} else if (errno == ETIMEDOUT) {
+			result = RETVAL_TIMEOUT;
 		} else {
 			result = RETVAL_CATCHALL;
 		}

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -261,8 +261,9 @@ main(int argc, char *argv[])
 		} else {
 			result = RETVAL_CATCHALL;
 		}
+		printf("result %d - errno %d\n", result, errno);
+
 		usrsctp_close(sock);
-		printf("errno = %d\n", errno);
 
 		goto out;
 	}

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -57,8 +57,8 @@
 #include <usrsctp.h>
 
 #define RETVAL_CATCHALL     50
-#define RETVAL_ECONNREFUSED 60
-#define RETVAL_TIMEOUT      61
+#define RETVAL_TIMEOUT      60
+#define RETVAL_ECONNREFUSED 61
 
 int done = 0;
 static const char *request_prefix = "GET";

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Felix Weinrank
+ * Copyright (C) 2016-2019 Felix Weinrank
  *
  * All rights reserved.
  *
@@ -99,20 +99,53 @@ int
 main(int argc, char *argv[])
 {
 	struct socket *sock;
+	struct sockaddr *addr;
+	socklen_t addr_len;
 	struct sockaddr_in addr4;
 	struct sockaddr_in6 addr6;
+	struct sockaddr_in bind4;
+	struct sockaddr_in6 bind6;
 	struct sctp_udpencaps encaps;
 	struct sctp_sndinfo sndinfo;
 	struct sctp_rtoinfo rtoinfo;
 	struct sctp_initmsg initmsg;
-	int result;
+	int result = 0;
+	uint8_t address_family = 0;
 
 	if (argc < 3) {
 		printf("Usage: http_client remote_addr remote_port [local_port] [local_encaps_port] [remote_encaps_port] [uri]\n");
 		return(EXIT_FAILURE);
 	}
 
-	result = 0;
+	memset((void *)&addr4, 0, sizeof(struct sockaddr_in));
+	memset((void *)&addr6, 0, sizeof(struct sockaddr_in6));
+
+	if (inet_pton(AF_INET, argv[1], &addr4.sin_addr) == 1) {
+		address_family = AF_INET;
+
+		addr = (struct sockaddr *)&addr4;
+		addr_len = sizeof(addr4);
+#ifdef HAVE_SIN_LEN
+		addr4.sin_len = sizeof(struct sockaddr_in);
+#endif
+		addr4.sin_family = AF_INET;
+		addr4.sin_port = htons(atoi(argv[2]));
+	} else if (inet_pton(AF_INET6, argv[1], &addr6.sin6_addr) == 1) {
+		address_family = AF_INET6;
+
+		addr = (struct sockaddr *)&addr6;
+		addr_len = sizeof(addr6);
+#ifdef HAVE_SIN6_LEN
+		addr6.sin6_len = sizeof(struct sockaddr_in6);
+#endif
+		addr6.sin6_family = AF_INET6;
+		addr6.sin6_port = htons(atoi(argv[2]));
+	} else {
+		printf("Unsupported destination address - use IPv4 or IPv6 address\n");
+		result = 1;
+		goto out;
+	}
+
 	if (argc > 4) {
 		usrsctp_init(atoi(argv[4]), NULL, debug_printf);
 	} else {
@@ -125,9 +158,9 @@ main(int argc, char *argv[])
 
 	usrsctp_sysctl_set_sctp_blackhole(2);
 
-	if ((sock = usrsctp_socket(AF_INET6, SOCK_STREAM, IPPROTO_SCTP, receive_cb, NULL, 0, NULL)) == NULL) {
+	if ((sock = usrsctp_socket(address_family, SOCK_STREAM, IPPROTO_SCTP, receive_cb, NULL, 0, NULL)) == NULL) {
 		perror("usrsctp_socket");
-		result = 1;
+		result = 2;
 		goto out;
 	}
 
@@ -148,34 +181,52 @@ main(int argc, char *argv[])
 	if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_INITMSG, (const void *)&initmsg, (socklen_t)sizeof(struct sctp_initmsg)) < 0) {
 		perror("setsockopt");
 		usrsctp_close(sock);
-		result = 3;
+		result = 4;
 		goto out;
 	}
 
 	if (argc > 3) {
-		memset((void *)&addr6, 0, sizeof(struct sockaddr_in6));
+
+		if (address_family == AF_INET) {
+			memset((void *)&bind4, 0, sizeof(struct sockaddr_in));
 #ifdef HAVE_SIN6_LEN
-		addr6.sin6_len = sizeof(struct sockaddr_in6);
+			bind4.sin_len = sizeof(struct sockaddr_in6);
 #endif
-		addr6.sin6_family = AF_INET6;
-		addr6.sin6_port = htons(atoi(argv[3]));
-		addr6.sin6_addr = in6addr_any;
-		if (usrsctp_bind(sock, (struct sockaddr *)&addr6, sizeof(struct sockaddr_in6)) < 0) {
-			perror("bind");
-			usrsctp_close(sock);
-			result = 2;
-			goto out;
+			bind4.sin_family = AF_INET;
+			bind4.sin_port = htons(atoi(argv[3]));
+			bind4.sin_addr.s_addr = htonl(INADDR_ANY);
+
+			if (usrsctp_bind(sock, (struct sockaddr *)&bind4, sizeof(bind4)) < 0) {
+				perror("bind");
+				usrsctp_close(sock);
+				result = 5;
+				goto out;
+			}
+		} else {
+			memset((void *)&bind6, 0, sizeof(struct sockaddr_in6));
+#ifdef HAVE_SIN6_LEN
+			bind6.sin6_len = sizeof(struct sockaddr_in6);
+#endif
+			bind6.sin6_family = AF_INET6;
+			bind6.sin6_port = htons(atoi(argv[3]));
+			bind6.sin6_addr = in6addr_any;
+			if (usrsctp_bind(sock, (struct sockaddr *)&bind6, sizeof(bind6)) < 0) {
+				perror("bind");
+				usrsctp_close(sock);
+				result = 6;
+				goto out;
+			}
 		}
 	}
 
 	if (argc > 5) {
 		memset(&encaps, 0, sizeof(struct sctp_udpencaps));
-		encaps.sue_address.ss_family = AF_INET6;
+		encaps.sue_address.ss_family = address_family;
 		encaps.sue_port = htons(atoi(argv[5]));
 		if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_REMOTE_UDP_ENCAPS_PORT, (const void *)&encaps, (socklen_t)sizeof(struct sctp_udpencaps)) < 0) {
 			perror("setsockopt");
 			usrsctp_close(sock);
-			result = 3;
+			result = 7;
 			goto out;
 		}
 	}
@@ -197,38 +248,20 @@ main(int argc, char *argv[])
 	printf("\nHTTP request:\n%s\n", request);
 	printf("\nHTTP response:\n");
 
-	memset((void *)&addr4, 0, sizeof(struct sockaddr_in));
-	memset((void *)&addr6, 0, sizeof(struct sockaddr_in6));
-#ifdef HAVE_SIN_LEN
-	addr4.sin_len = sizeof(struct sockaddr_in);
-#endif
-#ifdef HAVE_SIN6_LEN
-	addr6.sin6_len = sizeof(struct sockaddr_in6);
-#endif
-	addr4.sin_family = AF_INET;
-	addr6.sin6_family = AF_INET6;
-	addr4.sin_port = htons(atoi(argv[2]));
-	addr6.sin6_port = htons(atoi(argv[2]));
-	if (inet_pton(AF_INET6, argv[1], &addr6.sin6_addr) == 1) {
-		if (usrsctp_connect(sock, (struct sockaddr *)&addr6, sizeof(struct sockaddr_in6)) < 0) {
-			perror("usrsctp_connect");
-			usrsctp_close(sock);
-			result = 4;
-			goto out;
-		}
-	} else if (inet_pton(AF_INET, argv[1], &addr4.sin_addr) == 1) {
-		if (usrsctp_connect(sock, (struct sockaddr *)&addr4, sizeof(struct sockaddr_in)) < 0) {
-			perror("usrsctp_connect");
-			usrsctp_close(sock);
-			result = 5;
-			goto out;
-		}
-	} else {
-		printf("Illegal destination address\n");
+	if (usrsctp_connect(sock, addr, addr_len) < 0) {
+		perror("usrsctp_connect");
 		usrsctp_close(sock);
-		result = 6;
+
+		if (errno == ECONNREFUSED) {
+			result = 8;
+		} else {
+			result = 9;
+		}
+
 		goto out;
 	}
+
+	// WAS HERE!!!
 
 	memset(&sndinfo, 0, sizeof(struct sctp_sndinfo));
 	sndinfo.snd_ppid = htonl(63); /* PPID for HTTP/SCTP */
@@ -236,7 +269,7 @@ main(int argc, char *argv[])
 	if (usrsctp_sendv(sock, request, strlen(request), NULL, 0, &sndinfo, sizeof(struct sctp_sndinfo), SCTP_SENDV_SNDINFO, 0) < 0) {
 		perror("usrsctp_sendv");
 		usrsctp_close(sock);
-		result = 6;
+		result = 11;
 		goto out;
 	}
 

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -262,9 +262,6 @@ main(int argc, char *argv[])
 			result = RETVAL_CATCHALL;
 		}
 		perror("usrsctp_connect");
-		printf("result %d - errno %d - ECONNREFUSED %d - errror %d\n", result, errno, ECONNREFUSED, errno_safer);
-		fprintf(stderr, "%s\n", strerror(errno));
-
 		usrsctp_close(sock);
 
 		goto out;

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -254,8 +254,6 @@ main(int argc, char *argv[])
 
 	if (usrsctp_connect(sock, addr, addr_len) < 0) {
 		perror("usrsctp_connect");
-		usrsctp_close(sock);
-
 		if (errno == ECONNREFUSED) {
 			result = RETVAL_ECONNREFUSED;
 		} else if (errno == ETIMEDOUT) {
@@ -263,7 +261,7 @@ main(int argc, char *argv[])
 		} else {
 			result = RETVAL_CATCHALL;
 		}
-
+		usrsctp_close(sock);
 		printf("errno = %d\n", errno);
 
 		goto out;

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -264,7 +264,7 @@ main(int argc, char *argv[])
 			result = RETVAL_CATCHALL;
 		}
 
-		printf("result = %d\n", result);
+		printf("errno = %d\n", errno);
 
 		goto out;
 	}

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -115,6 +115,7 @@ main(int argc, char *argv[])
 	struct sctp_initmsg initmsg;
 	int result = 0;
 	uint8_t address_family = 0;
+	int errno_safer;
 
 	if (argc < 3) {
 		printf("Usage: http_client remote_addr remote_port [local_port] [local_encaps_port] [remote_encaps_port] [uri]\n");
@@ -193,7 +194,7 @@ main(int argc, char *argv[])
 
 		if (address_family == AF_INET) {
 			memset((void *)&bind4, 0, sizeof(struct sockaddr_in));
-#ifdef HAVE_SIN6_LEN
+#ifdef HAVE_SIN_LEN
 			bind4.sin_len = sizeof(struct sockaddr_in6);
 #endif
 			bind4.sin_family = AF_INET;
@@ -253,7 +254,7 @@ main(int argc, char *argv[])
 	printf("\nHTTP response:\n");
 
 	if (usrsctp_connect(sock, addr, addr_len) < 0) {
-		int errno_safer = errno;
+		errno_safer = errno;
 		if (errno_safer == ECONNREFUSED) {
 			result = RETVAL_ECONNREFUSED;
 		} else if (errno_safer == ETIMEDOUT) {

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -261,7 +261,8 @@ main(int argc, char *argv[])
 		} else {
 			result = RETVAL_CATCHALL;
 		}
-		printf("result %d - errno %d\n", result, errno);
+		printf("result %d - errno %d - ECONNREFUSED %d\n", result, errno, ECONNREFUSED);
+		fprintf(stderr, "%s\n", strerror(errno));
 
 		usrsctp_close(sock);
 

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -264,6 +264,8 @@ main(int argc, char *argv[])
 			result = RETVAL_CATCHALL;
 		}
 
+		printf("result = %d\n", result);
+
 		goto out;
 	}
 

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -253,17 +253,16 @@ main(int argc, char *argv[])
 	printf("\nHTTP response:\n");
 
 	if (usrsctp_connect(sock, addr, addr_len) < 0) {
-		int errrorr = errno;
-		if (errno == ECONNREFUSED) {
+		int errno_safer = errno;
+		if (errno_safer == ECONNREFUSED) {
 			result = RETVAL_ECONNREFUSED;
-		} else if (errno == ETIMEDOUT) {
+		} else if (errno_safer == ETIMEDOUT) {
 			result = RETVAL_TIMEOUT;
 		} else {
 			result = RETVAL_CATCHALL;
 		}
-
-		printf("result %d - errno %d - ECONNREFUSED %d - errror %d\n", result, errno, ECONNREFUSED, errrorr);
 		perror("usrsctp_connect");
+		printf("result %d - errno %d - ECONNREFUSED %d - errror %d\n", result, errno, ECONNREFUSED, errno_safer);
 		fprintf(stderr, "%s\n", strerror(errno));
 
 		usrsctp_close(sock);

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -292,5 +292,6 @@ out:
 		sleep(1);
 #endif
 	}
+	printf("Finished, returning with %d\n", result);
 	return (result);
 }

--- a/programs/http_client.c
+++ b/programs/http_client.c
@@ -253,7 +253,7 @@ main(int argc, char *argv[])
 	printf("\nHTTP response:\n");
 
 	if (usrsctp_connect(sock, addr, addr_len) < 0) {
-		perror("usrsctp_connect");
+		int errrorr = errno;
 		if (errno == ECONNREFUSED) {
 			result = RETVAL_ECONNREFUSED;
 		} else if (errno == ETIMEDOUT) {
@@ -261,7 +261,9 @@ main(int argc, char *argv[])
 		} else {
 			result = RETVAL_CATCHALL;
 		}
-		printf("result %d - errno %d - ECONNREFUSED %d\n", result, errno, ECONNREFUSED);
+
+		printf("result %d - errno %d - ECONNREFUSED %d - errror %d\n", result, errno, ECONNREFUSED, errrorr);
+		perror("usrsctp_connect");
 		fprintf(stderr, "%s\n", strerror(errno));
 
 		usrsctp_close(sock);

--- a/programs/http_client_upcall.c
+++ b/programs/http_client_upcall.c
@@ -303,8 +303,6 @@ main(int argc, char *argv[])
 	if (usrsctp_connect(sock, addr, addr_len) < 0) {
 		if (errno != EINPROGRESS) {
 			perror("usrsctp_connect");
-			usrsctp_close(sock);
-
 			if (errno == ECONNREFUSED) {
 				result = RETVAL_ECONNREFUSED;
 			} else if (errno == ETIMEDOUT) {
@@ -312,7 +310,7 @@ main(int argc, char *argv[])
 			} else {
 				result = RETVAL_CATCHALL;
 			}
-
+			usrsctp_close(sock);
 			printf("result = %d\n", result);
 			goto out;
 		}

--- a/programs/http_client_upcall.c
+++ b/programs/http_client_upcall.c
@@ -302,15 +302,17 @@ main(int argc, char *argv[])
 
 	if (usrsctp_connect(sock, addr, addr_len) < 0) {
 		if (errno != EINPROGRESS) {
-			perror("usrsctp_connect");
-			if (errno == ECONNREFUSED) {
+			int errno_safer = errno;
+			if (errno_safer == ECONNREFUSED) {
 				result = RETVAL_ECONNREFUSED;
-			} else if (errno == ETIMEDOUT) {
+			} else if (errno_safer == ETIMEDOUT) {
 				result = RETVAL_TIMEOUT;
 			} else {
 				result = RETVAL_CATCHALL;
 			}
-			printf("result %d - errno %d\n", result, errno);
+			perror("usrsctp_connect");
+			printf("result %d - errno %d - ECONNREFUSED %d - errror %d\n", result, errno, ECONNREFUSED, errno_safer);
+			fprintf(stderr, "%s\n", strerror(errno));
 
 			usrsctp_close(sock);
 

--- a/programs/http_client_upcall.c
+++ b/programs/http_client_upcall.c
@@ -332,6 +332,6 @@ out:
 #endif
 	}
 
-	printf("returning: %d\n", result);
+	printf("Finished, returning with %d\n", result);
 	return (result);
 }

--- a/programs/http_client_upcall.c
+++ b/programs/http_client_upcall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Felix Weinrank
+ * Copyright (C) 2016-2019 Felix Weinrank
  *
  * All rights reserved.
  *
@@ -52,6 +52,10 @@
 #endif
 #include <usrsctp.h>
 
+#define RETVAL_CATCHALL     50
+#define RETVAL_ECONNREFUSED 60
+#define RETVAL_TIMEOUT      61
+
 int done = 0;
 int writePending = 1;
 
@@ -64,7 +68,6 @@ typedef char* caddr_t;
 #endif
 
 #define BUFFERSIZE                 (1<<16)
-
 
 static void handle_upcall(struct socket *sock, void *arg, int flgs)
 {
@@ -128,19 +131,53 @@ int
 main(int argc, char *argv[])
 {
 	struct socket *sock;
+	struct sockaddr *addr;
+	socklen_t addr_len;
 	struct sockaddr_in addr4;
 	struct sockaddr_in6 addr6;
+	struct sockaddr_in bind4;
+	struct sockaddr_in6 bind6;
 	struct sctp_udpencaps encaps;
+	struct sctp_sndinfo sndinfo;
 	struct sctp_rtoinfo rtoinfo;
 	struct sctp_initmsg initmsg;
-	int result;
+	int result = 0;
+	uint8_t address_family = 0;
 
 	if (argc < 3) {
 		printf("Usage: http_client_upcall remote_addr remote_port [local_port] [local_encaps_port] [remote_encaps_port] [uri]\n");
 		return(EXIT_FAILURE);
 	}
 
-	result = 0;
+	memset((void *)&addr4, 0, sizeof(struct sockaddr_in));
+	memset((void *)&addr6, 0, sizeof(struct sockaddr_in6));
+
+	if (inet_pton(AF_INET, argv[1], &addr4.sin_addr) == 1) {
+		address_family = AF_INET;
+
+		addr = (struct sockaddr *)&addr4;
+		addr_len = sizeof(addr4);
+#ifdef HAVE_SIN_LEN
+		addr4.sin_len = sizeof(struct sockaddr_in);
+#endif
+		addr4.sin_family = AF_INET;
+		addr4.sin_port = htons(atoi(argv[2]));
+	} else if (inet_pton(AF_INET6, argv[1], &addr6.sin6_addr) == 1) {
+		address_family = AF_INET6;
+
+		addr = (struct sockaddr *)&addr6;
+		addr_len = sizeof(addr6);
+#ifdef HAVE_SIN6_LEN
+		addr6.sin6_len = sizeof(struct sockaddr_in6);
+#endif
+		addr6.sin6_family = AF_INET6;
+		addr6.sin6_port = htons(atoi(argv[2]));
+	} else {
+		printf("Unsupported destination address - use IPv4 or IPv6 address\n");
+		result = RETVAL_CATCHALL;
+		goto out;
+	}
+
 	if (argc > 4) {
 		usrsctp_init(atoi(argv[4]), NULL, debug_printf);
 	} else {
@@ -153,9 +190,9 @@ main(int argc, char *argv[])
 
 	usrsctp_sysctl_set_sctp_blackhole(2);
 
-	if ((sock = usrsctp_socket(AF_INET6, SOCK_STREAM, IPPROTO_SCTP, NULL, NULL, 0, NULL)) == NULL) {
+	if ((sock = usrsctp_socket(address_family, SOCK_STREAM, IPPROTO_SCTP, NULL, NULL, 0, NULL)) == NULL) {
 		perror("usrsctp_socket");
-		result = 1;
+		result = RETVAL_CATCHALL;
 		goto out;
 	}
 
@@ -168,7 +205,7 @@ main(int argc, char *argv[])
 	if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_RTOINFO, (const void *)&rtoinfo, (socklen_t)sizeof(struct sctp_rtoinfo)) < 0) {
 		perror("setsockopt");
 		usrsctp_close(sock);
-		result = 3;
+		result = RETVAL_CATCHALL;
 		goto out;
 	}
 	initmsg.sinit_num_ostreams = 1;
@@ -178,34 +215,52 @@ main(int argc, char *argv[])
 	if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_INITMSG, (const void *)&initmsg, (socklen_t)sizeof(struct sctp_initmsg)) < 0) {
 		perror("setsockopt");
 		usrsctp_close(sock);
-		result = 3;
+		result = RETVAL_CATCHALL;
 		goto out;
 	}
 
 	if (argc > 3) {
-		memset((void *)&addr6, 0, sizeof(struct sockaddr_in6));
+
+		if (address_family == AF_INET) {
+			memset((void *)&bind4, 0, sizeof(struct sockaddr_in));
 #ifdef HAVE_SIN6_LEN
-		addr6.sin6_len = sizeof(struct sockaddr_in6);
+			bind4.sin_len = sizeof(struct sockaddr_in6);
 #endif
-		addr6.sin6_family = AF_INET6;
-		addr6.sin6_port = htons(atoi(argv[3]));
-		addr6.sin6_addr = in6addr_any;
-		if (usrsctp_bind(sock, (struct sockaddr *)&addr6, sizeof(struct sockaddr_in6)) < 0) {
-			perror("bind");
-			usrsctp_close(sock);
-			result = 2;
-			goto out;
+			bind4.sin_family = AF_INET;
+			bind4.sin_port = htons(atoi(argv[3]));
+			bind4.sin_addr.s_addr = htonl(INADDR_ANY);
+
+			if (usrsctp_bind(sock, (struct sockaddr *)&bind4, sizeof(bind4)) < 0) {
+				perror("bind");
+				usrsctp_close(sock);
+				result = RETVAL_CATCHALL;
+				goto out;
+			}
+		} else {
+			memset((void *)&bind6, 0, sizeof(struct sockaddr_in6));
+#ifdef HAVE_SIN6_LEN
+			bind6.sin6_len = sizeof(struct sockaddr_in6);
+#endif
+			bind6.sin6_family = AF_INET6;
+			bind6.sin6_port = htons(atoi(argv[3]));
+			bind6.sin6_addr = in6addr_any;
+			if (usrsctp_bind(sock, (struct sockaddr *)&bind6, sizeof(bind6)) < 0) {
+				perror("bind");
+				usrsctp_close(sock);
+				result = RETVAL_CATCHALL;
+				goto out;
+			}
 		}
 	}
 
 	if (argc > 5) {
 		memset(&encaps, 0, sizeof(struct sctp_udpencaps));
-		encaps.sue_address.ss_family = AF_INET6;
+		encaps.sue_address.ss_family = address_family;
 		encaps.sue_port = htons(atoi(argv[5]));
 		if (usrsctp_setsockopt(sock, IPPROTO_SCTP, SCTP_REMOTE_UDP_ENCAPS_PORT, (const void *)&encaps, (socklen_t)sizeof(struct sctp_udpencaps)) < 0) {
 			perror("setsockopt");
 			usrsctp_close(sock);
-			result = 3;
+			result = RETVAL_CATCHALL;
 			goto out;
 		}
 	}
@@ -224,44 +279,35 @@ main(int argc, char *argv[])
 #endif
 	}
 
+	printf("\nHTTP request:\n%s\n", request);
+	printf("\nHTTP response:\n");
+
 	usrsctp_set_upcall(sock, handle_upcall, NULL);
 
-	memset((void *)&addr4, 0, sizeof(struct sockaddr_in));
-	memset((void *)&addr6, 0, sizeof(struct sockaddr_in6));
-#ifdef HAVE_SIN_LEN
-	addr4.sin_len = sizeof(struct sockaddr_in);
-#endif
-#ifdef HAVE_SIN6_LEN
-	addr6.sin6_len = sizeof(struct sockaddr_in6);
-#endif
-	addr4.sin_family = AF_INET;
-	addr6.sin6_family = AF_INET6;
-	addr4.sin_port = htons(atoi(argv[2]));
-	addr6.sin6_port = htons(atoi(argv[2]));
-	if (inet_pton(AF_INET6, argv[1], &addr6.sin6_addr) == 1) {
-		if (usrsctp_connect(sock, (struct sockaddr *)&addr6, sizeof(struct sockaddr_in6)) < 0) {
-			if (errno != EINPROGRESS) {
-				perror("usrsctp_connect");
-				usrsctp_close(sock);
-				result = 4;
-				goto out;
+	if (usrsctp_connect(sock, addr, addr_len) < 0) {
+		if (errno != EINPROGRESS) {
+			perror("usrsctp_connect");
+			usrsctp_close(sock);
+
+			if (errno == ECONNREFUSED) {
+				result = RETVAL_ECONNREFUSED;
+			} else {
+				result = RETVAL_CATCHALL;
 			}
+			goto out;
 		}
-	} else if (inet_pton(AF_INET, argv[1], &addr4.sin_addr) == 1) {
-		if (usrsctp_connect(sock, (struct sockaddr *)&addr4, sizeof(struct sockaddr_in)) < 0) {
-			if (errno != EINPROGRESS) {
-				perror("usrsctp_connect");
-				usrsctp_close(sock);
-				result = 5;
-				goto out;
-			}
-		}
-	} else {
-		printf("Illegal destination address\n");
+	}
+
+	memset(&sndinfo, 0, sizeof(struct sctp_sndinfo));
+	sndinfo.snd_ppid = htonl(63); /* PPID for HTTP/SCTP */
+	/* send GET request */
+	if (usrsctp_sendv(sock, request, strlen(request), NULL, 0, &sndinfo, sizeof(struct sctp_sndinfo), SCTP_SENDV_SNDINFO, 0) < 0) {
+		perror("usrsctp_sendv");
 		usrsctp_close(sock);
-		result = 6;
+		result = RETVAL_CATCHALL;
 		goto out;
 	}
+
 	while (!done) {
 #ifdef _WIN32
 		Sleep(1*1000);

--- a/programs/http_client_upcall.c
+++ b/programs/http_client_upcall.c
@@ -312,6 +312,8 @@ main(int argc, char *argv[])
 			} else {
 				result = RETVAL_CATCHALL;
 			}
+
+			printf("result = %d\n", result);
 			goto out;
 		}
 	}

--- a/programs/http_client_upcall.c
+++ b/programs/http_client_upcall.c
@@ -310,8 +310,10 @@ main(int argc, char *argv[])
 			} else {
 				result = RETVAL_CATCHALL;
 			}
+			printf("result %d - errno %d\n", result, errno);
+
 			usrsctp_close(sock);
-			printf("result = %d\n", result);
+
 			goto out;
 		}
 	}

--- a/programs/http_client_upcall.c
+++ b/programs/http_client_upcall.c
@@ -92,14 +92,17 @@ static void handle_upcall(struct socket *sock, void *arg, int flgs)
 	                 &infolen, &infotype, &flags);
 
 		if (n < 0) {
-			perror("usrsctp_recvv");
-			if (errno == ECONNREFUSED) {
+			int errno_safer = errno;
+			if (errno_safer == ECONNREFUSED) {
 				result = RETVAL_ECONNREFUSED;
-			} else if (errno == ETIMEDOUT) {
+			} else if (errno_safer == ETIMEDOUT) {
 				result = RETVAL_TIMEOUT;
 			} else {
 				result = RETVAL_CATCHALL;
 			}
+			perror("usrsctp_connect");
+			printf("result %d - errno %d - ECONNREFUSED %d - errror %d\n", result, errno, ECONNREFUSED, errno_safer);
+			fprintf(stderr, "%s\n", strerror(errno));
 		}
 
 		if (n <= 0){

--- a/programs/http_client_upcall.c
+++ b/programs/http_client_upcall.c
@@ -85,8 +85,9 @@ static void handle_upcall(struct socket *sock, void *arg, int flgs)
 		socklen_t len = (socklen_t)sizeof(struct sockaddr_in);
 		unsigned int infotype = 0;
 		socklen_t infolen = sizeof(struct sctp_recvv_rn);
-		memset(&rn, 0, sizeof(struct sctp_recvv_rn));
 		int errno_safer;
+
+		memset(&rn, 0, sizeof(struct sctp_recvv_rn));
 		n = usrsctp_recvv(sock, buf, BUFFERSIZE, (struct sockaddr *) &addr, &len, (void *)&rn,
 	                 &infolen, &infotype, &flags);
 
@@ -238,7 +239,7 @@ main(int argc, char *argv[])
 
 		if (address_family == AF_INET) {
 			memset((void *)&bind4, 0, sizeof(struct sockaddr_in));
-#ifdef HAVE_SIN6_LEN
+#ifdef HAVE_SIN_LEN
 			bind4.sin_len = sizeof(struct sockaddr_in6);
 #endif
 			bind4.sin_family = AF_INET;

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -2136,7 +2136,7 @@ done1:
 
 int usrsctp_connect(struct socket *so, struct sockaddr *name, int namelen)
 {
-	struct sockaddr *sa;
+	struct sockaddr *sa = NULL;
 
 	errno = getsockaddr(&sa, (caddr_t)name, namelen);
 	if (errno)


### PR DESCRIPTION
Improved error handling for the http_client and http_client_upcall examples.
The return codes distinguish between refused connections, timed out connections and other errors.

Also fixes a compiler warning:
```
In file included from /home/buildbot/bs-sctplab/netbsd/build/usrsctplib/netinet/sctp_os_userspace.h:448:0,
                 from /home/buildbot/bs-sctplab/netbsd/build/usrsctplib/netinet/sctp_os.h:74,
                 from /home/buildbot/bs-sctplab/netbsd/build/usrsctplib/user_socket.c:35:
/home/buildbot/bs-sctplab/netbsd/build/usrsctplib/user_socket.c: In function 'usrsctp_connect':
/home/buildbot/bs-sctplab/netbsd/build/usrsctplib/user_malloc.h:191:26: error: 'sa' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 #define FREE(addr, type) free((addr))
                          ^
/home/buildbot/bs-sctplab/netbsd/build/usrsctplib/user_socket.c:2139:19: note: 'sa' was declared here
  struct sockaddr *sa;
                   ^
cc1: all warnings being treated as errors```
