### PR TITLE
WIP: Problem: Cannot forward user data to the send callback.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ callgrind.out*
 
 # cmake build
 /build
+
+# ctags
+tags

--- a/usrsctplib/netinet/sctp_input.c
+++ b/usrsctplib/netinet/sctp_input.c
@@ -3037,6 +3037,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 #if defined(__Userspace__)
 			inp->ulp_info = (*inp_p)->ulp_info;
 			inp->recv_callback = (*inp_p)->recv_callback;
+			inp->recv_callback2 = (*inp_p)->recv_callback2;
 			inp->send_callback = (*inp_p)->send_callback;
 			inp->send_callback2 = (*inp_p)->send_callback2;
 			inp->send_sb_threshold = (*inp_p)->send_sb_threshold;

--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -2844,6 +2844,7 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 	inp->ulp_info = NULL;
 	inp->recv_callback = NULL;
 	inp->send_callback = NULL;
+	inp->send_callback2 = NULL;
 	inp->send_sb_threshold = 0;
 #endif
 	/* init the small hash table we use to track asocid <-> tcb */

--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -2843,6 +2843,7 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 #if defined(__Userspace__)
 	inp->ulp_info = NULL;
 	inp->recv_callback = NULL;
+	inp->recv_callback2 = NULL;
 	inp->send_callback = NULL;
 	inp->send_callback2 = NULL;
 	inp->send_sb_threshold = 0;

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -600,7 +600,8 @@ struct sctp_inpcb {
                              struct sctp_rcvinfo, int, void *);
 	uint32_t send_sb_threshold;
 	int (*send_callback)(struct socket *, uint32_t);
-	int (*send_callback2)(struct socket *, uint32_t, void *);
+	void (*recv_callback2)(struct socket *, uint32_t, void *);
+	void (*send_callback2)(struct socket *, uint32_t, void *);
 #endif
 };
 
@@ -609,7 +610,8 @@ int register_recv_cb (struct socket *,
                       int (*)(struct socket *, union sctp_sockstore, void *, size_t,
                               struct sctp_rcvinfo, int, void *));
 int register_send_cb (struct socket *, uint32_t, int (*)(struct socket *, uint32_t));
-int register_send_cb2 (struct socket *, uint32_t, int (*)(struct socket *, uint32_t, void *));
+int register_recv_callback2 (struct socket *, void (*)(struct socket *, uint32_t, void *));
+int register_send_callback2 (struct socket *, void (*)(struct socket *, uint32_t, void *));
 int register_ulp_info (struct socket *, void *);
 
 #endif

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -600,6 +600,7 @@ struct sctp_inpcb {
                              struct sctp_rcvinfo, int, void *);
 	uint32_t send_sb_threshold;
 	int (*send_callback)(struct socket *, uint32_t);
+	int (*send_callback2)(struct socket *, uint32_t, void *);
 #endif
 };
 
@@ -608,6 +609,7 @@ int register_recv_cb (struct socket *,
                       int (*)(struct socket *, union sctp_sockstore, void *, size_t,
                               struct sctp_rcvinfo, int, void *));
 int register_send_cb (struct socket *, uint32_t, int (*)(struct socket *, uint32_t));
+int register_send_cb2 (struct socket *, uint32_t, int (*)(struct socket *, uint32_t, void *));
 int register_ulp_info (struct socket *, void *);
 
 #endif

--- a/usrsctplib/netinet/sctp_peeloff.c
+++ b/usrsctplib/netinet/sctp_peeloff.c
@@ -154,6 +154,7 @@ sctp_do_peeloff(struct socket *head, struct socket *so, sctp_assoc_t assoc_id)
 	n_inp->ulp_info = inp->ulp_info;
 	n_inp->recv_callback = inp->recv_callback;
 	n_inp->send_callback = inp->send_callback;
