### PR TITLE
Reverted change for max length calculation in sctp_output

### DIFF
--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -14108,7 +14108,11 @@ sctp_lower_sosend(struct socket *so,
 	/* Calculate the maximum we can send */
 	inqueue_bytes = stcb->asoc.total_output_queue_size - (stcb->asoc.chunks_on_out_queue * SCTP_DATA_CHUNK_OVERHEAD(stcb));
 	if (SCTP_SB_LIMIT_SND(so) > inqueue_bytes) {
-		max_len = SCTP_SB_LIMIT_SND(so) - inqueue_bytes;
+		if (non_blocking) {
+			max_len = sndlen;
+		} else {
+			max_len = SCTP_SB_LIMIT_SND(so) - inqueue_bytes;
+		}
 	} else {
 		max_len = 0;
 	}


### PR DESCRIPTION
The max_length calculation change introduced in be8e0eb appears to break PeerConnectionEndToEndTest.CreateDataChannelLargeTransfer in WebRTC. This change reverts this portion of the code which appears to be causing the issue.

I do not fully understand why this change fixes the issue from the usrsctp side and since the initial fix that introduced this issue was put in place to address an issue found by a fuzzer I think it is important we understand the root cause before submitting it.

This is to address issue #345 