### PR TITLE
sctp_output: fix non-FreeBSD compilation

### DIFF
--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -13868,8 +13868,8 @@ sctp_lower_sosend(struct socket *so,
 		if (flags & MSG_EOF) {
 			sinfo_flags |= SCTP_EOF;
 		}
-	}
 #endif
+	}
 	if (sinfo_flags & SCTP_ADDR_OVER) {
 		if (addr)
 			net = sctp_findnet(stcb, addr);


### PR DESCRIPTION
Fixes an issue introduced in f4166b347188af0de05fa70456042ef8a792cdd7,
the scope must be closed outside of the FreeBSD clause, as it is opened
outside of it.