### PR TITLE
Fixed spelling issues reported by Lintian

### DIFF
--- a/programs/ekr_loop_offload.c
+++ b/programs/ekr_loop_offload.c
@@ -154,7 +154,7 @@ receive_cb(struct socket *sock, union sctp_sockstore addr, void *data,
 	printf("Message %p received on sock = %p.\n", data, (void *)sock);
 	if (data) {
 		if ((flags & MSG_NOTIFICATION) == 0) {
-			printf("Messsage of length %d received via %p:%u on stream %u with SSN %u and TSN %u, PPID %u, context %u, flags %x.\n",
+			printf("Message of length %d received via %p:%u on stream %u with SSN %u and TSN %u, PPID %u, context %u, flags %x.\n",
 			       (int)datalen,
 			       addr.sconn.sconn_addr,
 			       ntohs(addr.sconn.sconn_port),

--- a/programs/ekr_loop_upcall.c
+++ b/programs/ekr_loop_upcall.c
@@ -164,7 +164,7 @@ handle_upcall(struct socket *sock, void *data, int flgs)
 			if (flags & MSG_NOTIFICATION) {
 				printf("Notification of length %d received.\n", (int)n);
 			} else {
-				printf("Messsage of length %d received via %p:%u on stream %u with SSN %u and TSN %u, PPID %u, context %u, flags %x.\n",
+				printf("Message of length %d received via %p:%u on stream %u with SSN %u and TSN %u, PPID %u, context %u, flags %x.\n",
 				       (int)n,
 				       addr.sconn.sconn_addr,
 				       ntohs(addr.sconn.sconn_port),
@@ -522,7 +522,7 @@ main(int argc, char *argv[])
 		perror("usrsctp_accept");
 		exit(EXIT_FAILURE);
 	}
-	
+
 	usrsctp_set_upcall(s_s, handle_upcall, &fd_s);
 
 	usrsctp_close(s_l);

--- a/programs/rtcweb.c
+++ b/programs/rtcweb.c
@@ -1276,7 +1276,7 @@ print_status(struct peer_connection *pc)
 			printf("unreliable (max. %u rtx).\n", channel->pr_value);
 			break;
 		default:
-			printf("unkown policy %u.\n", channel->pr_policy);
+			printf("unknown policy %u.\n", channel->pr_policy);
 			break;
 		}
 	}

--- a/usrsctplib/netinet/sctp_asconf.c
+++ b/usrsctplib/netinet/sctp_asconf.c
@@ -1381,7 +1381,7 @@ sctp_asconf_queue_add(struct sctp_tcb *stcb, struct sctp_ifa *ifa,
 		if (sctp_asconf_queue_mgmt(stcb,
 					   stcb->asoc.asconf_addr_del_pending,
 					   SCTP_DEL_IP_ADDRESS) == 0) {
-			SCTPDBG(SCTP_DEBUG_ASCONF2, "asconf_queue_add: queing pending delete\n");
+			SCTPDBG(SCTP_DEBUG_ASCONF2, "asconf_queue_add: queuing pending delete\n");
 			pending_delete_queued = 1;
 			/* clear out the pending delete info */
 			stcb->asoc.asconf_del_pending = 0;


### PR DESCRIPTION
Some fixes of minor spelling issues reported by Lintian:

I: libusrsctp1: spelling-error-in-binary usr/lib/x86_64-linux-gnu/libusrsctp.so.1.0.0 queing queueing

I: libusrsctp-examples: spelling-error-in-binary usr/bin/ekr_loop_offload Messsage Message

I: libusrsctp-examples: spelling-error-in-binary usr/bin/ekr_loop_upcall Messsage Message

I: libusrsctp-examples: spelling-error-in-binary usr/bin/rtcweb unkown unknown
