### PR TITLE
Problem: Unable to modify sb_threshold at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ callgrind.out*
 
 # cmake build
 /build
+
+# ctags
+tags

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -609,6 +609,7 @@ int register_recv_cb (struct socket *,
                               struct sctp_rcvinfo, int, void *));
 int register_send_cb (struct socket *, uint32_t, int (*)(struct socket *, uint32_t));
 int register_ulp_info (struct socket *, void *);
+int register_sb_threshold(struct socket *, uint32_t);
 
 #endif
 struct sctp_tcb {

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -9073,4 +9073,19 @@ register_ulp_info (struct socket *so, void *ulp_info)
 	SCTP_INP_WUNLOCK(inp);
 	return (1);
 }
+
+int
+register_sb_threshold(struct socket *so, uint32_t sb_threshold)
+{
+	struct sctp_inpcb *inp;
+
+	inp = (struct sctp_inpcb *) so->so_pcb;
+	if (inp == NULL) {
+		return (0);
+	}
+	SCTP_INP_WLOCK(inp);
+	inp->send_sb_threshold = sb_threshold;
+	SCTP_INP_WUNLOCK(inp);
+	return (1);
+}
 #endif

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -2585,6 +2585,12 @@ usrsctp_set_ulpinfo(struct socket *so, void *ulp_info)
 }
 
 int
+usrsctp_set_sb_threshold(struct socket *so, uint32_t sb_threshold)
+{
+    return (register_sb_threshold(so, sb_threshold));
+}
+
+int
 usrsctp_bindx(struct socket *so, struct sockaddr *addrs, int addrcnt, int flags)
 {
 	struct sctp_getaddresses *gaddrs;

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -1033,6 +1033,9 @@ int
 usrsctp_set_ulpinfo(struct socket *, void *);
 
 int
+usrsctp_set_sb_threshold(struct socket *, uint32_t);
+
+int
 usrsctp_set_upcall(struct socket *so,
                    void (*upcall)(struct socket *, void *, int),
                    void *arg);


### PR DESCRIPTION
Solution: Add usrsctp_set_sb_threshold function.

Closes #368.