### PR TITLE
Fix MSVC Meson build

### DIFF
--- a/gen-def.py
+++ b/gen-def.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+#
+# gen-def.py usrsctp.lib
+import re
+import sys
+import subprocess
+from shutil import which
+
+try:
+    lib_file = sys.argv[1]
+except:
+    print('Usage: gen-def.py LIB-FILE')
+    exit(-1)
+
+print('EXPORTS')
+
+if which('dumpbin'):
+    dumpbin_cmd = subprocess.run(['dumpbin', '/linkermember:1', lib_file],
+        stdout=subprocess.PIPE)
+
+    pattern = re.compile('\s*[0-9a-fA-F]+ _?(?P<functionname>usrsctp_[^\s]*)')
+
+    for line in dumpbin_cmd.stdout.decode('utf-8').splitlines():
+        match = pattern.match(line)
+        if match:
+            print(match.group('functionname'))

--- a/meson.build
+++ b/meson.build
@@ -183,11 +183,32 @@ endif
 subdir('usrsctplib')
 
 # Build library
-usrsctp = library('usrsctp', sources,
-    dependencies: dependencies,
-    include_directories: include_dirs,
-    install: true,
-    version: meson.project_version())
+if compiler.get_id() == 'msvc' and get_option('default_library') == 'shared'
+    # Needed by usrsctp_def
+    find_program('dumpbin')
+
+    usrsctp_static = static_library('usrsctp-static', sources,
+        dependencies: dependencies,
+        include_directories: include_dirs)
+
+   usrsctp_def = custom_target('usrsctp.def',
+        command: [find_program('gen-def.py'), '@INPUT@'],
+        input: usrsctp_static,
+        output: 'usrsctp.def',
+        capture: true)
+
+    usrsctp = shared_library('usrsctp',
+        link_whole: usrsctp_static,
+        vs_module_defs: usrsctp_def,
+        install: true,
+        version: meson.project_version())
+else
+    usrsctp = library('usrsctp', sources,
+        dependencies: dependencies,
+        include_directories: include_dirs,
+        install: true,
+        version: meson.project_version())
+endif
 
 # Declare dependency
 usrsctp_dep = declare_dependency(


### PR DESCRIPTION
From the output of "dumpbin /linkermember" run on the static version of usrsctp generate .def file with function names to export from the DLL.