+	n_inp->send_callback2 = inp->send_callback2;
 	n_inp->send_sb_threshold = inp->send_sb_threshold;
 #endif
 	/*
@@ -259,6 +260,7 @@ sctp_get_peeloff(struct socket *head, sctp_assoc_t assoc_id, int *error)
 	n_inp->ulp_info = inp->ulp_info;
 	n_inp->recv_callback = inp->recv_callback;
 	n_inp->send_callback = inp->send_callback;
+	n_inp->send_callback2 = inp->send_callback2;
 	n_inp->send_sb_threshold = inp->send_sb_threshold;
 #endif
 

--- a/usrsctplib/netinet/sctp_peeloff.c
+++ b/usrsctplib/netinet/sctp_peeloff.c
@@ -153,6 +153,7 @@ sctp_do_peeloff(struct socket *head, struct socket *so, sctp_assoc_t assoc_id)
 #if defined(__Userspace__)
 	n_inp->ulp_info = inp->ulp_info;
 	n_inp->recv_callback = inp->recv_callback;
+	n_inp->recv_callback2 = inp->recv_callback2;
 	n_inp->send_callback = inp->send_callback;
 	n_inp->send_callback2 = inp->send_callback2;
 	n_inp->send_sb_threshold = inp->send_sb_threshold;

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -9060,7 +9060,28 @@ register_send_cb(struct socket *so, uint32_t sb_threshold, int (*send_cb)(struct
 }
 
 int
-register_ulp_info (struct socket *so, void *ulp_info)
+register_send_cb2(struct socket *so, uint32_t sb_threshold, int (*send_cb2)(struct socket *sock, uint32_t sb_free, void *ulp_info))
+{
+	struct sctp_inpcb *inp;
+
+	inp = (struct sctp_inpcb *) so->so_pcb;
+	if (inp == NULL) {
+		return (0);
+	}
+	SCTP_INP_WLOCK(inp);
+	inp->send_callback2 = send_cb2;
+	inp->send_sb_threshold = sb_threshold;
+	SCTP_INP_WUNLOCK(inp);
+	/* FIXME change to current amount free. This will be the full buffer
+	 * the first time this is registered but it could be only a portion
+	 * of the send buffer if this is called a second time e.g. if the
+	 * threshold changes.
+	 */
+	return (1);
+}
+
+int
+register_ulp_info(struct socket *so, void *ulp_info)
 {
 	struct sctp_inpcb *inp;
 

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -9023,8 +9023,9 @@ sctp_usrreq(so, req, m, nam, control)
 #if defined(__Userspace__)
 int
 register_recv_cb(struct socket *so,
-                 int (*receive_cb)(struct socket *sock, union sctp_sockstore addr, void *data,
-                 size_t datalen, struct sctp_rcvinfo, int flags, void *ulp_info))
+                 int (*receive_cb)(struct socket *sock, union sctp_sockstore addr,
+                 void *data, size_t datalen, struct sctp_rcvinfo, int flags,
+                 void *ulp_info))
 {
 	struct sctp_inpcb *inp;
 
@@ -9039,7 +9040,8 @@ register_recv_cb(struct socket *so,
 }
 
 int
-register_send_cb(struct socket *so, uint32_t sb_threshold, int (*send_cb)(struct socket *sock, uint32_t sb_free))
+register_send_cb(struct socket *so, uint32_t sb_threshold,
+                 int (*send_cb)(struct socket *sock, uint32_t sb_free))
 {
 	struct sctp_inpcb *inp;
 
@@ -9060,7 +9062,8 @@ register_send_cb(struct socket *so, uint32_t sb_threshold, int (*send_cb)(struct
 }
 
 int
-register_send_cb2(struct socket *so, uint32_t sb_threshold, int (*send_cb2)(struct socket *sock, uint32_t sb_free, void *ulp_info))
+register_recv_callback2(struct socket *so,
+                        void (*recv_callback2)(struct socket *, uint32_t, void *))
 {
 	struct sctp_inpcb *inp;
 
@@ -9069,14 +9072,25 @@ register_send_cb2(struct socket *so, uint32_t sb_threshold, int (*send_cb2)(stru
 		return (0);
 	}
 	SCTP_INP_WLOCK(inp);
-	inp->send_callback2 = send_cb2;
-	inp->send_sb_threshold = sb_threshold;
+	inp->recv_callback2 = recv_callback2;
 	SCTP_INP_WUNLOCK(inp);
-	/* FIXME change to current amount free. This will be the full buffer
-	 * the first time this is registered but it could be only a portion
-	 * of the send buffer if this is called a second time e.g. if the
-	 * threshold changes.
-	 */
+	return (1);
+}
+
+
+int
+register_send_callback2(struct socket *so,
+                        void (*send_callback2)(struct socket *, uint32_t, void *))
+{
+	struct sctp_inpcb *inp;
+
+	inp = (struct sctp_inpcb *) so->so_pcb;
+	if (inp == NULL) {
+		return (0);
+	}
+	SCTP_INP_WLOCK(inp);
+	inp->send_callback2 = send_callback2;
+	SCTP_INP_WUNLOCK(inp);
 	return (1);
 }
 

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -907,6 +907,14 @@ usrsctp_socket(int domain, int type, int protocol,
                uint32_t sb_threshold,
                void *ulp_info);
 
+struct socket *
+usrsctp_socket2(int domain, int type, int protocol,
+               int (*receive_cb)(struct socket *sock, union sctp_sockstore addr, void *data,
+                                 size_t datalen, struct sctp_rcvinfo, int flags, void *ulp_info),
+               int (*send_cb2)(struct socket *sock, uint32_t sb_free, void *ulp_info),
+               uint32_t sb_threshold,
+               void *ulp_info);
+
 int
 usrsctp_setsockopt(struct socket *so,
                    int level,


### PR DESCRIPTION
~~Solution: Add `usrsctp_socket2` function which adds a send_callback2 which accepts the ulp_info. Add `usrsctp_set_assoc_sb_threshold` which allows configuration of the `sb_threshold` on a association basis, as opposed to a global sb_threshold.~~

~~The new signature would be:~~
```c
usrsctp_socket2(int domain, int type, int protocol,
               int (*receive_cb)(struct socket *sock, union sctp_sockstore addr, void *data, size_t datalen, struct sctp_rcvinfo, int flags, void *ulp_info),
               int (*send_cb)(struct socket *sock, uint32_t sb_free, sctp_assoc_t assoc_id, void *ulp_info),
               void *ulp_info);
```

~~This change should be backward compatible. Also, I couldn't think of a better name for the function.~~

This closes #366.

Edit: Outdated: See https://github.com/sctplab/usrsctp/pull/367#issuecomment-532907638