### PR TITLE
Build fix for compilers without "-Wno-deprecated-declarations" option

### DIFF
--- a/usrsctplib/CMakeLists.txt
+++ b/usrsctplib/CMakeLists.txt
@@ -59,13 +59,12 @@ endif ()
 
 if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
 	add_definitions(-U__FreeBSD__)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-address-of-packed-member")
 endif ()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
 	add_definitions(-U__APPLE__)
 	add_definitions(-D__APPLE_USE_RFC_2292)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-address-of-packed-member -Wno-deprecated-declarations")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
 endif ()
 
 if (CMAKE_SYSTEM_NAME MATCHES "DragonFly")


### PR DESCRIPTION
Build fix: flags are already detected and set in ../CMakeLists.txt => build failed here if compiler does not support them.
