### PR TITLE
Rename delta to elapsed_ticks.

### DIFF
--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -218,7 +218,7 @@ sctp_os_timer_stop(sctp_os_timer_t *c)
 }
 
 void
-sctp_handle_tick(int delta)
+sctp_handle_tick(int elapsed_ticks)
 {
 	sctp_os_timer_t *c;
 	void (*c_func)(void *);
@@ -227,7 +227,7 @@ sctp_handle_tick(int delta)
 
 	SCTP_TIMERQ_LOCK();
 	/* update our tick count */
-	ticks += delta;
+	ticks += elapsed_ticks;
 	c = TAILQ_FIRST(&SCTP_BASE_INFO(callqueue));
 	while (c) {
 		if (c->c_time <= ticks) {

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -103,7 +103,7 @@ typedef struct sctp_callout sctp_os_timer_t;
 void sctp_os_timer_init(sctp_os_timer_t *tmr);
 void sctp_os_timer_start(sctp_os_timer_t *, int, void (*)(void *), void *);
 int sctp_os_timer_stop(sctp_os_timer_t *);
-void sctp_handle_tick(int elapsed_ticks);
+void sctp_handle_tick(int);
 
 #define SCTP_OS_TIMER_INIT	sctp_os_timer_init
 #define SCTP_OS_TIMER_START	sctp_os_timer_start

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -103,7 +103,7 @@ typedef struct sctp_callout sctp_os_timer_t;
 void sctp_os_timer_init(sctp_os_timer_t *tmr);
 void sctp_os_timer_start(sctp_os_timer_t *, int, void (*)(void *), void *);
 int sctp_os_timer_stop(sctp_os_timer_t *);
-void sctp_handle_tick(int delta);
+void sctp_handle_tick(int elapsed_ticks);
 
 #define SCTP_OS_TIMER_INIT	sctp_os_timer_init
 #define SCTP_OS_TIMER_START	sctp_os_timer_start


### PR DESCRIPTION
I've started investigation of possible fix to #131 myself. 
To understand how to fix an issue I've started to familiarize myself with timer implementation from  [`sctp_callout.c`](https://github.com/sctplab/usrsctp/blob/256ce79d3122ce92d73edb2d46f8eb6da664aa69/usrsctplib/netinet/sctp_callout.c), where changes suspected to introduce bug #131. During learning I've noticed some enhancements (in my opinion) can be done to the timer implementation. So this PR is very tiny and my first PR to this repository with small enhancement to a source code for better readability, just to get acquainted with contribution process to this repo.