### PR TITLE
Enable easier fuzzing of authenticated chunks

### DIFF
--- a/usrsctplib/netinet/sctp_auth.c
+++ b/usrsctplib/netinet/sctp_auth.c
@@ -1730,6 +1730,7 @@ sctp_handle_auth(struct sctp_tcb *stcb, struct sctp_auth_chunk *auth,
 	(void)sctp_compute_hmac_m(hmac_id, stcb->asoc.authinfo.recv_key,
 	    m, offset, computed_digest);
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 	/* compare the computed digest with the one in the AUTH chunk */
 	if (timingsafe_bcmp(digest, computed_digest, digestlen) != 0) {
 		SCTP_STAT_INCR(sctps_recvauthfailed);
@@ -1737,6 +1738,7 @@ sctp_handle_auth(struct sctp_tcb *stcb, struct sctp_auth_chunk *auth,
 			"SCTP Auth: HMAC digest check failed\n");
 		return (-1);
 	}
+#endif
 	return (0);
 }
 

--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -9537,6 +9537,9 @@ sctp_send_cookie_echo(struct mbuf *m,
 		}
 		ptype = ntohs(phdr->param_type);
 		plen = ntohs(phdr->param_length);
+		if (plen == 0) {
+			return (-3);
+		}
 		if (ptype == SCTP_STATE_COOKIE) {
 			int pad;
 

--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -9537,9 +9537,6 @@ sctp_send_cookie_echo(struct mbuf *m,
 		}
 		ptype = ntohs(phdr->param_type);
 		plen = ntohs(phdr->param_length);
-		if (plen == 0) {
-			return (-3);
-		}
 		if (ptype == SCTP_STATE_COOKIE) {
 			int pad;
 


### PR DESCRIPTION
This change is similar to the ones made by @weinrank to enable fuzzing.
Has no effect on normal builds.