### PR TITLE
#325: SCTP timer deadlock fix

### DIFF
--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -105,6 +105,7 @@ list(APPEND check_programs
 	test_timer.c
 	tsctp.c
 	tsctp_upcall.c
+	callout_queue_tests.c
 )
 
 foreach (source_file ${check_programs})

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -44,15 +44,6 @@ include(CheckIncludeFile)
 include_directories(${CMAKE_SOURCE_DIR}/usrsctplib)
 
 #################################################
-# INCLUDE MODULES AND SETTINGS
-#################################################
-add_definitions(-D__Userspace__)
-add_definitions(-D__Userspace_os_${CMAKE_SYSTEM_NAME})
-add_definitions(-DSCTP_SIMPLE_ALLOCATOR)
-add_definitions(-DSCTP_PROCESS_LEVEL_LOCKS)
-
-
-#################################################
 # OS DEPENDENT
 #################################################
 

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -43,6 +43,7 @@ include(CheckIncludeFile)
 
 include_directories(${CMAKE_SOURCE_DIR}/usrsctplib)
 
+
 #################################################
 # OS DEPENDENT
 #################################################

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -43,6 +43,14 @@ include(CheckIncludeFile)
 
 include_directories(${CMAKE_SOURCE_DIR}/usrsctplib)
 
+#################################################
+# INCLUDE MODULES AND SETTINGS
+#################################################
+add_definitions(-D__Userspace__)
+add_definitions(-D__Userspace_os_${CMAKE_SYSTEM_NAME})
+add_definitions(-DSCTP_SIMPLE_ALLOCATOR)
+add_definitions(-DSCTP_PROCESS_LEVEL_LOCKS)
+
 
 #################################################
 # OS DEPENDENT

--- a/programs/callout_queue_tests.c
+++ b/programs/callout_queue_tests.c
@@ -1,0 +1,590 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2019, by https://github.com/sctplab. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * a) Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * b) Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *
+ * c) Neither the name of Cisco Systems, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "netinet/sctp_callout_queue.h"
+#include "netinet/sctp_callout.h"
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <stdlib.h>
+
+typedef struct item
+{
+	struct sctp_binary_heap_node heap_node;
+	int32_t priority;
+} item_t;
+
+int item_comparer(void* x, void* y)
+{
+	struct item* X = (struct item*)x;
+	struct item* Y = (struct item*)y;
+	return X->priority - Y->priority;
+}
+
+int always_equal_comparer(void *x, void *y)
+{
+	return 0;
+}
+
+
+void test_sctp_binary_heap_node_traverse_path(void)
+{
+	/*
+	 * heap keyed by node index
+	 * 0             0
+	 *             /   \
+	 *            /     \
+	 *           /       \
+	 * 1        1         2
+	 *        /   \     /   \
+	 * 2     3     4   5     6
+	 *      / \   /
+	 * 3   7   8 9
+	 */
+	struct test_case
+	{
+		size_t index;
+		size_t expected_path;
+		uint8_t expected_depth;
+	} test_cases[] = {
+		{0, 0/* - */, 0},
+		{1, 0/* 0 */, 1},
+		{2, 1/* 1 */, 1},
+		{3, 0/* 0 0 */, 2},
+		{4, 2/* 1 0 */, 2},
+		{5, 1/* 0 1 */, 2},
+		{6, 3/* 1 1 */, 2},
+		{7, 0/* 0 0 0 */, 3},
+		{8, 4/* 1 0 0 */, 3},
+		{9, 2/* 0 1 0 */, 3},
+	};
+
+	for (uint32_t i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++)
+	{
+		struct test_case tc = test_cases[i];
+		size_t computed_path;
+		uint8_t computed_depth;
+		
+		sctp_binary_heap_node_get_traverse_path_from_index(
+			tc.index, &computed_path, &computed_depth);
+		if (computed_depth != tc.expected_depth)
+		{
+			printf("%s test FAILED: Traverse path depth for index %zu expected to be %hhu, but was computed to %hhu\n",
+				__func__, tc.index, tc.expected_depth, computed_depth);
+			return;
+		}
+
+
+		if (computed_path != tc.expected_path)
+		{
+			printf("%s test FAILED: Traverse path for index %zu expected to be %zu, but was computed to %zu\n",
+				__func__, tc.index, tc.expected_path, computed_path);
+			return;
+		}
+	}
+	printf("%s test PASSED\n", __func__);
+}
+
+
+void test_sctp_binary_heap_get_node_by_index_simple(void)
+{
+	struct sctp_binary_heap heap;
+	sctp_binary_heap_init(&heap, item_comparer);
+
+	struct item root;
+	sctp_binary_heap_node_init(&root.heap_node, &root);
+
+	struct item left;
+	sctp_binary_heap_node_init(&left.heap_node, &left);
+
+	struct item right;
+	sctp_binary_heap_node_init(&right.heap_node, &right);
+
+	// manual heap construction
+	heap.root = &root.heap_node;
+	root.heap_node.parent = NULL;
+
+	root.heap_node.left = &left.heap_node;
+	left.heap_node.parent = &root.heap_node;
+
+	root.heap_node.right = &right.heap_node;
+	right.heap_node.parent = &root.heap_node;
+	heap.size = 3;
+	sctp_binary_heap_verify(&heap);
+	
+	sctp_binary_heap_node_t* parent, **node;
+	sctp_binary_heap_get_node_by_index(&heap, 0, &parent, &node);
+
+	if (parent != NULL || *node != &root.heap_node)
+	{
+		printf("%s test FAILED: Wrong node by index 0\n", __func__);
+		return;
+	}
+
+	sctp_binary_heap_get_node_by_index(&heap, 1, &parent, &node);
+	if (parent != &root.heap_node || *node != &left.heap_node)
+	{
+		printf("%s test FAILED: Wrong node by index 1\n", __func__);
+		return;
+	}
+
+	sctp_binary_heap_get_node_by_index(&heap, 2, &parent, &node);
+	if (parent != &root.heap_node || *node != &right.heap_node)
+	{
+		printf("%s test FAILED: Wrong node by index 2\n", __func__);
+		return;
+	}
+
+	// Check position of next to add node can be obtained.
+	sctp_binary_heap_get_node_by_index(&heap, 3, &parent, &node);
+	if (parent != &left.heap_node || node != &left.heap_node.left|| *node != NULL)
+	{
+		printf("%s test FAILED: Wrong node by index 3\n", __func__);
+		return;
+	}
+	printf("%s test PASSED\n", __func__);
+}
+
+
+void test_sctp_binary_heap_get_node_by_index(void)
+{
+	const size_t items_count = 128;
+	item_t* items = (item_t*)malloc(items_count * sizeof(item_t));
+	if (items == NULL)
+	{
+		printf("%s test FAILED: failed to allocate memory\n", __func__);
+		return;
+	}
+
+	sctp_binary_heap_t heap;
+	sctp_binary_heap_init(&heap, item_comparer);
+
+	for (size_t i = 0; i < items_count; i++)
+	{
+		sctp_binary_heap_node_init(&items[i].heap_node, &items[i]);
+		items[i].priority = (int)i; // write node index as priority
+		sctp_binary_heap_push(&heap, &items[i].heap_node);
+	}
+
+	for (size_t i = 0; i < items_count; i++)
+	{
+		sctp_binary_heap_node_t* parent, **node;
+		sctp_binary_heap_get_node_by_index(&heap, i, &parent, &node);
+		if (node == NULL || *node == NULL)
+		{
+			printf("%s test FAILED: unable to get heap node by index %zu\n", __func__, i);
+			goto free_items;
+		}
+		const size_t node_index = ((item_t*)(*node)->data)->priority;
+		if (node_index != i)
+		{
+			printf("%s test FAILED: got wrong node by index %zu, obtained node has index %zu\n",
+				__func__, i, node_index);
+			goto free_items;
+		}
+		if ((*node)->parent != parent)
+		{
+			printf("%s test FAILED: (*node)->parent does not match to parent at index %zu\n", __func__, i);
+			goto free_items;
+		}
+	}
+
+	printf("%s test PASSED\n", __func__);
+
+free_items:
+	if (items != NULL)
+	{
+		free(items);
+		items = NULL;
+	}
+}
+
+
+void test_sctp_binary_heap_push_simple(void)
+{
+	struct sctp_binary_heap heap;
+	sctp_binary_heap_init(&heap, item_comparer);
+
+	struct item item1;
+	item1.priority = 20;
+	sctp_binary_heap_node_init(&item1.heap_node, &item1);
+
+	struct item item2;
+	item2.priority = 10;
+	sctp_binary_heap_node_init(&item2.heap_node, &item2);
+
+	struct item item3;
+	item3.priority = 5;
+	sctp_binary_heap_node_init(&item3.heap_node, &item3);
+
+	sctp_binary_heap_push(&heap, &item1.heap_node);
+	if (sctp_binary_heap_size(&heap) != 1)
+	{
+		printf("%s test FAILED: Heap size must be 1 after insert\n", __func__);
+		return;
+	}
+	if (heap.root != &item1.heap_node)
+	{
+		printf("%s test FAILED: Item 1 with priority %"PRId32" must be at heap root after insert\n", 
+			__func__, item1.priority);
+		return;
+	}
+	
+	sctp_binary_heap_push(&heap, &item2.heap_node);
+	if (sctp_binary_heap_size(&heap) != 2)
+	{
+		printf("%s test FAILED: Heap size must be 2 after insert\n", __func__);
+		return;
+	}
+	if (heap.root != &item2.heap_node)
+	{
+		printf("%s test FAILED: Item 2 with priority %"PRId32" must be at heap root after insert\n",
+			__func__, item2.priority);
+		return;
+	}
+
+	sctp_binary_heap_push(&heap, &item3.heap_node);
+	if (sctp_binary_heap_size(&heap) != 3)
+	{
+		printf("%s test FAILED: Heap size must be 3 after insert\n", __func__);
+		return;
+	}
+	if (heap.root != &item3.heap_node)
+	{
+		printf("%s test FAILED: Item 3 with priority %"PRId32" must be at heap root after insert\n",
+			__func__, item3.priority);
+		return;
+	}
+
+	printf("%s test PASSED\n", __func__);
+}
+
+
+void test_sctp_binary_heap_push_pop_sequential_items(void)
+{
+	const size_t items_count = 1024 * 1024;
+	item_t* items = (item_t*)malloc(items_count * sizeof(item_t));
+	if (items == NULL)
+	{
+		printf("%s test FAILED: failed to allocate memory for items\n", __func__);
+		return;
+	}
+
+	sctp_binary_heap_t heap;
+	sctp_binary_heap_init(&heap, item_comparer);
+
+	for (size_t i = 0; i < items_count; i++)
+	{
+		items[i].priority = (int32_t)(items_count - 1 - i);
+		sctp_binary_heap_node_init(&items[i].heap_node, &items[i]);
+		sctp_binary_heap_push(&heap, &items[i].heap_node);
+		if (sctp_binary_heap_size(&heap) != i + 1)
+		{
+			printf("%s test FAILED: heap size expected to be %zu\n",
+				__func__, i + 1);
+			goto free_items;
+		}
+	}
+
+	sctp_binary_heap_node_t *node;
+	size_t index = 0;
+	while (0 == sctp_binary_heap_pop(&heap, &node))
+	{
+		const size_t item_priority = ((item_t*)node->data)->priority;
+		if (item_priority != index)
+		{
+			printf("%s test FAILED: expected to extract item with priority %zu but extracted with priority %zu\n",
+				__func__, index, item_priority);
+		}
+
+		index++;
+
+		if (sctp_binary_heap_size(&heap) != items_count - index)
+		{
+			printf("%s test FAILED: heap size expected to be %zu\n",
+				__func__, index);
+			goto free_items;
+		}
+	}
+	if (sctp_binary_heap_size(&heap) != 0)
+	{
+		printf("%s test FAILED: heap size expected to be 0\n",
+			__func__);
+		goto free_items;
+	}
+	
+	printf("%s test PASSED\n", __func__);
+
+free_items:
+	if (items != NULL)
+	{
+		free(items);
+		items = NULL;
+	}
+}
+
+
+void test_sctp_binary_heap_push_pop_random_items(void)
+{
+	const size_t items_count = 1024 * 1024;
+	item_t *items = (item_t*) malloc(items_count * sizeof(item_t));
+	if (items == NULL)
+	{
+		printf("%s test FAILED: failed to allocate memory for items\n",
+			__func__);
+		return;
+	}
+
+	sctp_binary_heap_t heap;
+	sctp_binary_heap_init(&heap, item_comparer);
+
+	for (size_t i = 0; i < items_count; i++)
+	{
+		items[i].priority = (int32_t)rand() % items_count;
+		sctp_binary_heap_node_init(&items[i].heap_node, &items[i]);
+		sctp_binary_heap_push(&heap, &items[i].heap_node);
+		if (sctp_binary_heap_size(&heap) != i + 1)
+		{
+			printf("%s test FAILED: heap size expected to be %zu\n",
+				__func__, i + 1);
+			goto free_items;
+		}
+	}
+	sctp_binary_heap_verify(&heap);
+
+	int32_t root_priority = INT32_MIN;
+	sctp_binary_heap_node_t * top;
+	while(0 == sctp_binary_heap_pop(&heap, &top))
+	{
+		const int32_t next_priority = ((item_t*)top->data)->priority;
+		if (root_priority > next_priority)
+		{
+			printf("%s test FAILED: Priority %"PRId32" of popped item is less than previously popped %"PRId32" \n",
+				__func__, next_priority, root_priority);
+			goto free_items;
+		}
+		root_priority = next_priority;
+	}
+
+	if (sctp_binary_heap_size(&heap) != 0)
+	{
+		printf("%s test FAILED: heap size expected to be 0\n",
+			__func__);
+		goto free_items;
+	}
+	printf("%s test PASSED\n", __func__);
+
+free_items:
+	if (items != NULL)
+	{
+		free(items);
+		items = NULL;
+	}
+}
+
+
+void test_sctp_binary_heap_push_interleaved_with_pop_random_items(void)
+{
+	const size_t items_count = 1024 * 1024;
+	item_t* items = (item_t*)malloc(items_count * sizeof(item_t));
+	if (items == NULL)
+	{
+		printf("%s test FAILED: failed to allocate memory for items\n",
+			__func__);
+		return;
+	}
+
+	sctp_binary_heap_t heap;
+	sctp_binary_heap_init(&heap, item_comparer);
+
+	for (size_t i = 0; i < items_count; i++)
+	{
+		items[i].priority = (int32_t)rand() % items_count;
+		sctp_binary_heap_node_init(&items[i].heap_node, &items[i]);
+		sctp_binary_heap_push(&heap, &items[i].heap_node);
+		if (sctp_binary_heap_size(&heap) != i + 1)
+		{
+			printf("%s test FAILED: heap size expected to be %zu\n",
+				__func__, i + 1);
+			goto free_items;
+		}
+	}
+	sctp_binary_heap_verify(&heap);
+
+	int32_t root_priority = INT32_MIN;
+	sctp_binary_heap_node_t* top;
+	size_t iterations = 0;
+	while (sctp_binary_heap_size(&heap) != 0)
+	{
+		sctp_binary_heap_pop(&heap, &top);
+		item_t *top_item = (item_t *)(top->data);
+		int32_t next_priority = top_item->priority;
+
+		if (root_priority > next_priority)
+		{
+			printf("%s test FAILED: Priority %"PRId32" of popped item is less than previously popped %"PRId32" \n",
+				__func__, next_priority, root_priority);
+			goto free_items;
+		}
+
+		if (iterations % 2 == 0)
+		{
+			top_item->priority = rand();
+			sctp_binary_heap_node_init(&top_item->heap_node, top_item);
+			sctp_binary_heap_push(&heap, &top_item->heap_node);
+			if (top_item->priority < next_priority)
+			{
+				next_priority = top_item->priority;
+			}
+		}
+
+		root_priority = next_priority;
+		iterations++;
+	}
+
+
+	printf("%s test PASSED\n", __func__);
+
+free_items:
+	if (items != NULL)
+	{
+		free(items);
+		items = NULL;
+	}
+}
+
+
+void test_sctp_binary_heap_priority_collision_handled_in_push_order(void)
+{
+	item_t items[512];
+
+	sctp_binary_heap_t heap;
+	sctp_binary_heap_init(&heap, always_equal_comparer);
+
+	for (size_t i = 0; i < 512; i++)
+	{
+		items[i].priority = (int32_t)i;
+		sctp_binary_heap_node_init(&items[i].heap_node, &items[i]);
+		sctp_binary_heap_push(&heap, &items[i].heap_node);
+	}
+
+	for (size_t i = 0; i < 512; i++)
+	{
+		sctp_binary_heap_node_t* node;
+		sctp_binary_heap_pop(&heap, &node);
+		item_t* item = (item_t*)node->data;
+		if (item->priority != (int32_t)i)
+		{
+			printf("%s test FAILED: Priority %"PRId32" of popped item does not match push order %zu\n",
+				__func__, item->priority, i);
+			return;
+		}
+	}
+
+	if (sctp_binary_heap_size(&heap) != 0)
+	{
+		printf("%s test FAILED: heap size expected to be 0\n",
+			__func__);
+		return;
+	}
+	printf("%s test PASSED\n", __func__);
+}
+
+
+void test_timer_overflow(void)
+{
+	struct test_case {
+		uint32_t earlier_timer;
+		uint32_t later_timer;
+	} test_cases[] = {
+		{ UINT32_MAX, 0},
+		{ 10, 20 },
+		{ UINT32_MAX - 10, 10 /* UINT32_MAX */ },
+		{ UINT32_MAX / 2 - 10, UINT32_MAX / 2 + 10 },
+	};
+
+	for (size_t i = 0; i < sizeof(test_cases)/sizeof(test_cases[0]); i++)
+	{
+		const struct test_case tc = test_cases[i];
+
+		sctp_os_timer_t timer1;
+		sctp_os_timer_init(&timer1);
+		timer1.c_time = tc.later_timer;
+
+		sctp_os_timer_t timer2;
+		sctp_os_timer_init(&timer2);
+		timer2.c_time = tc.earlier_timer;
+
+		sctp_binary_heap_t heap;
+		sctp_binary_heap_init(&heap, (sctp_binary_heap_node_data_comparer)sctp_os_timer_compare);
+
+		sctp_binary_heap_push(&heap, &timer1.heap_node);
+		sctp_binary_heap_push(&heap, &timer2.heap_node);
+
+		sctp_binary_heap_node_t* node;
+		sctp_os_timer_t* timer;
+
+		sctp_binary_heap_pop(&heap, &node);
+		timer = (sctp_os_timer_t*)node->data;
+		if (timer->c_time != tc.earlier_timer)
+		{
+			printf("%s test FAILED: expected to extract timer with c_time %"PRIu32"\n",
+				__func__, tc.earlier_timer);
+			return;
+		}
+
+		sctp_binary_heap_pop(&heap, &node);
+		timer = (sctp_os_timer_t*)node->data;
+		if (timer->c_time != tc.later_timer)
+		{
+			printf("%s test FAILED: expected to extract timer with c_time %"PRIu32"\n",
+				__func__, tc.later_timer);
+			return;
+		}
+	}
+
+	printf("%s test PASSED\n", __func__);
+}
+
+int main(void)
+{
+	test_sctp_binary_heap_node_traverse_path();
+	test_sctp_binary_heap_get_node_by_index_simple();
+	test_sctp_binary_heap_get_node_by_index();
+	test_sctp_binary_heap_push_simple();
+	test_sctp_binary_heap_push_pop_sequential_items();
+	test_sctp_binary_heap_push_pop_random_items();
+	test_sctp_binary_heap_push_interleaved_with_pop_random_items();
+	test_sctp_binary_heap_priority_collision_handled_in_push_order();
+	test_timer_overflow();
+}

--- a/programs/callout_queue_tests.c
+++ b/programs/callout_queue_tests.c
@@ -63,11 +63,11 @@ int always_equal_comparer(const void *x, const void *y)
 typedef struct {
 	sctp_binary_heap_node_t heap_node;
 	uint32_t time;
-} timer_t;
+} simulated_timer_t;
 
 
 int
-timer_compare(const timer_t* a, const timer_t* b)
+timer_compare(const simulated_timer_t* a, const simulated_timer_t* b)
 {
 	if (SCTP_UINT32_GT(a->time, b->time))
 	{
@@ -567,11 +567,11 @@ void test_timer_overflow(void)
 	{
 		const struct test_case tc = test_cases[i];
 
-		timer_t timer1;
+		simulated_timer_t timer1;
 		timer1.time = tc.later_timer;
 		sctp_binary_heap_node_init(&timer1.heap_node, &timer1);
 
-		timer_t timer2;
+		simulated_timer_t timer2;
 		timer2.time = tc.earlier_timer;
 		sctp_binary_heap_node_init(&timer2.heap_node, &timer2);
 
@@ -582,10 +582,10 @@ void test_timer_overflow(void)
 		sctp_binary_heap_push(&heap, &timer2.heap_node);
 
 		sctp_binary_heap_node_t* node;
-		timer_t* timer;
+		simulated_timer_t* timer;
 
 		sctp_binary_heap_pop(&heap, &node);
-		timer = (timer_t*)node->data;
+		timer = (simulated_timer_t*)node->data;
 		if (timer->time != tc.earlier_timer)
 		{
 			printf("%s test FAILED: expected to extract timer with c_time %"PRIu32"\n",
@@ -594,7 +594,7 @@ void test_timer_overflow(void)
 		}
 
 		sctp_binary_heap_pop(&heap, &node);
-		timer = (timer_t*)node->data;
+		timer = (simulated_timer_t*)node->data;
 		if (timer->time != tc.later_timer)
 		{
 			printf("%s test FAILED: expected to extract timer with c_time %"PRIu32"\n",

--- a/programs/callout_queue_tests.c
+++ b/programs/callout_queue_tests.c
@@ -44,14 +44,14 @@ typedef struct item
 	int32_t priority;
 } item_t;
 
-int item_comparer(void* x, void* y)
+int item_comparer(const void* x, const void* y)
 {
-	struct item* X = (struct item*)x;
-	struct item* Y = (struct item*)y;
+	const struct item *X = x;
+	const struct item *Y = y;
 	return X->priority - Y->priority;
 }
 
-int always_equal_comparer(void *x, void *y)
+int always_equal_comparer(const void *x, const void *y)
 {
 	return 0;
 }

--- a/programs/callout_queue_tests.c
+++ b/programs/callout_queue_tests.c
@@ -31,8 +31,9 @@
  */
 
 
-#include "netinet/sctp_callout_queue.h"
-#include "netinet/sctp_callout.h"
+#include <netinet/sctp_callout_queue.h>
+#include <netinet/sctp_os_userspace.h>
+#include <netinet/sctp_callout.h>
 
 #include <stdio.h>
 #include <inttypes.h>

--- a/programs/callout_queue_tests.c
+++ b/programs/callout_queue_tests.c
@@ -68,7 +68,8 @@ void shuffle_array(uint32_t *a, size_t size)
 	// https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
 	for (size_t i = size - 1; i >= 1; i--) 
 	{
-		size_t j = random() % (i + 1);
+		const size_t r = (size_t)1 * RAND_MAX * rand() + rand();
+		size_t j = r % (i + 1);
 		uint32_t temp = a[j];
 		a[j] = a[i];
 		a[i] = temp;
@@ -607,7 +608,7 @@ void test_sctp_binary_heap_priority_collision_handled_in_push_order(void)
 
 void test_random_remove() 
 {
-	const size_t items_count = 30 * 1024;
+	const uint32_t items_count = 30 * 1024;
 	uint32_t* remove_order = NULL;
 	item_t* items = NULL;
 
@@ -630,7 +631,7 @@ void test_random_remove()
 	sctp_binary_heap_t heap;
 	sctp_binary_heap_init(&heap, item_comparer, item_visualizer);
 
-	for (size_t i = 0; i < items_count; i++) 
+	for (uint32_t i = 0; i < items_count; i++) 
 	{
 		remove_order[i] = i;
 		items[i].priority = (i + 1);
@@ -640,7 +641,7 @@ void test_random_remove()
 
 	shuffle_array(remove_order, items_count);
 
-	for (size_t i = 0; i < items_count; i++) 
+	for (uint32_t i = 0; i < items_count; i++) 
 	{
 		sctp_binary_heap_remove(&heap, &items[remove_order[i]].heap_node);
 
@@ -732,7 +733,6 @@ void test_timer_overflow(void)
 int main(void)
 {
 	srand(42);
-	srandom(42);
 	test_sctp_binary_heap_node_traverse_path();
 	test_sctp_binary_heap_get_node_by_index_simple();
 	test_sctp_binary_heap_get_node_by_index();

--- a/programs/callout_queue_tests.c
+++ b/programs/callout_queue_tests.c
@@ -45,25 +45,33 @@ typedef struct item
 	int32_t priority;
 } item_t;
 
-int item_comparer(const void* x, const void* y)
+
+int
+item_comparer(const void* x, const void* y)
 {
 	const item_t* X = x;
 	const item_t* Y = y;
 	return X->priority - Y->priority;
 }
 
-void item_visualizer(const void* x, size_t max_len, char *out_buffer) 
+
+void
+item_visualizer(const void* x, size_t max_len, char *out_buffer)
 {
 	const item_t* X = x;
 	snprintf(out_buffer, max_len, "%" PRId32, X->priority);
 }
 
-int always_equal_comparer(const void *x, const void *y)
+
+int
+always_equal_comparer(const void *x, const void *y)
 {
 	return 0;
 }
 
-void shuffle_array(uint32_t *a, size_t size) 
+
+void
+shuffle_array(uint32_t *a, size_t size)
 {
 	// https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
 	for (size_t i = size - 1; i >= 1; i--) 
@@ -88,19 +96,16 @@ typedef struct {
 int
 timer_compare(const simulated_timer_t* a, const simulated_timer_t* b)
 {
-	if (SCTP_UINT32_GT(a->time, b->time))
-	{
-		return 1;
-	}
 	if (a->time == b->time)
 	{
 		return 0;
 	}
-	return -1;
+	return SCTP_UINT32_GT(a->time, b->time) ? 1 : -1;
 }
 
 
-void test_sctp_binary_heap_node_traverse_path(void)
+void
+test_sctp_binary_heap_node_traverse_path(void)
 {
 	/*
 	 * heap keyed by node index
@@ -159,7 +164,8 @@ void test_sctp_binary_heap_node_traverse_path(void)
 }
 
 
-void test_sctp_binary_heap_get_node_by_index_simple(void)
+void
+test_sctp_binary_heap_get_node_by_index_simple(void)
 {
 	struct sctp_binary_heap heap;
 	sctp_binary_heap_init(&heap, item_comparer, item_visualizer);
@@ -229,7 +235,8 @@ void test_sctp_binary_heap_get_node_by_index_simple(void)
 }
 
 
-void test_sctp_binary_heap_get_node_by_index(void)
+void
+test_sctp_binary_heap_get_node_by_index(void)
 {
 	const size_t items_count = 128;
 	item_t* items = (item_t*)malloc(items_count * sizeof(item_t));
@@ -289,7 +296,8 @@ free_mem:
 }
 
 
-void test_sctp_binary_heap_push_simple(void)
+void
+test_sctp_binary_heap_push_simple(void)
 {
 	struct sctp_binary_heap heap;
 	sctp_binary_heap_init(&heap, item_comparer, item_visualizer);
@@ -354,7 +362,8 @@ void test_sctp_binary_heap_push_simple(void)
 }
 
 
-void test_sctp_binary_heap_push_pop_sequential_items(void)
+void
+test_sctp_binary_heap_push_pop_sequential_items(void)
 {
 	const size_t items_count = 1024 * 1024;
 	item_t* items = (item_t*)malloc(items_count * sizeof(item_t));
@@ -424,7 +433,8 @@ free_mem:
 }
 
 
-void test_sctp_binary_heap_push_pop_random_items(void)
+void 
+test_sctp_binary_heap_push_pop_random_items(void)
 {
 	const size_t items_count = 1024 * 1024;
 	item_t *items = (item_t*) malloc(items_count * sizeof(item_t));
@@ -488,7 +498,8 @@ free_mem:
 }
 
 
-void test_sctp_binary_heap_push_interleaved_with_pop_random_items(void)
+void
+test_sctp_binary_heap_push_interleaved_with_pop_random_items(void)
 {
 	const size_t items_count = 1024 * 1024;
 	item_t* items = (item_t*)malloc(items_count * sizeof(item_t));
@@ -564,7 +575,8 @@ free_mem:
 }
 
 
-void test_sctp_binary_heap_priority_collision_handled_in_push_order(void)
+void
+test_sctp_binary_heap_priority_collision_handled_in_push_order(void)
 {
 	item_t items[512];
 
@@ -606,7 +618,8 @@ void test_sctp_binary_heap_priority_collision_handled_in_push_order(void)
 	printf("%s test PASSED\n", __func__);
 }
 
-void test_random_remove() 
+void
+test_random_remove()
 {
 	const uint32_t items_count = 30 * 1024;
 	uint32_t* remove_order = NULL;
@@ -675,7 +688,8 @@ free_mem:
 }
 
 
-void test_timer_overflow(void)
+void
+test_timer_overflow(void)
 {
 	struct test_case {
 		uint32_t earlier_timer;

--- a/programs/callout_queue_tests.c
+++ b/programs/callout_queue_tests.c
@@ -619,7 +619,7 @@ test_sctp_binary_heap_priority_collision_handled_in_push_order(void)
 }
 
 void
-test_random_remove()
+test_random_remove(void)
 {
 	const uint32_t items_count = 30 * 1024;
 	uint32_t* remove_order = NULL;

--- a/usrsctplib/CMakeLists.txt
+++ b/usrsctplib/CMakeLists.txt
@@ -113,6 +113,7 @@ list(APPEND usrsctp_netinet_headers
 	netinet/sctp_auth.h
 	netinet/sctp_bsd_addr.h
 	netinet/sctp_callout.h
+	netinet/sctp_callout_queue.h
 	netinet/sctp_constants.h
 	netinet/sctp_crc32.h
 	netinet/sctp_header.h
@@ -150,6 +151,7 @@ list(APPEND usrsctp_sources
 	netinet/sctp_auth.c
 	netinet/sctp_bsd_addr.c
 	netinet/sctp_callout.c
+	netinet/sctp_callout_queue.c
 	netinet/sctp_cc_functions.c
 	netinet/sctp_crc32.c
 	netinet/sctp_indata.c

--- a/usrsctplib/Makefile.am
+++ b/usrsctplib/Makefile.am
@@ -50,6 +50,7 @@ libusrsctp_la_SOURCES  = user_atomic.h \
                          netinet/sctp_auth.c netinet/sctp_auth.h \
                          netinet/sctp_bsd_addr.c netinet/sctp_bsd_addr.h \
                          netinet/sctp_callout.c netinet/sctp_callout.h \
+                         netinet/sctp_callout_queue.c netinet/sctp_callout_queue.h \
                          netinet/sctp_cc_functions.c \
                          netinet/sctp_constants.h \
                          netinet/sctp_crc32.c netinet/sctp_crc32.h \

--- a/usrsctplib/Makefile.nmake
+++ b/usrsctplib/Makefile.nmake
@@ -81,6 +81,7 @@ usrsctp_HEADERS = \
 	netinet\sctp_auth.h \
 	netinet\sctp_bsd_addr.h \
 	netinet\sctp_callout.h \
+	netinet\sctp_callout_queue.h \
 	netinet\sctp_constants.h \
 	netinet\sctp_crc32.h \
 	netinet\sctp_header.h \
@@ -128,6 +129,9 @@ sctp_bsd_addr.obj : netinet\sctp_bsd_addr.c $(usrsctp_HEADERS)
 
 sctp_callout.obj : netinet\sctp_callout.c $(usrsctp_HEADERS)
 	cl $(CVARSDLL) $(CFLAGS) -c netinet\sctp_callout.c
+
+sctp_callout_queue.obj : netinet\sctp_callout_queue.c $(usrsctp_HEADERS)
+	cl $(CVARSDLL) $(CFLAGS) -c netinet\sctp_callout_queue.c
 
 sctp_cc_functions.obj : netinet\sctp_cc_functions.c $(usrsctp_HEADERS)
 	cl $(CVARSDLL) $(CFLAGS) -c netinet\sctp_cc_functions.c

--- a/usrsctplib/netinet/meson.build
+++ b/usrsctplib/netinet/meson.build
@@ -3,6 +3,7 @@ sources += files([
     'sctp_auth.c',
     'sctp_bsd_addr.c',
     'sctp_callout.c',
+    'sctp_callout_queue.c',
     'sctp_cc_functions.c',
     'sctp_crc32.c',
     'sctp_indata.c',

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -423,6 +423,7 @@ user_sctp_timer_iterate(void *arg)
 		}
 		sctp_handle_tick(MSEC_TO_TICKS(TIMEOUT_INTERVAL));
 	}
+	sctp_userland_cond_destroy(&sctp_os_timer_current_completed);
 	return (NULL);
 }
 

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -349,8 +349,7 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 	sctp_binary_heap_node_t* node = NULL;
 	while (0 == sctp_binary_heap_peek(heap, &node)) {
 		sctp_os_timer_t* c = (sctp_os_timer_t*)node->data;
-		if (!SCTP_UINT32_GE(ticks, c->c_time))
-		{
+		if (!SCTP_UINT32_GE(ticks, c->c_time)) {
 			if (last_heap_modification_reported != heap->mod_count) {
 				SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": the next soonest callout %p is scheduled at %" PRIu32 ", total scheduled callouts %zu\n",
 					__func__, ticks, c, c->c_time, sctp_binary_heap_size(heap));
@@ -385,7 +384,7 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 		} else {
 			SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": skipping callout %p with wrong flags %d\n", 
 				__func__, ticks, c, c->c_flags);
-			KASSERT(0, ("Timer from queue expected to be scheduled and active"));
+			KASSERT(0, ("Timer from queue expected to be scheduled and active and not cancelled"));
 		}
 	}
 	SCTP_TIMERQ_UNLOCK();

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -158,6 +158,7 @@ sctp_os_timer_wait_completion_impl(sctp_os_timer_t* c)
 			if (current_tid == c->c_executor_id)
 			{
 				// callout tried to wait for completion of itself
+				KASSERT(0, ("Deadlock detected: wait for self completion"));
 				retry_condition_wait = 0;
 			}
 			else

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -185,7 +185,7 @@ sctp_os_timer_start(sctp_os_timer_t *c, uint32_t to_ticks, void (*ftn) (void *),
 	case SCTP_CALLOUT_SCHEDULED:
 	{
 		sctp_binary_heap_remove(&SCTP_BASE_INFO(timers_queue), &c->heap_node);
-		break;
+		// FALLTHROUGH
 	}
 	case SCTP_CALLOUT_RUNNING:
 	case SCTP_CALLOUT_NEW:

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -339,7 +339,7 @@ sctp_os_timer_stop(sctp_os_timer_t *c)
 void
 sctp_handle_tick(uint32_t elapsed_ticks)
 {
-	static uint32_t last_heap_modification_reported = 0;
+	static uint32_t last_heap_version_reported = 0;
 
 	SCTP_TIMERQ_LOCK();
 	/* update our tick count */
@@ -350,10 +350,10 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 	while (0 == sctp_binary_heap_peek(heap, &node)) {
 		sctp_os_timer_t* c = (sctp_os_timer_t*)node->data;
 		if (!SCTP_UINT32_GE(ticks, c->c_time)) {
-			if (last_heap_modification_reported != heap->mod_count) {
+			if (last_heap_version_reported != sctp_binary_heap_version(heap)) {
 				SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": the next soonest callout %p is scheduled at %" PRIu32 ", total scheduled callouts %zu\n",
 					__func__, ticks, c, c->c_time, sctp_binary_heap_size(heap));
-				last_heap_modification_reported = heap->mod_count;
+				last_heap_version_reported = sctp_binary_heap_version(heap);
 			}
 			// Earliest timer is not ready yet 
 			break;

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -46,6 +46,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <user_atomic.h>
 #include <netinet/sctp_sysctl.h>
 #include <netinet/sctp_pcb.h>

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -46,7 +46,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include <inttypes.h>
 #include <user_atomic.h>
 #include <netinet/sctp_sysctl.h>
 #include <netinet/sctp_pcb.h>
@@ -55,136 +54,6 @@
 #include <netinet/sctp_callout.h>
 #include <netinet/sctp_pcb.h>
 #endif
-
-
-#if defined (__Userspace__)
-static
-void sctp_userland_cond_wait(userland_cond_t* cond, userland_mutex_t* mtx)
-{
-#if defined (__Userspace_os_Windows)
-	SleepConditionVariableCS(cond, mtx, INFINITE);
-#else	
-	int rc = pthread_cond_wait(cond, mtx);
-	if (rc)
-		SCTP_PRINTF("ERROR; return code from pthread_cond_wait is %d\n", rc);
-#endif
-}
-
-
-static
-void sctp_userland_cond_signal(userland_cond_t* cond)
-{
-#if defined (__Userspace_os_Windows)
-	WakeAllConditionVariable(cond);
-#else	
-	int rc = pthread_cond_broadcast(cond);
-	if (rc)
-		SCTP_PRINTF("ERROR; return code from pthread_cond_broadcast is %d\n", rc);
-#endif
-}
-
-static
-void sctp_userland_cond_init(userland_cond_t* cond)
-{
-#if defined (__Userspace_os_Windows)
-	InitializeConditionVariable(cond);
-#else	
-	int rc = pthread_cond_init(cond, NULL);
-	if (rc)
-		SCTP_PRINTF("ERROR; return code from pthread_cond_init is %d\n", rc);
-#endif
-}
-
-static
-void sctp_userland_cond_destroy(userland_cond_t* cond)
-{
-#if defined (__Userspace_os_Windows)
-	DeleteConditionVariable(cond);
-#else	
-	int rc = pthread_cond_destroy(cond);
-	if (rc)
-		SCTP_PRINTF("ERROR; return code from pthread_cond_destroy is %d\n", rc);
-#endif
-}
-#endif
-
-
-static void
-sctp_os_timer_cancel_impl(sctp_os_timer_t* c)
-{
-	switch (c->c_state)
-	{
-	case SCTP_CALLOUT_SCHEDULED:
-	{
-		sctp_binary_heap_remove(&SCTP_BASE_INFO(timers_queue), &c->heap_node);
-		c->c_state = SCTP_CALLOUT_COMPLETED;
-		break;
-	}
-	case SCTP_CALLOUT_RUNNING:
-	{
-		c->c_state = SCTP_CALLOUT_CANCEL_REQUESTED;
-		break;
-	}
-	case SCTP_CALLOUT_CANCEL_REQUESTED:
-	case SCTP_CALLOUT_COMPLETED:
-	case SCTP_CALLOUT_NEW:
-	{
-		// nothing to do
-		break;
-	}
-	default:
-	{
-		KASSERT(0, ("Unknown callout state"));
-		break;
-	}
-	}
-}
-
-
-static void
-sctp_os_timer_wait_completion_impl(sctp_os_timer_t* c)
-{
-	userland_thread_id_t current_tid;
-	sctp_userspace_thread_id(&current_tid);
-
-	int retry_condition_wait = 1;
-	do
-	{
-		switch (c->c_state)
-		{
-		case SCTP_CALLOUT_RUNNING:
-		case SCTP_CALLOUT_CANCEL_REQUESTED:
-		case SCTP_CALLOUT_SCHEDULED:
-		{
-			if (sctp_userspace_thread_equal(current_tid, c->c_executor_id))
-			{
-				// callout tried to wait for completion of itself
-				KASSERT(0, ("Deadlock detected: wait for self completion"));
-				retry_condition_wait = 0;
-			}
-			else
-			{
-#if defined (__Userspace__)
-				sctp_userland_cond_wait(&c->c_completion, &SCTP_BASE_VAR(timer_mtx));
-#endif
-			}
-			break;
-		}
-		case SCTP_CALLOUT_COMPLETED:
-		case SCTP_CALLOUT_NEW:
-		{
-			retry_condition_wait = 0;
-			break;
-		}
-		default:
-		{
-			KASSERT(0, ("Unknown callout state"));
-			break;
-		}
-		}
-	} while (retry_condition_wait);
-}
-
 
 /*
  * Callout/Timer routines for OS that doesn't have them
@@ -204,58 +73,36 @@ uint32_t sctp_get_tick_count(void) {
 	return ret;
 }
 
-void sctp_os_timer_describe(const sctp_os_timer_t* t, size_t max_len, char *buffer)
-{
-	snprintf(buffer, max_len, "t=%" PRIu32 ",f=%p,a=%p", t->c_time, (void *)t->c_func, (void *)t->c_arg);
-}
+/*
+ * SCTP_TIMERQ_LOCK protects:
+ * - SCTP_BASE_INFO(callqueue)
+ * - sctp_os_timer_next: next timer to check
+ * - sctp_os_timer_current: current callout callback in progress
+ * - sctp_os_timer_current_tid: current callout thread id in progress
+ * - sctp_os_timer_waiting: some thread is waiting for callout to complete
+ * - sctp_os_timer_wait_ctr: incremented every time a thread wants to wait
+ *                           for a callout to complete.
+ */
+static sctp_os_timer_t *sctp_os_timer_next = NULL;
+static sctp_os_timer_t *sctp_os_timer_current = NULL;
+static int sctp_os_timer_waiting = 0;
+static int sctp_os_timer_wait_ctr = 0;
+static userland_thread_id_t sctp_os_timer_current_tid;
 
-int
-sctp_os_timer_compare(const sctp_os_timer_t * a, const sctp_os_timer_t *b)
-{
-	if (SCTP_UINT32_GT(a->c_time, b->c_time))
-	{
-		return 1;
-	}
-	if (a->c_time == b->c_time)
-	{
-		return 0;
-	}
-	return -1;
-}
+/*
+ * SCTP_TIMERWAIT_LOCK (sctp_os_timerwait_mtx) protects:
+ * - sctp_os_timer_wait_cond: waiting for callout to complete
+ * - sctp_os_timer_done_ctr: value of "wait_ctr" after triggering "waiting"
+ */
+userland_mutex_t sctp_os_timerwait_mtx;
+static userland_cond_t sctp_os_timer_wait_cond;
+static int sctp_os_timer_done_ctr = 0;
+
 
 void
 sctp_os_timer_init(sctp_os_timer_t *c)
 {
 	memset(c, 0, sizeof(*c));
-	sctp_binary_heap_node_init(&c->heap_node, c);
-#if defined(__Userspace__)
-	sctp_userland_cond_init(&c->c_completion);
-#endif
-}
-
-void
-sctp_os_timer_deinit(sctp_os_timer_t* c)
-{
-	KASSERT(!sctp_os_timer_is_active(c), ("Deiniting active timer"));
-#if defined(__Userspace__)
-	sctp_userland_cond_destroy(&c->c_completion);
-#endif
-}
-
-int sctp_os_timer_is_pending(const sctp_os_timer_t *c)
-{
-	SCTP_TIMERQ_LOCK();
-	const int is_pending = (c->c_state == SCTP_CALLOUT_SCHEDULED);
-	SCTP_TIMERQ_UNLOCK();
-	return is_pending;
-}
-
-int sctp_os_timer_is_active(const sctp_os_timer_t* c)
-{
-	SCTP_TIMERQ_LOCK();
-	const int is_active = !(c->c_state == SCTP_CALLOUT_COMPLETED || c->c_state == SCTP_CALLOUT_NEW);
-	SCTP_TIMERQ_UNLOCK();
-	return is_active;
 }
 
 void
@@ -264,137 +111,157 @@ sctp_os_timer_start(sctp_os_timer_t *c, uint32_t to_ticks, void (*ftn) (void *),
 {
 	/* paranoia */
 	if ((c == NULL) || (ftn == NULL))
-	{
-		KASSERT(0, ("Attempted to start NULL timer or NULL callback"));
-		return;
-	}
+	    return;
 
 	SCTP_TIMERQ_LOCK();
-
-	switch (c->c_state)
-	{
-	case SCTP_CALLOUT_CANCEL_REQUESTED:
-	{
-		/* Do not re-schedule cancelled callout which is not yet completed */
-		break;
-	}
-	case SCTP_CALLOUT_SCHEDULED:
-	{
-		sctp_binary_heap_remove(&SCTP_BASE_INFO(timers_queue), &c->heap_node);
-		// Workaround for  -Wimplicit-fallthrough
-		goto SCHEDULE_TIMER;
-	}
-	SCHEDULE_TIMER:
-	case SCTP_CALLOUT_RUNNING:
-	case SCTP_CALLOUT_NEW:
-	case SCTP_CALLOUT_COMPLETED:
-	{
-		if (to_ticks == 0)
-			to_ticks = 1;
-
-		c->c_arg = arg;
-		c->c_state = SCTP_CALLOUT_SCHEDULED;
-		c->c_func = ftn;
-		c->c_time = ticks + to_ticks;
-
-		sctp_binary_heap_push(&SCTP_BASE_INFO(timers_queue), &c->heap_node);
-		break;
-	}
-	default:
-		KASSERT(0, ("Unknown callout state"));
+	/* check to see if we're rescheduling a timer */
+	if (c == sctp_os_timer_current) {
+		/*
+		 * We're being asked to reschedule a callout which is
+		 * currently in progress.
+		 */
+		if (sctp_os_timer_waiting) {
+			/*
+			 * This callout is already being stopped.
+			 * callout.  Don't reschedule.
+			 */
+			SCTP_TIMERQ_UNLOCK();
+			return;
+		}
 	}
 
+	if (c->c_flags & SCTP_CALLOUT_PENDING) {
+		if (c == sctp_os_timer_next) {
+			sctp_os_timer_next = TAILQ_NEXT(c, tqe);
+		}
+		TAILQ_REMOVE(&SCTP_BASE_INFO(callqueue), c, tqe);
+		/*
+		 * part of the normal "stop a pending callout" process
+		 * is to clear the CALLOUT_ACTIVE and CALLOUT_PENDING
+		 * flags.  We don't bother since we are setting these
+		 * below and we still hold the lock.
+		 */
+	}
+
+	/*
+	 * We could unlock/splx here and lock/spl at the TAILQ_INSERT_TAIL,
+	 * but there's no point since doing this setup doesn't take much time.
+	 */
+	if (to_ticks == 0)
+		to_ticks = 1;
+
+	c->c_arg = arg;
+	c->c_flags = (SCTP_CALLOUT_ACTIVE | SCTP_CALLOUT_PENDING);
+	c->c_func = ftn;
+	c->c_time = ticks + to_ticks;
+	TAILQ_INSERT_TAIL(&SCTP_BASE_INFO(callqueue), c, tqe);
 	SCTP_TIMERQ_UNLOCK();
 }
-
-
-void
-sctp_os_timer_cancel(sctp_os_timer_t* c)
-{
-	SCTP_TIMERQ_LOCK();
-	sctp_os_timer_cancel_impl(c);
-	SCTP_TIMERQ_UNLOCK();
-}
-
-
-void
-sctp_os_timer_wait_completion(sctp_os_timer_t* c)
-{
-	SCTP_TIMERQ_LOCK();
-	sctp_os_timer_wait_completion_impl(c);
-	SCTP_TIMERQ_UNLOCK();
-}
-
 
 int
 sctp_os_timer_stop(sctp_os_timer_t *c)
 {
+	int wakeup_cookie;
+
 	SCTP_TIMERQ_LOCK();
-	sctp_os_timer_cancel_impl(c);
-	sctp_os_timer_wait_completion_impl(c);
+	/*
+	 * Don't attempt to delete a callout that's not on the queue.
+	 */
+	if (!(c->c_flags & SCTP_CALLOUT_PENDING)) {
+		c->c_flags &= ~SCTP_CALLOUT_ACTIVE;
+		if (sctp_os_timer_current != c) {
+			SCTP_TIMERQ_UNLOCK();
+			return (0);
+		} else {
+			/*
+			 * Deleting the callout from the currently running
+			 * callout from the same thread, so just return
+			 */
+			userland_thread_id_t tid;
+			sctp_userspace_thread_id(&tid);
+			if (sctp_userspace_thread_equal(tid,
+						sctp_os_timer_current_tid)) {
+				SCTP_TIMERQ_UNLOCK();
+				return (0);
+			}
+
+			/* need to wait until the callout is finished */
+			sctp_os_timer_waiting = 1;
+			wakeup_cookie = ++sctp_os_timer_wait_ctr;
+			SCTP_TIMERQ_UNLOCK();
+			SCTP_TIMERWAIT_LOCK();
+			/*
+			 * wait only if sctp_handle_tick didn't do a wakeup
+			 * in between the lock dance
+			 */
+			if (wakeup_cookie - sctp_os_timer_done_ctr > 0) {
+#if defined (__Userspace_os_Windows)
+				SleepConditionVariableCS(&sctp_os_timer_wait_cond,
+							 &sctp_os_timerwait_mtx,
+							 INFINITE);
+#else
+				pthread_cond_wait(&sctp_os_timer_wait_cond,
+						  &sctp_os_timerwait_mtx);
+#endif
+			}
+			SCTP_TIMERWAIT_UNLOCK();
+		}
+		return (0);
+	}
+	c->c_flags &= ~(SCTP_CALLOUT_ACTIVE | SCTP_CALLOUT_PENDING);
+	if (c == sctp_os_timer_next) {
+		sctp_os_timer_next = TAILQ_NEXT(c, tqe);
+	}
+	TAILQ_REMOVE(&SCTP_BASE_INFO(callqueue), c, tqe);
 	SCTP_TIMERQ_UNLOCK();
 	return (1);
 }
 
-
 void
 sctp_handle_tick(uint32_t elapsed_ticks)
 {
+	sctp_os_timer_t *c;
+	void (*c_func)(void *);
+	void *c_arg;
+	int wakeup_cookie;
+
 	SCTP_TIMERQ_LOCK();
 	/* update our tick count */
 	ticks += elapsed_ticks;
-
-	sctp_binary_heap_t* heap = &SCTP_BASE_INFO(timers_queue);
-	sctp_binary_heap_node_t* node = NULL;
-	while (0 == sctp_binary_heap_peek(heap, &node))
-	{
-		sctp_os_timer_t* t = ((sctp_os_timer_t*)node->data);
-		if (!SCTP_UINT32_GE(ticks, t->c_time))
-		{
-			// Earliest timer is not ready yet 
-			break;
-		}
-		sctp_binary_heap_remove(heap, node);
-
-		if (t->c_state == SCTP_CALLOUT_SCHEDULED)
-		{
-			userland_thread_id_t tid;
-			sctp_userspace_thread_id(&tid);
-			t->c_executor_id = tid;
-			t->c_state = SCTP_CALLOUT_RUNNING;
-
-			void (* const c_func)(void*) = t->c_func;
-			void* c_arg = t->c_arg;
+	c = TAILQ_FIRST(&SCTP_BASE_INFO(callqueue));
+	while (c) {
+		if (SCTP_UINT32_GE(ticks, c->c_time)) {
+			sctp_os_timer_next = TAILQ_NEXT(c, tqe);
+			TAILQ_REMOVE(&SCTP_BASE_INFO(callqueue), c, tqe);
+			c_func = c->c_func;
+			c_arg = c->c_arg;
+			c->c_flags &= ~SCTP_CALLOUT_PENDING;
+			sctp_os_timer_current = c;
+			sctp_userspace_thread_id(&sctp_os_timer_current_tid);
 			SCTP_TIMERQ_UNLOCK();
 			c_func(c_arg);
 			SCTP_TIMERQ_LOCK();
-
-			t->c_executor_id = 0;
-		}
-
-		switch (t->c_state)
-		{
-		case SCTP_CALLOUT_RUNNING:
-		case SCTP_CALLOUT_CANCEL_REQUESTED:
-		{
-			t->c_state = SCTP_CALLOUT_COMPLETED;
-#if defined(__Userspace__)
-			sctp_userland_cond_signal(&t->c_completion);
+			sctp_os_timer_current = NULL;
+			if (sctp_os_timer_waiting) {
+				wakeup_cookie = sctp_os_timer_wait_ctr;
+				SCTP_TIMERQ_UNLOCK();
+				SCTP_TIMERWAIT_LOCK();
+#if defined (__Userspace_os_Windows)
+				WakeAllConditionVariable(&sctp_os_timer_wait_cond);
+#else
+				pthread_cond_broadcast(&sctp_os_timer_wait_cond);
 #endif
-			break;
+				sctp_os_timer_done_ctr = wakeup_cookie;
+				SCTP_TIMERWAIT_UNLOCK();
+				SCTP_TIMERQ_LOCK();
+				sctp_os_timer_waiting = 0;
+			}
+			c = sctp_os_timer_next;
+		} else {
+			c = TAILQ_NEXT(c, tqe);
 		}
-		case SCTP_CALLOUT_SCHEDULED:
-			// nothing to do, timer is rescheduled
-			break;
-		case SCTP_CALLOUT_COMPLETED:
-		case SCTP_CALLOUT_NEW:
-		default:
-			KASSERT(0, ("Unexpected timer state"));
-			break;
-		}
-
 	}
-
+	sctp_os_timer_next = NULL;
 	SCTP_TIMERQ_UNLOCK();
 }
 
@@ -442,6 +309,15 @@ sctp_start_timer(void)
 	 * here, it is being done in sctp_pcb_init()
 	 */
 	int rc;
+
+#if defined(__Userspace_os_Windows)
+	InitializeConditionVariable(&sctp_os_timer_wait_cond);
+#else
+	rc = pthread_cond_init(&sctp_os_timer_wait_cond, NULL);
+	if (rc)
+		SCTP_PRINTF("ERROR; return code from pthread_cond_init is %d\n", rc);
+#endif
+
 	rc = sctp_userspace_thread_create(&SCTP_BASE_VAR(timer_thread), user_sctp_timer_iterate);
 	if (rc) {
 		SCTP_PRINTF("ERROR; return code from sctp_thread_create() is %d\n", rc);

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -192,7 +192,7 @@ sctp_os_timer_deinit(sctp_os_timer_t* c)
 {
 	SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": request to deinit callout %p\n", 
 		__func__, sctp_get_tick_count(), c);
-	KASSERT(!sctp_os_timer_is_active(c), ("Deiniting an active timer"));
+	KASSERT(!sctp_os_timer_is_active(c), ("Deiniting an active callout"));
 #if defined(__Userspace__)
 	sctp_userland_cond_destroy(&c->c_completion);
 #endif
@@ -235,7 +235,7 @@ sctp_os_timer_start(sctp_os_timer_t *c, uint32_t to_ticks, void (*ftn) (void *),
 	}
 
 	SCTP_TIMERQ_LOCK();
-	SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": request to start timer %p with delay of %" PRIu32 " ticks\n", 
+	SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": request to start callout %p with delay of %" PRIu32 " ticks\n", 
 		__func__, ticks, c, to_ticks);
 	/* check to see if we're rescheduling a timer */
 	if ((c->c_flags & SCTP_CALLOUT_EXECUTING) != 0) {
@@ -354,8 +354,8 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 		if (!SCTP_UINT32_GE(ticks, c->c_time))
 		{
 			if (last_heap_modification_reported != heap->mod_count) {
-				SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": the next soonest callout %p is scheduled at %" PRIu32 "\n",
-					__func__, ticks, c, c->c_time);
+				SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": the next soonest callout %p is scheduled at %" PRIu32 ", total scheduled callouts %zu\n",
+					__func__, ticks, c, c->c_time, sctp_binary_heap_size(heap));
 				last_heap_modification_reported = heap->mod_count;
 			}
 			// Earliest timer is not ready yet 

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -73,7 +73,7 @@ sctp_userland_cond_wait(userland_cond_t* cond,
 	int rc = pthread_cond_timedwait(cond, mtx, &ts);
 	if (rc) {
 		if (rc == ETIMEDOUT) {
-			SCTP_PRINTF("WARN; pthread_cond_timedwait did not return within %" PRd64 " sec\n",
+			SCTP_PRINTF("WARN; pthread_cond_timedwait did not return within %" PRId64 " sec\n",
 				(int64_t)ts.tv_sec);
 		} else {
 			SCTP_PRINTF("ERROR; return code from pthread_cond_wait is %d\n",

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -157,16 +157,16 @@ void
 sctp_os_timer_describe(const sctp_os_timer_t* t,
                        size_t max_len,
                        char* buffer) {
-  snprintf(buffer, max_len, "t=%" PRIu32 ",f=%p,a=%p", t->c_time,
-           (void*)t->c_func, (void*)t->c_arg);
+	snprintf(buffer, max_len, "t=%" PRIu32 ",f=%p,a=%p", t->c_time,
+		(void*)t->c_func, (void*)t->c_arg);
 }
 
 int
 sctp_os_timer_compare(const sctp_os_timer_t* a, const sctp_os_timer_t* b) {
-  if (a->c_time == b->c_time) {
-    return 0;
-  }
-  return SCTP_UINT32_GT(a->c_time, b->c_time) ? 1 : -1;
+	if (a->c_time == b->c_time) {
+		return 0;
+	}
+	return SCTP_UINT32_GT(a->c_time, b->c_time) ? 1 : -1;
 }
 
 void

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -204,7 +204,7 @@ uint32_t sctp_get_tick_count(void) {
 }
 
 int
-sctp_os_timer_compare(sctp_os_timer_t* a, sctp_os_timer_t* b)
+sctp_os_timer_compare(const sctp_os_timer_t * a, const sctp_os_timer_t *b)
 {
 	if (SCTP_UINT32_GT(a->c_time, b->c_time))
 	{

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -226,13 +226,13 @@ sctp_os_timer_start(sctp_os_timer_t *c, uint32_t to_ticks, void (*ftn) (void *),
 	/* check to see if we're rescheduling a timer */
 	if ((c->c_flags & SCTP_CALLOUT_EXECUTING) != 0) {
 		/*
-		* We're being asked to reschedule a callout which is
-		* currently in progress.
-		*/
+		 * We're being asked to reschedule a callout which is
+		 * currently in progress.
+		 */
 		if ((c->c_flags & SCTP_CALLOUT_ACTIVE) == 0) {
 			/*
-			* This callout is already being stopped.
-			* callout.  Don't reschedule.
+			 * This callout is already being stopped.
+			 * callout.  Don't reschedule.
 			 */
 			SCTP_TIMERQ_UNLOCK();
 			return;

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -55,6 +55,58 @@
 #include <netinet/sctp_pcb.h>
 #endif
 
+
+#if defined (__Userspace__)
+static
+void sctp_userland_cond_wait(userland_cond_t* cond, userland_mutex_t* mtx)
+{
+#if defined (__Userspace_os_Windows)
+	SleepConditionVariableCS(cond, mtx, INFINITE);
+#else	
+	int rc = pthread_cond_wait(cond, mtx);
+	if (rc)
+		SCTP_PRINTF("ERROR; return code from pthread_cond_wait is %d\n", rc);
+#endif
+}
+
+
+static
+void sctp_userland_cond_signal(userland_cond_t* cond)
+{
+#if defined (__Userspace_os_Windows)
+	WakeAllConditionVariable(cond);
+#else	
+	int rc = pthread_cond_broadcast(cond);
+	if (rc)
+		SCTP_PRINTF("ERROR; return code from pthread_cond_broadcast is %d\n", rc);
+#endif
+}
+
+static
+void sctp_userland_cond_init(userland_cond_t* cond)
+{
+#if defined (__Userspace_os_Windows)
+	InitializeConditionVariable(cond);
+#else	
+	int rc = pthread_cond_init(cond, NULL);
+	if (rc)
+		SCTP_PRINTF("ERROR; return code from pthread_cond_init is %d\n", rc);
+#endif
+}
+
+static
+void sctp_userland_cond_destroy(userland_cond_t* cond)
+{
+#if defined (__Userspace_os_Windows)
+	DeleteConditionVariable(cond);
+#else	
+	int rc = pthread_cond_destroy(cond);
+	if (rc)
+		SCTP_PRINTF("ERROR; return code from pthread_cond_destroy is %d\n", rc);
+#endif
+}
+#endif
+
 /*
  * Callout/Timer routines for OS that doesn't have them
  */
@@ -73,36 +125,44 @@ uint32_t sctp_get_tick_count(void) {
 	return ret;
 }
 
-/*
- * SCTP_TIMERQ_LOCK protects:
- * - SCTP_BASE_INFO(callqueue)
- * - sctp_os_timer_next: next timer to check
- * - sctp_os_timer_current: current callout callback in progress
- * - sctp_os_timer_current_tid: current callout thread id in progress
- * - sctp_os_timer_waiting: some thread is waiting for callout to complete
- * - sctp_os_timer_wait_ctr: incremented every time a thread wants to wait
- *                           for a callout to complete.
- */
-static sctp_os_timer_t *sctp_os_timer_next = NULL;
-static sctp_os_timer_t *sctp_os_timer_current = NULL;
-static int sctp_os_timer_waiting = 0;
-static int sctp_os_timer_wait_ctr = 0;
-static userland_thread_id_t sctp_os_timer_current_tid;
-
-/*
- * SCTP_TIMERWAIT_LOCK (sctp_os_timerwait_mtx) protects:
- * - sctp_os_timer_wait_cond: waiting for callout to complete
- * - sctp_os_timer_done_ctr: value of "wait_ctr" after triggering "waiting"
- */
-userland_mutex_t sctp_os_timerwait_mtx;
-static userland_cond_t sctp_os_timer_wait_cond;
-static int sctp_os_timer_done_ctr = 0;
-
+int
+sctp_os_timer_compare(sctp_os_timer_t* a, sctp_os_timer_t* b)
+{
+	if (SCTP_UINT32_GT(a->c_time, b->c_time))
+	{
+		return 1;
+	}
+	if (a->c_time == b->c_time)
+	{
+		return 0;
+	}
+	return -1;
+}
 
 void
 sctp_os_timer_init(sctp_os_timer_t *c)
 {
 	memset(c, 0, sizeof(*c));
+	sctp_binary_heap_node_init(&c->heap_node, c);
+#if defined(__Userspace__)
+	sctp_userland_cond_init(&c->c_completion);
+#endif
+}
+
+int sctp_os_timer_is_pending(const sctp_os_timer_t *c)
+{
+	SCTP_TIMERQ_LOCK();
+	const int is_pending = (c->c_state == SCTP_CALLOUT_SCHEDULED);
+	SCTP_TIMERQ_UNLOCK();
+	return is_pending;
+}
+
+int sctp_os_timer_is_active(const sctp_os_timer_t* c)
+{
+	SCTP_TIMERQ_LOCK();
+	const int is_active = !(c->c_state == SCTP_CALLOUT_COMPLETED || c->c_state == SCTP_CALLOUT_NEW);
+	SCTP_TIMERQ_UNLOCK();
+	return is_active;
 }
 
 void
@@ -114,154 +174,197 @@ sctp_os_timer_start(sctp_os_timer_t *c, uint32_t to_ticks, void (*ftn) (void *),
 	    return;
 
 	SCTP_TIMERQ_LOCK();
-	/* check to see if we're rescheduling a timer */
-	if (c == sctp_os_timer_current) {
-		/*
-		 * We're being asked to reschedule a callout which is
-		 * currently in progress.
-		 */
-		if (sctp_os_timer_waiting) {
-			/*
-			 * This callout is already being stopped.
-			 * callout.  Don't reschedule.
-			 */
-			SCTP_TIMERQ_UNLOCK();
-			return;
-		}
+
+	switch (c->c_state)
+	{
+	case SCTP_CALLOUT_CANCEL_REQUESTED:
+	{
+		/* Do not reschedule cancelled callout */
+		break;
+	}
+	case SCTP_CALLOUT_SCHEDULED:
+	{
+		sctp_binary_heap_remove(&SCTP_BASE_INFO(timers_queue), &c->heap_node);
+		break;
+	}
+	case SCTP_CALLOUT_RUNNING:
+	case SCTP_CALLOUT_NEW:
+	case SCTP_CALLOUT_COMPLETED:
+	{
+		if (to_ticks == 0)
+			to_ticks = 1;
+
+		c->c_arg = arg;
+		c->c_state = SCTP_CALLOUT_SCHEDULED;
+		c->c_func = ftn;
+		c->c_time = ticks + to_ticks;
+
+		sctp_binary_heap_push(&SCTP_BASE_INFO(timers_queue), &c->heap_node);
+		break;
+	}
+	default:
+		KASSERT(0, ("Unknown callout state"));
 	}
 
-	if (c->c_flags & SCTP_CALLOUT_PENDING) {
-		if (c == sctp_os_timer_next) {
-			sctp_os_timer_next = TAILQ_NEXT(c, tqe);
-		}
-		TAILQ_REMOVE(&SCTP_BASE_INFO(callqueue), c, tqe);
-		/*
-		 * part of the normal "stop a pending callout" process
-		 * is to clear the CALLOUT_ACTIVE and CALLOUT_PENDING
-		 * flags.  We don't bother since we are setting these
-		 * below and we still hold the lock.
-		 */
-	}
-
-	/*
-	 * We could unlock/splx here and lock/spl at the TAILQ_INSERT_TAIL,
-	 * but there's no point since doing this setup doesn't take much time.
-	 */
-	if (to_ticks == 0)
-		to_ticks = 1;
-
-	c->c_arg = arg;
-	c->c_flags = (SCTP_CALLOUT_ACTIVE | SCTP_CALLOUT_PENDING);
-	c->c_func = ftn;
-	c->c_time = ticks + to_ticks;
-	TAILQ_INSERT_TAIL(&SCTP_BASE_INFO(callqueue), c, tqe);
 	SCTP_TIMERQ_UNLOCK();
 }
+
+
+void
+sctp_os_timer_cancel(sctp_os_timer_t* c)
+{
+	SCTP_TIMERQ_LOCK();
+
+	switch (c->c_state)
+	{
+	case SCTP_CALLOUT_SCHEDULED:
+	{
+		sctp_binary_heap_remove(&SCTP_BASE_INFO(timers_queue), &c->heap_node);
+		c->c_state = SCTP_CALLOUT_COMPLETED;
+		break;
+	}
+	case SCTP_CALLOUT_RUNNING:
+	{
+		c->c_state = SCTP_CALLOUT_CANCEL_REQUESTED;
+		break;
+	}
+	case SCTP_CALLOUT_CANCEL_REQUESTED:
+	case SCTP_CALLOUT_COMPLETED:
+	case SCTP_CALLOUT_NEW:
+	{
+		// nothing to do
+		break;
+	}
+	default:
+	{
+		KASSERT(0, ("Unknown callout state"));
+		break;
+	}
+	}
+
+	SCTP_TIMERQ_UNLOCK();
+}
+
+
+void
+sctp_os_timer_wait_completion(sctp_os_timer_t* c)
+{
+	SCTP_TIMERQ_LOCK();
+
+	userland_thread_id_t current_tid;
+	sctp_userspace_thread_id(&current_tid);
+
+	int retry_condition_wait = 1;
+	do
+	{
+		switch (c->c_state)
+		{
+		case SCTP_CALLOUT_RUNNING:
+		case SCTP_CALLOUT_CANCEL_REQUESTED:
+		case SCTP_CALLOUT_SCHEDULED:
+		{
+			if (current_tid == c->c_executor_id)
+			{
+				// callout tried to wait for completion of itself
+				retry_condition_wait = 0;
+			}
+			else
+			{
+#if defined (__Userspace__)
+				sctp_userland_cond_wait(&c->c_completion, &SCTP_BASE_VAR(timer_mtx));
+#endif
+			}
+			break;
+		}
+		case SCTP_CALLOUT_COMPLETED:
+		case SCTP_CALLOUT_NEW:
+		{
+			retry_condition_wait = 0;
+			break;
+		}
+		default:
+		{
+			KASSERT(0, ("Unknown callout state"));
+			break;
+		}
+		}
+	} while (retry_condition_wait);
+
+	SCTP_TIMERQ_UNLOCK();
+}
+
 
 int
 sctp_os_timer_stop(sctp_os_timer_t *c)
 {
-	int wakeup_cookie;
-
 	SCTP_TIMERQ_LOCK();
-	/*
-	 * Don't attempt to delete a callout that's not on the queue.
-	 */
-	if (!(c->c_flags & SCTP_CALLOUT_PENDING)) {
-		c->c_flags &= ~SCTP_CALLOUT_ACTIVE;
-		if (sctp_os_timer_current != c) {
-			SCTP_TIMERQ_UNLOCK();
-			return (0);
-		} else {
-			/*
-			 * Deleting the callout from the currently running
-			 * callout from the same thread, so just return
-			 */
-			userland_thread_id_t tid;
-			sctp_userspace_thread_id(&tid);
-			if (sctp_userspace_thread_equal(tid,
-						sctp_os_timer_current_tid)) {
-				SCTP_TIMERQ_UNLOCK();
-				return (0);
-			}
 
-			/* need to wait until the callout is finished */
-			sctp_os_timer_waiting = 1;
-			wakeup_cookie = ++sctp_os_timer_wait_ctr;
-			SCTP_TIMERQ_UNLOCK();
-			SCTP_TIMERWAIT_LOCK();
-			/*
-			 * wait only if sctp_handle_tick didn't do a wakeup
-			 * in between the lock dance
-			 */
-			if (wakeup_cookie - sctp_os_timer_done_ctr > 0) {
-#if defined (__Userspace_os_Windows)
-				SleepConditionVariableCS(&sctp_os_timer_wait_cond,
-							 &sctp_os_timerwait_mtx,
-							 INFINITE);
-#else
-				pthread_cond_wait(&sctp_os_timer_wait_cond,
-						  &sctp_os_timerwait_mtx);
-#endif
-			}
-			SCTP_TIMERWAIT_UNLOCK();
-		}
-		return (0);
-	}
-	c->c_flags &= ~(SCTP_CALLOUT_ACTIVE | SCTP_CALLOUT_PENDING);
-	if (c == sctp_os_timer_next) {
-		sctp_os_timer_next = TAILQ_NEXT(c, tqe);
-	}
-	TAILQ_REMOVE(&SCTP_BASE_INFO(callqueue), c, tqe);
+	sctp_os_timer_cancel(c);
+	sctp_os_timer_wait_completion(c);
+
 	SCTP_TIMERQ_UNLOCK();
 	return (1);
 }
 
+
 void
 sctp_handle_tick(uint32_t elapsed_ticks)
 {
-	sctp_os_timer_t *c;
-	void (*c_func)(void *);
-	void *c_arg;
-	int wakeup_cookie;
-
 	SCTP_TIMERQ_LOCK();
 	/* update our tick count */
 	ticks += elapsed_ticks;
-	c = TAILQ_FIRST(&SCTP_BASE_INFO(callqueue));
-	while (c) {
-		if (SCTP_UINT32_GE(ticks, c->c_time)) {
-			sctp_os_timer_next = TAILQ_NEXT(c, tqe);
-			TAILQ_REMOVE(&SCTP_BASE_INFO(callqueue), c, tqe);
-			c_func = c->c_func;
-			c_arg = c->c_arg;
-			c->c_flags &= ~SCTP_CALLOUT_PENDING;
-			sctp_os_timer_current = c;
-			sctp_userspace_thread_id(&sctp_os_timer_current_tid);
+
+	sctp_binary_heap_t* heap = &SCTP_BASE_INFO(timers_queue);
+	sctp_binary_heap_node_t* node = NULL;
+	while (0 == sctp_binary_heap_peek(heap, &node))
+	{
+		sctp_os_timer_t* t = ((sctp_os_timer_t*)node->data);
+		if (!SCTP_UINT32_GE(sctp_get_tick_count(), t->c_time))
+		{
+			// Earliest timer is not ready yet 
+			break;
+		}
+		sctp_binary_heap_remove(heap, node);
+
+		if (t->c_state == SCTP_CALLOUT_SCHEDULED)
+		{
+			userland_thread_id_t tid;
+			sctp_userspace_thread_id(&tid);
+			t->c_executor_id = tid;
+			t->c_state = SCTP_CALLOUT_RUNNING;
+
+			void (* const c_func)(void*) = t->c_func;
+			void* c_arg = t->c_arg;
 			SCTP_TIMERQ_UNLOCK();
 			c_func(c_arg);
 			SCTP_TIMERQ_LOCK();
-			sctp_os_timer_current = NULL;
-			if (sctp_os_timer_waiting) {
-				wakeup_cookie = sctp_os_timer_wait_ctr;
-				SCTP_TIMERQ_UNLOCK();
-				SCTP_TIMERWAIT_LOCK();
-#if defined (__Userspace_os_Windows)
-				WakeAllConditionVariable(&sctp_os_timer_wait_cond);
-#else
-				pthread_cond_broadcast(&sctp_os_timer_wait_cond);
-#endif
-				sctp_os_timer_done_ctr = wakeup_cookie;
-				SCTP_TIMERWAIT_UNLOCK();
-				SCTP_TIMERQ_LOCK();
-				sctp_os_timer_waiting = 0;
-			}
-			c = sctp_os_timer_next;
-		} else {
-			c = TAILQ_NEXT(c, tqe);
+
+			t->c_executor_id = 0;
 		}
+
+		switch (t->c_state)
+		{
+		case SCTP_CALLOUT_RUNNING:
+		case SCTP_CALLOUT_CANCEL_REQUESTED:
+		{
+			t->c_state = SCTP_CALLOUT_COMPLETED;
+#if defined(__Userspace__)
+			sctp_userland_cond_signal(&t->c_completion);
+#endif
+			break;
+		}
+		case SCTP_CALLOUT_SCHEDULED:
+			// nothing to do, timer is rescheduled
+			break;
+		case SCTP_CALLOUT_COMPLETED:
+		case SCTP_CALLOUT_NEW:
+		default:
+			KASSERT(0, ("Unexpected timer state"));
+			break;
+		}
+
 	}
-	sctp_os_timer_next = NULL;
+
 	SCTP_TIMERQ_UNLOCK();
 }
 
@@ -309,15 +412,6 @@ sctp_start_timer(void)
 	 * here, it is being done in sctp_pcb_init()
 	 */
 	int rc;
-
-#if defined(__Userspace_os_Windows)
-	InitializeConditionVariable(&sctp_os_timer_wait_cond);
-#else
-	rc = pthread_cond_init(&sctp_os_timer_wait_cond, NULL);
-	if (rc)
-		SCTP_PRINTF("ERROR; return code from pthread_cond_init is %d\n", rc);
-#endif
-
 	rc = sctp_userspace_thread_create(&SCTP_BASE_VAR(timer_thread), user_sctp_timer_iterate);
 	if (rc) {
 		SCTP_PRINTF("ERROR; return code from sctp_thread_create() is %d\n", rc);

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -367,8 +367,11 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 			uint32_t c_time = c->c_time;
 			(void)c_time; // workaround for unused variable warning
 			c->c_flags &= ~SCTP_CALLOUT_PENDING;
-			sctp_os_timer_current = c;
 			sctp_userspace_thread_id(&sctp_os_timer_current_tid);
+			sctp_os_timer_current = c;
+#if defined(__Userspace__)
+			sctp_userland_cond_signal(&sctp_os_timer_current_changed);
+#endif
 			SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": callout %p with to_ticks = %" PRIu32 " is about to execute\n", 
 				__func__, ticks, sctp_os_timer_current, c_time);
 			SCTP_TIMERQ_UNLOCK();

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -140,11 +140,11 @@ sctp_os_timer_cancel_impl(sctp_os_timer_t* c) {
 		c->c_flags &= ~SCTP_CALLOUT_PENDING;
 		sctp_binary_heap_remove(&SCTP_BASE_INFO(timers_queue), &c->heap_node);
 		SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": cancelled pending callout %p\n",
-			__func__, ticks);
+			__func__, ticks, c);
 		return (1);
 	}
 	SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": cancelled non-pending callout %p\n",
-		__func__, ticks);
+		__func__, ticks, c);
 	return (0);
 }
 

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -296,9 +296,7 @@ void
 sctp_os_timer_cancel(sctp_os_timer_t* c)
 {
 	SCTP_TIMERQ_LOCK();
-
 	sctp_os_timer_cancel_impl(c);
-
 	SCTP_TIMERQ_UNLOCK();
 }
 
@@ -307,9 +305,7 @@ void
 sctp_os_timer_wait_completion(sctp_os_timer_t* c)
 {
 	SCTP_TIMERQ_LOCK();
-
 	sctp_os_timer_wait_completion_impl(c);
-
 	SCTP_TIMERQ_UNLOCK();
 }
 
@@ -318,10 +314,8 @@ int
 sctp_os_timer_stop(sctp_os_timer_t *c)
 {
 	SCTP_TIMERQ_LOCK();
-
 	sctp_os_timer_cancel_impl(c);
 	sctp_os_timer_wait_completion_impl(c);
-
 	SCTP_TIMERQ_UNLOCK();
 	return (1);
 }

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -334,7 +334,7 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 	while (0 == sctp_binary_heap_peek(heap, &node))
 	{
 		sctp_os_timer_t* t = ((sctp_os_timer_t*)node->data);
-		if (!SCTP_UINT32_GE(sctp_get_tick_count(), t->c_time))
+		if (!SCTP_UINT32_GE(ticks, t->c_time))
 		{
 			// Earliest timer is not ready yet 
 			break;

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -371,6 +371,10 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 			SCTP_TIMERQ_UNLOCK();
 			c_func(c_arg);
 			SCTP_TIMERQ_LOCK();
+			/* sctp_os_timer_current pointer MUST NOT be dereferenced
+			 * after this point, because it's memory might be already
+			 * freed by c_func or something else.
+			 */
 			SCTPDBG(SCTP_DEBUG_TIMER2, "%s: now=%" PRIu32 ": callout %p with to_ticks = %" PRIu32 " is executed\n", 
 				__func__, ticks, sctp_os_timer_current, c_time);
 			sctp_os_timer_current = NULL;

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -79,7 +79,7 @@ uint32_t sctp_get_tick_count(void) {
  * - SCTP_BASE_INFO(timers_queue)
  * - sctp_os_timer_current: current callout callback in progress
  * - sctp_os_timer_current_tid: current callout thread id in progress
- * - sctp_os_timer_current_changed: conditional variable signaled when 
+ * - sctp_os_timer_current_changed: conditional variable signaled when
  *                                  current callout pointer is changed
  */
 static sctp_os_timer_t *sctp_os_timer_current = NULL;

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -59,7 +59,7 @@
 #if defined(__Userspace__)
 static void
 sctp_userland_cond_wait(userland_cond_t* cond,
-						userland_mutex_t* mtx) {
+                        userland_mutex_t* mtx) {
 #if defined(__Userspace_os_Windows)
 	const DWORD timeoutMillis = 20 * 1000;
 	const BOOL waited = SleepConditionVariableCS(cond, mtx, timeoutMillis);

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -163,8 +163,7 @@ void
 sctp_os_timer_describe(const sctp_os_timer_t* t,
                        size_t max_len,
                        char* buffer) {
-	snprintf(buffer, max_len, "t=%" PRIu32 ",f=%p,a=%p", t->c_time,
-		(void*)t->c_func, (void*)t->c_arg);
+	snprintf(buffer, max_len, "t=%" PRIu32 ",a=%p", t->c_time, t);
 }
 
 int

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -155,7 +155,7 @@ sctp_os_timer_wait_completion_impl(sctp_os_timer_t* c)
 		case SCTP_CALLOUT_CANCEL_REQUESTED:
 		case SCTP_CALLOUT_SCHEDULED:
 		{
-			if (current_tid == c->c_executor_id)
+			if (sctp_userspace_thread_equal(current_tid, c->c_executor_id))
 			{
 				// callout tried to wait for completion of itself
 				KASSERT(0, ("Deadlock detected: wait for self completion"));

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -265,8 +265,10 @@ sctp_os_timer_start(sctp_os_timer_t *c, uint32_t to_ticks, void (*ftn) (void *),
 	case SCTP_CALLOUT_SCHEDULED:
 	{
 		sctp_binary_heap_remove(&SCTP_BASE_INFO(timers_queue), &c->heap_node);
-		// FALLTHROUGH
+		// Workaround for  -Wimplicit-fallthrough
+		goto SCHEDULE_TIMER;
 	}
+	SCHEDULE_TIMER:
 	case SCTP_CALLOUT_RUNNING:
 	case SCTP_CALLOUT_NEW:
 	case SCTP_CALLOUT_COMPLETED:

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -163,7 +163,7 @@ void
 sctp_os_timer_describe(const sctp_os_timer_t* t,
                        size_t max_len,
                        char* buffer) {
-	snprintf(buffer, max_len, "t=%" PRIu32 ",a=%p", t->c_time, t);
+	snprintf(buffer, max_len, "t=%" PRIu32 ",a=%p", t->c_time, (void*)t);
 }
 
 int

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -363,6 +363,7 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 			void (*c_func)(void*) = c->c_func;
 			void* c_arg = c->c_arg;
 			uint32_t c_time = c->c_time;
+			(void)c_time; // workaround for unused variable warning
 			c->c_flags &= ~SCTP_CALLOUT_PENDING;
 			sctp_os_timer_current = c;
 			sctp_userspace_thread_id(&sctp_os_timer_current_tid);

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -227,6 +227,15 @@ sctp_os_timer_init(sctp_os_timer_t *c)
 #endif
 }
 
+void
+sctp_os_timer_deinit(sctp_os_timer_t* c)
+{
+	KASSERT(!sctp_os_timer_is_active(c), ("Deiniting active timer"));
+#if defined(__Userspace__)
+	sctp_userland_cond_destroy(&c->c_completion);
+#endif
+}
+
 int sctp_os_timer_is_pending(const sctp_os_timer_t *c)
 {
 	SCTP_TIMERQ_LOCK();

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -203,6 +203,11 @@ uint32_t sctp_get_tick_count(void) {
 	return ret;
 }
 
+void sctp_os_timer_describe(const sctp_os_timer_t* t, size_t max_len, char *buffer)
+{
+	snprintf(buffer, max_len, "t=%" PRIu32 ",f=%p,a=%p", t->c_time, (void *)t->c_func, (void *)t->c_arg);
+}
+
 int
 sctp_os_timer_compare(const sctp_os_timer_t * a, const sctp_os_timer_t *b)
 {

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -346,7 +346,6 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 	/* update our tick count */
 	ticks += elapsed_ticks;
 
-	uint32_t timedout_callouts = 0;
 	sctp_binary_heap_t* heap = &SCTP_BASE_INFO(timers_queue);
 	sctp_binary_heap_node_t* node = NULL;
 	while (0 == sctp_binary_heap_peek(heap, &node)) {

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -223,7 +223,6 @@ sctp_os_timer_deactivate(sctp_os_timer_t* c) {
 	SCTP_TIMERQ_UNLOCK();
 }
 
-
 void
 sctp_os_timer_start(sctp_os_timer_t *c, uint32_t to_ticks, void (*ftn) (void *),
                     void *arg)

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -91,6 +91,9 @@ static userland_cond_t sctp_os_timer_current_changed;
 static void
 sctp_userland_cond_wait(userland_cond_t* cond,
                         userland_mutex_t* mtx) {
+	// callee must be robust to spurious wakeups, both because
+	// wakeup could happen due to native API behavior and because
+	// there is indendend timeout for wait.
 #if defined(__Userspace_os_Windows)
 	const DWORD timeoutMillis = 20 * 1000;
 	const BOOL waited = SleepConditionVariableCS(cond, mtx, timeoutMillis);

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -130,6 +130,7 @@ struct sctp_callout {
 };
 typedef struct sctp_callout sctp_os_timer_t;
 
+void sctp_os_timer_describe(const sctp_os_timer_t*, size_t, char *);
 int sctp_os_timer_compare(const sctp_os_timer_t*, const sctp_os_timer_t*);
 void sctp_os_timer_init(sctp_os_timer_t *);
 void sctp_os_timer_deinit(sctp_os_timer_t *);

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -84,9 +84,8 @@ struct sctp_callout {
 	void (*c_func)(void *);	/* function to call */
 	int c_flags;		/* state of this entry */
 #if defined(__Userspace__)
-	userland_cond_t c_completion; /* conditional variable signaled
-									 when timer completes execution */
-	userland_thread_id_t c_executor_id;
+	userland_cond_t c_completion; /* conditional variable signaled when timer completes execution */
+	userland_thread_id_t c_executor_id; /* id of thread executing timer's callback */
 #endif
 };
 typedef struct sctp_callout sctp_os_timer_t;

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -39,7 +39,6 @@ __FBSDID("$FreeBSD$");
 #define _NETINET_SCTP_CALLOUT_
 
 #include "sctp_callout_queue.h"
-#include "sctp_os_userspace.h"
 
 /*
  * NOTE: the following MACROS are required for locking the callout

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -78,6 +78,35 @@ __FBSDID("$FreeBSD$");
 
 uint32_t sctp_get_tick_count(void);
 
+/*
+ * Callout state transitions:
+ * to update it import to http://asciiflow.com/
+ * 
+ *                         cancel
+ *                      +----------+
+ *                      |          |
+ *                  +---+---+      |
+ *                  |  new  +<-----+
+ *                  +---+---+
+ *                      |                 start
+ *                      |     +-------------------------------+
+ *                start |     |                               |
+ *                      v     v                               |
+ *               +------+-----+-+         tick          +-----+-----+
+ *        +----->+  scheduled   +---------------------->+  running  |
+ *        |      +------+-------+                       ++----+-----+
+ *        |             |                                |    |
+ *        |             |             tick (done)        |    |
+ * start  |      cancel |     +--------------------------+    |  cancel
+ *        |             |     |                               |
+ *        |             v     v                               v
+ *        |      +------+-----++     tick (done)     +--------+-----------+
+ *        +------+  completed  +<--------------------+  cancel requested  +-----+
+ *               +-+-----------+                     +---------+----------+     |
+ *                 |         ^                                 ^                |
+ *                 +---------+                                 +----------------+
+ *                   cancel                                       start/cancel
+*/
 enum sctp_callout_state
 {
 	SCTP_CALLOUT_NEW = 0, /* default state of a callout */

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -91,11 +91,10 @@ typedef struct sctp_callout sctp_os_timer_t;
 
 void sctp_os_timer_describe(const sctp_os_timer_t*, size_t, char*);
 int sctp_os_timer_compare(const sctp_os_timer_t*, const sctp_os_timer_t*);
-void sctp_os_timer_init(sctp_os_timer_t*);
 int sctp_os_timer_is_pending(const sctp_os_timer_t*);
 int sctp_os_timer_is_active(const sctp_os_timer_t*);
 void sctp_os_timer_deactivate(sctp_os_timer_t*);
-
+void sctp_os_timer_init(sctp_os_timer_t*);
 void sctp_os_timer_start(sctp_os_timer_t *, uint32_t, void (*)(void *), void *);
 int sctp_os_timer_cancel(sctp_os_timer_t*);
 int sctp_os_timer_stop(sctp_os_timer_t *);

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -93,6 +93,7 @@ typedef struct sctp_callout sctp_os_timer_t;
 #define	SCTP_CALLOUT_ACTIVE	0x0002	/* callout is currently active */
 #define	SCTP_CALLOUT_PENDING	0x0004	/* callout is waiting for timeout */
 #define	SCTP_CALLOUT_EXECUTING	0x0008	/* callout is currently executing */
+#define	SCTP_CALLOUT_CANCELLED	0x0010	/* callout is cancelled */
 
 void sctp_os_timer_describe(const sctp_os_timer_t*, size_t, char*);
 int sctp_os_timer_compare(const sctp_os_timer_t*, const sctp_os_timer_t*);

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -130,7 +130,7 @@ struct sctp_callout {
 };
 typedef struct sctp_callout sctp_os_timer_t;
 
-int sctp_os_timer_compare(sctp_os_timer_t*, sctp_os_timer_t*);
+int sctp_os_timer_compare(const sctp_os_timer_t*, const sctp_os_timer_t*);
 void sctp_os_timer_init(sctp_os_timer_t *tmr);
 int sctp_os_timer_is_pending(const sctp_os_timer_t*);
 int sctp_os_timer_is_active(const sctp_os_timer_t*);

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -38,9 +38,6 @@ __FBSDID("$FreeBSD$");
 #ifndef _NETINET_SCTP_CALLOUT_
 #define _NETINET_SCTP_CALLOUT_
 
-#include "sctp_callout_queue.h"
-#include "sctp_os_userspace.h"
-
 /*
  * NOTE: the following MACROS are required for locking the callout
  * queue along with a lock/mutex in the OS specific headers and
@@ -55,6 +52,7 @@ __FBSDID("$FreeBSD$");
 
 #define SCTP_TICKS_PER_FASTTIMO 20	/* called about every 20ms */
 
+extern userland_mutex_t sctp_os_timerwait_mtx;
 
 #if defined(__Userspace__)
 #if defined(__Userspace_os_Windows)
@@ -63,93 +61,58 @@ __FBSDID("$FreeBSD$");
 #define SCTP_TIMERQ_LOCK_INIT()     InitializeCriticalSection(&SCTP_BASE_VAR(timer_mtx))
 #define SCTP_TIMERQ_LOCK_DESTROY()  DeleteCriticalSection(&SCTP_BASE_VAR(timer_mtx))
 
-
+#define SCTP_TIMERWAIT_LOCK()          EnterCriticalSection(&sctp_os_timerwait_mtx)
+#define SCTP_TIMERWAIT_UNLOCK()        LeaveCriticalSection(&sctp_os_timerwait_mtx)
+#define SCTP_TIMERWAIT_LOCK_INIT()     InitializeCriticalSection(&sctp_os_timerwait_mtx)
+#define SCTP_TIMERWAIT_LOCK_DESTROY()  DeleteCriticalSection(&sctp_os_timerwait_mtx)
 #else
 #ifdef INVARIANTS
 #define SCTP_TIMERQ_LOCK()          KASSERT(pthread_mutex_lock(&SCTP_BASE_VAR(timer_mtx)) == 0, ("%s: timer_mtx already locked", __func__))
 #define SCTP_TIMERQ_UNLOCK()        KASSERT(pthread_mutex_unlock(&SCTP_BASE_VAR(timer_mtx)) == 0, ("%s: timer_mtx not locked", __func__))
+#define SCTP_TIMERWAIT_LOCK()       KASSERT(pthread_mutex_lock(&sctp_os_timerwait_mtx) == 0, ("%s: sctp_os_timerwait_mtx already locked", __func__))
+#define SCTP_TIMERWAIT_UNLOCK()	    KASSERT(pthread_mutex_unlock(&sctp_os_timerwait_mtx) == 0, ("%s: sctp_os_timerwait_mtx not locked", __func__))
 #else
 #define SCTP_TIMERQ_LOCK()          (void)pthread_mutex_lock(&SCTP_BASE_VAR(timer_mtx))
 #define SCTP_TIMERQ_UNLOCK()        (void)pthread_mutex_unlock(&SCTP_BASE_VAR(timer_mtx))
+#define SCTP_TIMERWAIT_LOCK()       (void)pthread_mutex_lock(&sctp_os_timerwait_mtx)
+#define SCTP_TIMERWAIT_UNLOCK()     (void)pthread_mutex_unlock(&sctp_os_timerwait_mtx)
 #endif
 #define SCTP_TIMERQ_LOCK_INIT()     (void)pthread_mutex_init(&SCTP_BASE_VAR(timer_mtx), &SCTP_BASE_VAR(mtx_attr))
 #define SCTP_TIMERQ_LOCK_DESTROY()  (void)pthread_mutex_destroy(&SCTP_BASE_VAR(timer_mtx))
+#define SCTP_TIMERWAIT_LOCK_INIT()     (void)pthread_mutex_init(&sctp_os_timerwait_mtx, &SCTP_BASE_VAR(mtx_attr))
+#define SCTP_TIMERWAIT_LOCK_DESTROY()  (void)pthread_mutex_destroy(&sctp_os_timerwait_mtx)
 #endif
 #endif
 
 uint32_t sctp_get_tick_count(void);
 
-/*
- * Callout state transitions:
- * to update it import to http://asciiflow.com/
- * 
- *                         cancel
- *                      +----------+
- *                      |          |
- *                  +---+---+      |
- *                  |  new  +<-----+
- *                  +---+---+
- *                      |                 start
- *                      |     +-------------------------------+
- *                start |     |                               |
- *                      v     v                               |
- *               +------+-----+-+         tick          +-----+-----+
- *        +----->+  scheduled   +---------------------->+  running  |
- *        |      +------+-------+                       ++----+-----+
- *        |             |                                |    |
- *        |             |             tick (done)        |    |
- * start  |      cancel |     +--------------------------+    |  cancel
- *        |             |     |                               |
- *        |             v     v                               v
- *        |      +------+-----++     tick (done)     +--------+-----------+
- *        +------+  completed  +<--------------------+  cancel requested  +-----+
- *               +-+-----------+                     +---------+----------+     |
- *                 |         ^                                 ^                |
- *                 +---------+                                 +----------------+
- *                   cancel                                       start/cancel
-*/
-enum sctp_callout_state
-{
-	SCTP_CALLOUT_NEW = 0, /* default state of a callout */
-	SCTP_CALLOUT_SCHEDULED = 1, /* callout has been scheduled to execution */
-	SCTP_CALLOUT_RUNNING = 2, /* callout executing it's callback right now */
-	SCTP_CALLOUT_CANCEL_REQUESTED = 3, /* callout cancel is requested */
-	SCTP_CALLOUT_COMPLETED = 4, /* callout executed it's callback or cancelled*/
-};
+TAILQ_HEAD(calloutlist, sctp_callout);
 
 struct sctp_callout {
-	sctp_binary_heap_node_t heap_node;
+	TAILQ_ENTRY(sctp_callout) tqe;
 	uint32_t c_time;		/* ticks to the event */
 	void *c_arg;		/* function argument */
 	void (*c_func)(void *);	/* function to call */
-	enum sctp_callout_state c_state;		/* state of this entry */
-#if defined(__Userspace__)
-	userland_cond_t c_completion;
-	userland_thread_id_t c_executor_id;
-#endif
+	int c_flags;		/* state of this entry */
 };
 typedef struct sctp_callout sctp_os_timer_t;
 
-void sctp_os_timer_describe(const sctp_os_timer_t*, size_t, char *);
-int sctp_os_timer_compare(const sctp_os_timer_t*, const sctp_os_timer_t*);
-void sctp_os_timer_init(sctp_os_timer_t *);
-void sctp_os_timer_deinit(sctp_os_timer_t *);
-int sctp_os_timer_is_pending(const sctp_os_timer_t*);
-int sctp_os_timer_is_active(const sctp_os_timer_t*);
+#define	SCTP_CALLOUT_ACTIVE	0x0002	/* callout is currently active */
+#define	SCTP_CALLOUT_PENDING	0x0004	/* callout is waiting for timeout */
+
+void sctp_os_timer_init(sctp_os_timer_t *tmr);
 void sctp_os_timer_start(sctp_os_timer_t *, uint32_t, void (*)(void *), void *);
-void sctp_os_timer_cancel(sctp_os_timer_t*);
-void sctp_os_timer_wait_completion(sctp_os_timer_t*);
 int sctp_os_timer_stop(sctp_os_timer_t *);
 void sctp_handle_tick(uint32_t);
 
 #define SCTP_OS_TIMER_INIT	sctp_os_timer_init
-#define SCTP_OS_TIMER_DEINIT sctp_os_timer_deinit
 #define SCTP_OS_TIMER_START	sctp_os_timer_start
-#define SCTP_OS_TIMER_STOP	sctp_os_timer_cancel
-#define SCTP_OS_TIMER_STOP_DRAIN sctp_os_timer_stop
-#define	SCTP_OS_TIMER_PENDING(tmr) sctp_os_timer_is_pending(tmr)
-#define	SCTP_OS_TIMER_ACTIVE(tmr) sctp_os_timer_is_active(tmr)
-#define	SCTP_OS_TIMER_DEACTIVATE(tmr) sctp_os_timer_cancel(tmr)
+#define SCTP_OS_TIMER_STOP	sctp_os_timer_stop
+/* MT FIXME: Is the following correct? */
+#define SCTP_OS_TIMER_STOP_DRAIN SCTP_OS_TIMER_STOP
+#define	SCTP_OS_TIMER_PENDING(tmr) ((tmr)->c_flags & SCTP_CALLOUT_PENDING)
+#define	SCTP_OS_TIMER_ACTIVE(tmr) ((tmr)->c_flags & SCTP_CALLOUT_ACTIVE)
+#define	SCTP_OS_TIMER_DEACTIVATE(tmr) ((tmr)->c_flags &= ~SCTP_CALLOUT_ACTIVE)
 
 #if defined(__Userspace__)
 void sctp_start_timer(void);

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -142,9 +142,8 @@ void sctp_handle_tick(uint32_t);
 
 #define SCTP_OS_TIMER_INIT	sctp_os_timer_init
 #define SCTP_OS_TIMER_START	sctp_os_timer_start
-#define SCTP_OS_TIMER_STOP	sctp_os_timer_stop
-/* MT FIXME: Is the following correct? */
-#define SCTP_OS_TIMER_STOP_DRAIN SCTP_OS_TIMER_STOP
+#define SCTP_OS_TIMER_STOP	sctp_os_timer_cancel
+#define SCTP_OS_TIMER_STOP_DRAIN sctp_os_timer_stop
 #define	SCTP_OS_TIMER_PENDING(tmr) sctp_os_timer_is_pending(tmr)
 #define	SCTP_OS_TIMER_ACTIVE(tmr) sctp_os_timer_is_active(tmr)
 #define	SCTP_OS_TIMER_DEACTIVATE(tmr) sctp_os_timer_cancel(tmr)

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -39,6 +39,7 @@ __FBSDID("$FreeBSD$");
 #define _NETINET_SCTP_CALLOUT_
 
 #include "sctp_callout_queue.h"
+#include "sctp_os_userspace.h"
 
 /*
  * NOTE: the following MACROS are required for locking the callout

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -83,22 +83,16 @@ struct sctp_callout {
 	void *c_arg;		/* function argument */
 	void (*c_func)(void *);	/* function to call */
 	int c_flags;		/* state of this entry */
-#if defined(__Userspace__)
-	userland_cond_t c_completion; /* conditional variable signaled when timer completes execution */
-	userland_thread_id_t c_executor_id; /* id of thread executing timer's callback */
-#endif
 };
 typedef struct sctp_callout sctp_os_timer_t;
 
 #define	SCTP_CALLOUT_ACTIVE	0x0002	/* callout is currently active */
 #define	SCTP_CALLOUT_PENDING	0x0004	/* callout is waiting for timeout */
-#define	SCTP_CALLOUT_EXECUTING	0x0008	/* callout is currently executing */
-#define	SCTP_CALLOUT_CANCELLED	0x0010	/* callout is cancelled */
+#define	SCTP_CALLOUT_CANCELLED	0x0008	/* callout is cancelled */
 
 void sctp_os_timer_describe(const sctp_os_timer_t*, size_t, char*);
 int sctp_os_timer_compare(const sctp_os_timer_t*, const sctp_os_timer_t*);
 void sctp_os_timer_init(sctp_os_timer_t*);
-void sctp_os_timer_deinit(sctp_os_timer_t*);
 int sctp_os_timer_is_pending(const sctp_os_timer_t*);
 int sctp_os_timer_is_active(const sctp_os_timer_t*);
 void sctp_os_timer_deactivate(sctp_os_timer_t*);
@@ -109,7 +103,6 @@ int sctp_os_timer_stop(sctp_os_timer_t *);
 void sctp_handle_tick(uint32_t);
 
 #define SCTP_OS_TIMER_INIT	sctp_os_timer_init
-#define SCTP_OS_TIMER_DEINIT sctp_os_timer_deinit
 #define SCTP_OS_TIMER_START	sctp_os_timer_start
 #define SCTP_OS_TIMER_STOP sctp_os_timer_cancel
 #define SCTP_OS_TIMER_STOP_DRAIN sctp_os_timer_stop

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -38,6 +38,8 @@ __FBSDID("$FreeBSD$");
 #ifndef _NETINET_SCTP_CALLOUT_
 #define _NETINET_SCTP_CALLOUT_
 
+#include "sctp_callout_queue.h"
+
 /*
  * NOTE: the following MACROS are required for locking the callout
  * queue along with a lock/mutex in the OS specific headers and
@@ -52,7 +54,6 @@ __FBSDID("$FreeBSD$");
 
 #define SCTP_TICKS_PER_FASTTIMO 20	/* called about every 20ms */
 
-extern userland_mutex_t sctp_os_timerwait_mtx;
 
 #if defined(__Userspace__)
 #if defined(__Userspace_os_Windows)
@@ -61,47 +62,51 @@ extern userland_mutex_t sctp_os_timerwait_mtx;
 #define SCTP_TIMERQ_LOCK_INIT()     InitializeCriticalSection(&SCTP_BASE_VAR(timer_mtx))
 #define SCTP_TIMERQ_LOCK_DESTROY()  DeleteCriticalSection(&SCTP_BASE_VAR(timer_mtx))
 
-#define SCTP_TIMERWAIT_LOCK()          EnterCriticalSection(&sctp_os_timerwait_mtx)
-#define SCTP_TIMERWAIT_UNLOCK()        LeaveCriticalSection(&sctp_os_timerwait_mtx)
-#define SCTP_TIMERWAIT_LOCK_INIT()     InitializeCriticalSection(&sctp_os_timerwait_mtx)
-#define SCTP_TIMERWAIT_LOCK_DESTROY()  DeleteCriticalSection(&sctp_os_timerwait_mtx)
+
 #else
 #ifdef INVARIANTS
 #define SCTP_TIMERQ_LOCK()          KASSERT(pthread_mutex_lock(&SCTP_BASE_VAR(timer_mtx)) == 0, ("%s: timer_mtx already locked", __func__))
 #define SCTP_TIMERQ_UNLOCK()        KASSERT(pthread_mutex_unlock(&SCTP_BASE_VAR(timer_mtx)) == 0, ("%s: timer_mtx not locked", __func__))
-#define SCTP_TIMERWAIT_LOCK()       KASSERT(pthread_mutex_lock(&sctp_os_timerwait_mtx) == 0, ("%s: sctp_os_timerwait_mtx already locked", __func__))
-#define SCTP_TIMERWAIT_UNLOCK()	    KASSERT(pthread_mutex_unlock(&sctp_os_timerwait_mtx) == 0, ("%s: sctp_os_timerwait_mtx not locked", __func__))
 #else
 #define SCTP_TIMERQ_LOCK()          (void)pthread_mutex_lock(&SCTP_BASE_VAR(timer_mtx))
 #define SCTP_TIMERQ_UNLOCK()        (void)pthread_mutex_unlock(&SCTP_BASE_VAR(timer_mtx))
-#define SCTP_TIMERWAIT_LOCK()       (void)pthread_mutex_lock(&sctp_os_timerwait_mtx)
-#define SCTP_TIMERWAIT_UNLOCK()     (void)pthread_mutex_unlock(&sctp_os_timerwait_mtx)
 #endif
 #define SCTP_TIMERQ_LOCK_INIT()     (void)pthread_mutex_init(&SCTP_BASE_VAR(timer_mtx), &SCTP_BASE_VAR(mtx_attr))
 #define SCTP_TIMERQ_LOCK_DESTROY()  (void)pthread_mutex_destroy(&SCTP_BASE_VAR(timer_mtx))
-#define SCTP_TIMERWAIT_LOCK_INIT()     (void)pthread_mutex_init(&sctp_os_timerwait_mtx, &SCTP_BASE_VAR(mtx_attr))
-#define SCTP_TIMERWAIT_LOCK_DESTROY()  (void)pthread_mutex_destroy(&sctp_os_timerwait_mtx)
 #endif
 #endif
 
 uint32_t sctp_get_tick_count(void);
 
-TAILQ_HEAD(calloutlist, sctp_callout);
+enum sctp_callout_state
+{
+	SCTP_CALLOUT_NEW = 0, /* default state of a callout */
+	SCTP_CALLOUT_SCHEDULED = 1, /* callout has been scheduled to execution */
+	SCTP_CALLOUT_RUNNING = 2, /* callout executing it's callback right now */
+	SCTP_CALLOUT_CANCEL_REQUESTED = 3, /* callout cancel is requested */
+	SCTP_CALLOUT_COMPLETED = 4, /* callout executed it's callback or cancelled*/
+};
 
 struct sctp_callout {
-	TAILQ_ENTRY(sctp_callout) tqe;
+	sctp_binary_heap_node_t heap_node;
 	uint32_t c_time;		/* ticks to the event */
 	void *c_arg;		/* function argument */
 	void (*c_func)(void *);	/* function to call */
-	int c_flags;		/* state of this entry */
+	enum sctp_callout_state c_state;		/* state of this entry */
+#if defined(__Userspace__)
+	userland_cond_t c_completion;
+	userland_thread_id_t c_executor_id;
+#endif
 };
 typedef struct sctp_callout sctp_os_timer_t;
 
-#define	SCTP_CALLOUT_ACTIVE	0x0002	/* callout is currently active */
-#define	SCTP_CALLOUT_PENDING	0x0004	/* callout is waiting for timeout */
-
+int sctp_os_timer_compare(sctp_os_timer_t*, sctp_os_timer_t*);
 void sctp_os_timer_init(sctp_os_timer_t *tmr);
+int sctp_os_timer_is_pending(const sctp_os_timer_t*);
+int sctp_os_timer_is_active(const sctp_os_timer_t*);
 void sctp_os_timer_start(sctp_os_timer_t *, uint32_t, void (*)(void *), void *);
+void sctp_os_timer_cancel(sctp_os_timer_t*);
+void sctp_os_timer_wait_completion(sctp_os_timer_t*);
 int sctp_os_timer_stop(sctp_os_timer_t *);
 void sctp_handle_tick(uint32_t);
 
@@ -110,9 +115,9 @@ void sctp_handle_tick(uint32_t);
 #define SCTP_OS_TIMER_STOP	sctp_os_timer_stop
 /* MT FIXME: Is the following correct? */
 #define SCTP_OS_TIMER_STOP_DRAIN SCTP_OS_TIMER_STOP
-#define	SCTP_OS_TIMER_PENDING(tmr) ((tmr)->c_flags & SCTP_CALLOUT_PENDING)
-#define	SCTP_OS_TIMER_ACTIVE(tmr) ((tmr)->c_flags & SCTP_CALLOUT_ACTIVE)
-#define	SCTP_OS_TIMER_DEACTIVATE(tmr) ((tmr)->c_flags &= ~SCTP_CALLOUT_ACTIVE)
+#define	SCTP_OS_TIMER_PENDING(tmr) sctp_os_timer_is_pending(tmr)
+#define	SCTP_OS_TIMER_ACTIVE(tmr) sctp_os_timer_is_active(tmr)
+#define	SCTP_OS_TIMER_DEACTIVATE(tmr) sctp_os_timer_cancel(tmr)
 
 #if defined(__Userspace__)
 void sctp_start_timer(void);

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -131,7 +131,8 @@ struct sctp_callout {
 typedef struct sctp_callout sctp_os_timer_t;
 
 int sctp_os_timer_compare(const sctp_os_timer_t*, const sctp_os_timer_t*);
-void sctp_os_timer_init(sctp_os_timer_t *tmr);
+void sctp_os_timer_init(sctp_os_timer_t *);
+void sctp_os_timer_deinit(sctp_os_timer_t *);
 int sctp_os_timer_is_pending(const sctp_os_timer_t*);
 int sctp_os_timer_is_active(const sctp_os_timer_t*);
 void sctp_os_timer_start(sctp_os_timer_t *, uint32_t, void (*)(void *), void *);
@@ -141,6 +142,7 @@ int sctp_os_timer_stop(sctp_os_timer_t *);
 void sctp_handle_tick(uint32_t);
 
 #define SCTP_OS_TIMER_INIT	sctp_os_timer_init
+#define SCTP_OS_TIMER_DEINIT sctp_os_timer_deinit
 #define SCTP_OS_TIMER_START	sctp_os_timer_start
 #define SCTP_OS_TIMER_STOP	sctp_os_timer_cancel
 #define SCTP_OS_TIMER_STOP_DRAIN sctp_os_timer_stop

--- a/usrsctplib/netinet/sctp_callout_queue.c
+++ b/usrsctplib/netinet/sctp_callout_queue.c
@@ -724,8 +724,9 @@ sctp_binary_heap_node_print(sctp_binary_heap_node_t *node, uint32_t space)
 	}
 	if (node->heap->data_visualizer != NULL) 
 	{
-		char vis[10] = {0};
-		node->heap->data_visualizer(node->data, sizeof(vis), vis);
+		char vis[11] = {0};
+		node->heap->data_visualizer(node->data, sizeof(vis) - 1, vis);
+		vis[sizeof(vis)-1] = 0; 
 		printf("%s\n", vis); 
 	}
 	else 

--- a/usrsctplib/netinet/sctp_callout_queue.c
+++ b/usrsctplib/netinet/sctp_callout_queue.c
@@ -1,0 +1,655 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2019, by https://github.com/sctplab. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * a) Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * b) Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *
+ * c) Neither the name of Cisco Systems, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "sctp_callout_queue.h"
+#include "user_environment.h"
+#include "sctp_os_userspace.h"
+#include "sctp_pcb.h"
+
+#include <inttypes.h>
+
+#if defined(SCTP_DEBUG)
+//#define SCTP_BINARY_HEAP_VERIFY_MUTATE_FUNCTIONS
+#endif
+
+
+void
+sctp_binary_heap_node_swap_nodes(
+	sctp_binary_heap_t*,
+	sctp_binary_heap_node_t*,
+	sctp_binary_heap_node_t*);
+
+
+void
+sctp_binary_heap_node_swap_non_adjacent(
+	sctp_binary_heap_t*,
+	sctp_binary_heap_node_t*,
+	sctp_binary_heap_node_t*);
+
+
+void
+sctp_binary_heap_node_swap_with_parent(
+	sctp_binary_heap_t*,
+	sctp_binary_heap_node_t*);
+
+
+void
+sctp_binary_heap_node_verify(
+	const sctp_binary_heap_t*,
+	const sctp_binary_heap_node_t*);
+
+
+static size_t
+sctp_binary_heap_node_parent_index(size_t index)
+{
+	return (index - 1) / 2;
+}
+
+
+static size_t
+sctp_binary_heap_node_count_descendants(const sctp_binary_heap_node_t* node)
+{
+	if (node == NULL)
+	{
+		return 0;
+	}
+	return 1
+		+ sctp_binary_heap_node_count_descendants(node->left)
+		+ sctp_binary_heap_node_count_descendants(node->right);
+}
+
+
+void
+sctp_binary_heap_node_get_traverse_path_from_index(
+	size_t index, 
+	size_t* out_path, 
+	uint8_t* out_depth)
+{
+	size_t path = 0;
+	uint8_t depth = 0;
+	size_t parent = index;
+	while (parent != 0)
+	{
+		path = path << 1;
+		path |= (parent % 2 == 0 ? 1 : 0);
+		parent = sctp_binary_heap_node_parent_index(parent);
+		depth++;
+	}
+	*out_path = path;
+	*out_depth = depth;
+}
+
+
+int
+sctp_binary_heap_get_node_by_index(
+	sctp_binary_heap_t* heap,
+	size_t index,
+	sctp_binary_heap_node_t **out_parent,
+	sctp_binary_heap_node_t ***out_node)
+{
+	if (out_parent == NULL || out_node == NULL || index > heap->size)
+	{
+		return -1;
+	}
+
+	size_t path = 0;
+	uint8_t depth = 0;
+	sctp_binary_heap_node_get_traverse_path_from_index(index, &path, &depth);
+
+	sctp_binary_heap_node_t *parent = NULL, **node = &heap->root;
+	for (uint8_t i = 0; i < depth; i++)
+	{
+		parent = *node;
+		if (path & (((size_t)1) << i))
+		{
+			node = &(*node)->right;
+		}
+		else
+		{
+			node = &(*node)->left;
+		}
+	}
+	*out_parent = parent;
+	*out_node = node;
+	return 0;
+}
+
+
+void
+sctp_binary_heap_init(
+	sctp_binary_heap_t* heap,
+	sctp_binary_heap_node_data_comparer comparer)
+{
+	memset(heap, 0, sizeof(*heap));
+	heap->comparer = comparer;
+}
+
+
+void
+sctp_binary_heap_node_init(
+	sctp_binary_heap_node_t* node,
+	void* data)
+{
+	memset(node, 0, sizeof(*node));
+	node->data = data;
+}
+
+
+size_t sctp_binary_heap_size(
+	const sctp_binary_heap_t* heap)
+{
+	return heap->size;
+}
+
+
+int
+sctp_binary_heap_contains_node(
+	const sctp_binary_heap_t* heap,
+	const sctp_binary_heap_node_t* node)
+{
+	return heap == node->heap;
+}
+
+
+void
+sctp_binary_heap_remove(
+	sctp_binary_heap_t* heap,
+	sctp_binary_heap_node_t* node)
+{
+	if (heap != node->heap)
+	{
+		KASSERT(0, ("Node's heap is other than heaps"));
+		return;
+	}
+
+	heap->size -= 1;
+	if (heap->size > 0)
+	{
+		sctp_binary_heap_node_t* parent;
+		sctp_binary_heap_node_t** last_node;
+		int ret = sctp_binary_heap_get_node_by_index(heap, heap->size, &parent, &last_node);
+		KASSERT(ret == 0, ("Node lookup must succeed"));
+		(void)ret;
+		sctp_binary_heap_node_swap_nodes(heap, node, *last_node);
+		if (node->parent->left == node)
+		{
+			node->parent->left = NULL;
+		}
+		else if (node->parent->right == node)
+		{
+			node->parent->right = NULL;
+		}
+		else
+		{
+			KASSERT(0, ("Wrong link from parent node"));
+			return;
+		}
+		sctp_binary_heap_bubble_down(heap, heap->root);
+	}
+	else
+	{
+		heap->root = NULL;
+	}
+
+	node->left = NULL;
+	node->right = NULL;
+	node->parent = NULL;
+	node->heap = NULL;
+	node->sequence = 0;
+}
+
+
+int
+sctp_binary_heap_peek(
+	const sctp_binary_heap_t* heap,
+	sctp_binary_heap_node_t** out_node)
+{
+	if (heap->size > 0)
+	{
+		KASSERT(heap->root != NULL, ("Heap root must be not null when size is not 0"));
+		*out_node = heap->root;
+		return 0;
+	}
+	return -1;
+}
+
+
+int
+sctp_binary_heap_pop(
+	sctp_binary_heap_t* heap,
+	sctp_binary_heap_node_t** out_node)
+{
+	if (0 != sctp_binary_heap_peek(heap, out_node))
+	{
+		return -1;
+	}
+	sctp_binary_heap_remove(heap, *out_node);
+#if defined(SCTP_BINARY_HEAP_VERIFY_MUTATE_FUNCTIONS)
+	sctp_binary_heap_verify(heap);
+#endif
+	return 0;
+}
+
+
+void
+sctp_binary_heap_push(
+	sctp_binary_heap_t* heap,
+	sctp_binary_heap_node_t* node)
+{
+	if (node->heap != NULL)
+	{
+		KASSERT(0, ("Node is already inserted into the heap"));
+		return;
+	}
+	sctp_binary_heap_node_t* parent, **next;
+	sctp_binary_heap_get_node_by_index(heap, heap->size, &parent, &next);
+	*next = node;
+	node->heap = heap;
+	node->parent = parent;
+	node->sequence = heap->push_sequence;
+	heap->size += 1;
+	heap->push_sequence += 1;
+	sctp_binary_heap_bubble_up(heap, node);
+#if defined(SCTP_BINARY_HEAP_VERIFY_MUTATE_FUNCTIONS)
+	sctp_binary_heap_verify(heap);
+#endif
+}
+
+
+void
+sctp_binary_heap_node_swap_nodes(
+	sctp_binary_heap_t* heap,
+	sctp_binary_heap_node_t* a,
+	sctp_binary_heap_node_t* b)
+{
+	if (a->heap != b->heap)
+	{
+		KASSERT(0, ("Nodes belong to the different heaps"));
+		return;
+	}
+	if (heap != a->heap)
+	{
+		KASSERT(0, ("Nodes does not belong to the heap"));
+		return;
+	}
+
+	if (a->parent == b)
+	{
+		sctp_binary_heap_node_swap_with_parent(heap, a);
+	}
+	else if (b->parent == a)
+	{
+		sctp_binary_heap_node_swap_with_parent(heap, b);
+	}
+	else
+	{
+		sctp_binary_heap_node_swap_non_adjacent(heap, a, b);
+	}
+}
+
+
+void
+sctp_binary_heap_node_swap_non_adjacent(
+	sctp_binary_heap_t* heap,
+	sctp_binary_heap_node_t* a,
+	sctp_binary_heap_node_t* b)
+{
+	if (a->heap != b->heap)
+	{
+		KASSERT(0, ("Nodes belong to the different heaps"));
+		return;
+	}
+	if (heap != a->heap)
+	{
+		KASSERT(0, ("Nodes does not belong to the heap"));
+		return;
+	}
+	if (a->parent == b || b ->parent == a)
+	{
+		KASSERT(0, ("Nodes are adjusent"));
+		return;
+	}
+	sctp_binary_heap_node_t* const a_parent = a->parent,
+		* const a_left_child = a->left,
+		* const a_right_child = a->right;
+
+	sctp_binary_heap_node_t* const b_parent = b->parent,
+		* const b_left_child = b->left,
+		* const b_right_child = b->right;
+
+	sctp_binary_heap_node_t** a_from_parent = NULL;
+	if (a_parent != NULL)
+	{
+		if (a_parent->left == a)
+		{
+			a_from_parent = &a_parent->left;
+		}
+		else if (a_parent->right == a)
+		{
+			a_from_parent = &a_parent->right;
+		}
+		else
+		{
+			KASSERT(0, ("Heap inconsistency detected"));
+			return;
+		}
+	}
+
+	sctp_binary_heap_node_t** b_from_parent = NULL;
+	if (b_parent != NULL)
+	{
+		if (b_parent->left == b)
+		{
+			b_from_parent = &b_parent->left;
+		}
+		else if (b_parent->right == b)
+		{
+			b_from_parent = &b_parent->right;
+		}
+		else
+		{
+			KASSERT(0, ("Heap inconsistency detected"));
+			return;
+		}
+	}
+	// swap
+	// a
+	a->left = b_left_child;
+	if (b_left_child != NULL)
+	{
+		b_left_child->parent = a;
+	}
+
+	a->right = b_right_child;
+	if (b_right_child != NULL)
+	{
+		b_right_child->parent = a;
+	}
+
+	a->parent = b_parent;
+	if (b_from_parent != NULL)
+	{
+		*b_from_parent = a;
+	}
+
+	// b
+	b->left = a_left_child;
+	if (a_left_child != NULL)
+	{
+		a_left_child->parent = b;
+	}
+
+	b->right = a_right_child;
+	if (a_right_child != NULL)
+	{
+		a_right_child->parent = b;
+	}
+
+	b->parent = a_parent;
+	if (a_from_parent != NULL)
+	{
+		*a_from_parent = b;
+	}
+
+	// maybe update root
+	if (heap->root == a)
+	{
+		heap->root = b;
+	}
+	else if (heap->root == b)
+	{
+		heap->root = a;
+	}
+}
+
+
+void
+sctp_binary_heap_node_swap_with_parent(
+	sctp_binary_heap_t* heap,
+	sctp_binary_heap_node_t* node)
+{
+	if (heap != node->heap)
+	{
+		KASSERT(0, ("Node does notbelong to the heap"));
+		return;
+	}
+
+	sctp_binary_heap_node_t* const parent = node->parent;
+	if (parent == NULL)
+	{
+		return;
+	}
+
+	const int parent_is_root = (parent == heap->root);
+
+	// populate pointers to neighbor nodes
+	sctp_binary_heap_node_t* const parent_parent = parent->parent;
+	sctp_binary_heap_node_t* const parent_left_child = parent->left;
+	sctp_binary_heap_node_t* const parent_right_child = parent->right;
+	sctp_binary_heap_node_t* const node_left_child = node->left;
+	sctp_binary_heap_node_t* const node_right_child = node->right;
+
+	sctp_binary_heap_node_t** parent_parent_child = NULL;
+	if (parent_parent)
+	{
+		if (parent_parent->left == parent)
+		{
+			parent_parent_child = &parent_parent->left;
+		}
+		else if (parent_parent->right == parent)
+		{
+			parent_parent_child = &parent_parent->right;
+		}
+		else
+		{
+			KASSERT(0, ("Heap inconsistency detected"));
+			return;
+		}
+	}
+
+	// updated pointers (up to 10)
+	node->parent = parent_parent;
+	if (parent_parent_child != NULL)
+	{
+		*parent_parent_child = node;
+	}
+	parent->parent = node;
+
+	if (node_left_child != NULL)
+	{
+		node_left_child->parent = parent;
+	}
+	if (node_right_child != NULL)
+	{
+		node_right_child->parent = parent;
+	}
+
+	parent->right = node_right_child;
+	parent->left = node_left_child;
+
+	if (node == parent_left_child)
+	{
+		node->left = parent;
+		node->right = parent_right_child;
+		if (parent_right_child != NULL)
+		{
+			parent_right_child->parent = node;
+		}
+	}
+	else
+	{
+		node->right = parent;
+		node->left = parent_left_child;
+		if (parent_left_child != NULL)
+		{
+			parent_left_child->parent = node;
+		}
+	}
+
+	if (parent_is_root)
+	{
+		heap->root = node;
+	}
+}
+
+
+void
+sctp_binary_heap_bubble_up(
+	sctp_binary_heap_t* heap,
+	sctp_binary_heap_node_t* node)
+{
+	sctp_binary_heap_node_t *n = node;
+	while (n->parent != NULL)
+	{
+		if (sctp_binary_heap_node_compare_data(heap, n, n->parent) > 0)
+		{
+			break;
+		}
+		sctp_binary_heap_node_swap_with_parent(heap, n);
+	}
+}
+
+
+void
+sctp_binary_heap_bubble_down(
+	sctp_binary_heap_t* heap,
+	sctp_binary_heap_node_t* node)
+{
+	while (1)
+	{
+		sctp_binary_heap_node_t* smallest = node;
+		if (node->left != NULL && sctp_binary_heap_node_compare_data(heap, node->left, smallest) < 0)
+		{
+			smallest = node->left;
+		}
+		if (node->right != NULL && sctp_binary_heap_node_compare_data(heap, node->right, smallest) < 0)
+		{
+			smallest = node->right;
+		}
+		if (smallest == node)
+		{
+			return;
+		}
+		sctp_binary_heap_node_swap_with_parent(heap, smallest);
+	}
+}
+
+
+void
+sctp_binary_heap_verify(
+	const sctp_binary_heap_t* heap)
+{
+	const size_t actual_nodes_count = sctp_binary_heap_node_count_descendants(heap->root);
+	if (actual_nodes_count != heap->size)
+	{
+		KASSERT(0,
+			("Actual and declared nodes count mismatches"));
+		return;
+	}
+
+	if (heap->root != NULL)
+	{
+		sctp_binary_heap_node_verify(heap, heap->root);
+	}
+}
+
+
+void
+sctp_binary_heap_node_verify(
+	const sctp_binary_heap_t* heap,
+	const sctp_binary_heap_node_t* node)
+{
+	if (heap != node->heap)
+	{
+		KASSERT(0, ("Node belong to different heap"));
+		return;
+	}
+
+	if (node->parent == NULL)
+	{
+		if (node != heap->root)
+		{
+			KASSERT(0, ("Root node must have parent set to NULL"));
+			return;
+		}
+	}
+	else
+	{
+		if (sctp_binary_heap_node_compare_data(heap, node->parent, node) > 0)
+		{
+			KASSERT(0, ("Parent has bigger priority"));
+			return;
+		}
+	}
+
+	if (node->left != NULL)
+	{
+		if (node->left->parent != node)
+		{
+			KASSERT(0, ("Left substree wrong parent"));
+			return;
+		}
+		sctp_binary_heap_node_verify(heap, node->left);
+	}
+
+	if (node->right != NULL)
+	{
+		if (node->right->parent != node)
+		{
+			KASSERT(0, ("Right substree has wrong parent"));
+			return;
+		}
+		sctp_binary_heap_node_verify(heap, node->right);
+	}
+}
+
+
+int
+sctp_binary_heap_node_compare_data(
+	const sctp_binary_heap_t* heap,
+	const sctp_binary_heap_node_t* a,
+	const sctp_binary_heap_node_t* b)
+{
+	const int cmp = heap->comparer(a->data, b->data);
+	if (cmp != 0)
+	{
+		return cmp;
+	}
+	// break equal priorities by order of push into heap
+	if (a->sequence == b->sequence)
+	{
+		KASSERT(a == b, ("Only possible when compared to itself"));
+		return 0;
+	}
+	return SCTP_UINT32_GT(a->sequence, b->sequence) ? 1 : -1;
+}

--- a/usrsctplib/netinet/sctp_callout_queue.c
+++ b/usrsctplib/netinet/sctp_callout_queue.c
@@ -200,6 +200,7 @@ sctp_binary_heap_remove(
 	}
 
 	heap->size -= 1;
+	heap->mod_count += 1;
 	if (heap->size > 0)
 	{
 		sctp_binary_heap_node_t* parent;
@@ -287,9 +288,9 @@ sctp_binary_heap_push(
 	*next = node;
 	node->heap = heap;
 	node->parent = parent;
-	node->sequence = heap->push_sequence;
+	node->sequence = heap->mod_count;
 	heap->size += 1;
-	heap->push_sequence += 1;
+	heap->mod_count += 1;
 	sctp_binary_heap_bubble_up(heap, node);
 #if defined(SCTP_BINARY_HEAP_VERIFY_MUTATE_FUNCTIONS)
 	sctp_binary_heap_verify(heap);

--- a/usrsctplib/netinet/sctp_callout_queue.c
+++ b/usrsctplib/netinet/sctp_callout_queue.c
@@ -121,7 +121,7 @@ sctp_binary_heap_node_verify_connectivity(
 	{
 		if (node->left->parent != node)
 		{
-			KASSERT(0, ("Left substree hsa wrong link to parent"));
+			KASSERT(0, ("Left substree has wrong link to parent"));
 			return -1;
 		}
 		err = sctp_binary_heap_node_verify_connectivity(heap, node->left);

--- a/usrsctplib/netinet/sctp_callout_queue.c
+++ b/usrsctplib/netinet/sctp_callout_queue.c
@@ -350,18 +350,18 @@ sctp_binary_heap_node_swap_non_adjacent(
 		KASSERT(0, ("Nodes does not belong to the heap"));
 		return;
 	}
-	if (a->parent == b || b ->parent == a)
+	if (a->parent == b || b->parent == a)
 	{
 		KASSERT(0, ("Nodes are adjacent"));
 		return;
 	}
-	sctp_binary_heap_node_t* const a_parent = a->parent,
-		* const a_left_child = a->left,
-		* const a_right_child = a->right;
+	sctp_binary_heap_node_t* const a_parent = a->parent;
+	sctp_binary_heap_node_t* const a_left_child = a->left;
+	sctp_binary_heap_node_t* const a_right_child = a->right;
 
-	sctp_binary_heap_node_t* const b_parent = b->parent,
-		* const b_left_child = b->left,
-		* const b_right_child = b->right;
+	sctp_binary_heap_node_t* const b_parent = b->parent;
+	sctp_binary_heap_node_t* const b_left_child = b->left;
+	sctp_binary_heap_node_t* const b_right_child = b->right;
 
 	sctp_binary_heap_node_t** a_from_parent = NULL;
 	if (a_parent != NULL)
@@ -479,7 +479,7 @@ sctp_binary_heap_node_swap_with_parent(
 	sctp_binary_heap_node_t* const node_right_child = node->right;
 
 	sctp_binary_heap_node_t** parent_parent_child = NULL;
-	if (parent_parent)
+	if (parent_parent != NULL)
 	{
 		if (parent_parent->left == parent)
 		{
@@ -596,8 +596,7 @@ sctp_binary_heap_verify(
 	const size_t actual_nodes_count = sctp_binary_heap_node_count_descendants(heap->root);
 	if (actual_nodes_count != heap->size)
 	{
-		KASSERT(0,
-			("Actual and declared nodes count mismatch"));
+		KASSERT(0, ("Actual and declared nodes count mismatch"));
 		return -1;
 	}
 

--- a/usrsctplib/netinet/sctp_callout_queue.c
+++ b/usrsctplib/netinet/sctp_callout_queue.c
@@ -172,10 +172,18 @@ sctp_binary_heap_node_init(
 }
 
 
-size_t sctp_binary_heap_size(
+size_t 
+sctp_binary_heap_size(
 	const sctp_binary_heap_t* heap)
 {
 	return heap->size;
+}
+
+uint32_t
+sctp_binary_heap_version(
+	const sctp_binary_heap_t* heap)
+{
+	return heap->mod_count;
 }
 
 

--- a/usrsctplib/netinet/sctp_callout_queue.c
+++ b/usrsctplib/netinet/sctp_callout_queue.c
@@ -724,7 +724,7 @@ sctp_binary_heap_node_print(sctp_binary_heap_node_t *node, uint32_t space)
 	}
 	if (node->heap->data_visualizer != NULL) 
 	{
-		char vis[8] = {0};
+		char vis[10] = {0};
 		node->heap->data_visualizer(node->data, sizeof(vis), vis);
 		printf("%s\n", vis); 
 	}

--- a/usrsctplib/netinet/sctp_callout_queue.c
+++ b/usrsctplib/netinet/sctp_callout_queue.c
@@ -74,6 +74,26 @@ sctp_binary_heap_node_verify_priorities(
 	const sctp_binary_heap_t*,
 	const sctp_binary_heap_node_t*);
 
+
+static void
+sctp_binary_heap_bubble_up(
+	sctp_binary_heap_t*,
+	sctp_binary_heap_node_t*);
+
+
+static void
+sctp_binary_heap_bubble_down(
+	sctp_binary_heap_t*,
+	sctp_binary_heap_node_t*);
+
+
+static int
+sctp_binary_heap_node_compare_data(
+	const sctp_binary_heap_t*,
+	const sctp_binary_heap_node_t*,
+	const sctp_binary_heap_node_t*);
+
+
 static size_t
 sctp_binary_heap_node_parent_index(size_t index)
 {
@@ -306,7 +326,7 @@ sctp_binary_heap_push(
 }
 
 
-void
+static void
 sctp_binary_heap_node_swap_nodes(
 	sctp_binary_heap_t* heap,
 	sctp_binary_heap_node_t* a,
@@ -342,7 +362,7 @@ sctp_binary_heap_node_swap_nodes(
 }
 
 
-void
+static void
 sctp_binary_heap_node_swap_non_adjacent(
 	sctp_binary_heap_t* heap,
 	sctp_binary_heap_node_t* a,
@@ -460,7 +480,7 @@ sctp_binary_heap_node_swap_non_adjacent(
 }
 
 
-void
+static void
 sctp_binary_heap_node_swap_with_parent(
 	sctp_binary_heap_t* heap,
 	sctp_binary_heap_node_t* node)
@@ -555,7 +575,7 @@ sctp_binary_heap_node_swap_with_parent(
 }
 
 
-void
+static void
 sctp_binary_heap_bubble_up(
 	sctp_binary_heap_t* heap,
 	sctp_binary_heap_node_t* node)
@@ -572,7 +592,7 @@ sctp_binary_heap_bubble_up(
 }
 
 
-void
+static void
 sctp_binary_heap_bubble_down(
 	sctp_binary_heap_t* heap,
 	sctp_binary_heap_node_t* node)
@@ -690,7 +710,7 @@ sctp_binary_heap_node_verify_priorities(
 }
 
 
-int
+static int
 sctp_binary_heap_node_compare_data(
 	const sctp_binary_heap_t* heap,
 	const sctp_binary_heap_node_t* a,
@@ -711,8 +731,7 @@ sctp_binary_heap_node_compare_data(
 }
 
 
-static
-void 
+static void
 sctp_binary_heap_node_print(sctp_binary_heap_node_t *node, uint32_t space) 
 { 
 	if (node == NULL) 
@@ -743,6 +762,7 @@ sctp_binary_heap_node_print(sctp_binary_heap_node_t *node, uint32_t space)
 	}
 	sctp_binary_heap_node_print(node->left, space); 
 } 
+
 
 void 
 sctp_binary_heap_print(

--- a/usrsctplib/netinet/sctp_callout_queue.h
+++ b/usrsctplib/netinet/sctp_callout_queue.h
@@ -45,6 +45,9 @@ typedef struct sctp_binary_heap sctp_binary_heap_t;
 /* function to compare data stored in heap nodes */
 typedef int (*sctp_binary_heap_node_data_comparer)(const void*, const void*);
 
+/* function to visualize node's data as a string */
+typedef void (*sctp_binary_heap_node_data_visualizer)(const void*, size_t max_len, char *out_buffer);
+
 /* structure representing heap node */
 struct sctp_binary_heap_node
 {
@@ -63,6 +66,7 @@ struct sctp_binary_heap
 	uint32_t push_sequence; /* next assigned sequence number by push operation */
 	size_t size; /* number of nodes stored in this heap */
 	sctp_binary_heap_node_data_comparer comparer; /* function to compare data associated with nodes */
+	sctp_binary_heap_node_data_visualizer data_visualizer; /* optional user-provided function to provide human readable representation of node's data */
 };
 
 
@@ -84,7 +88,8 @@ sctp_binary_heap_get_node_by_index(
 void
 sctp_binary_heap_init(
 	sctp_binary_heap_t*,
-	sctp_binary_heap_node_data_comparer);
+	sctp_binary_heap_node_data_comparer,
+	sctp_binary_heap_node_data_visualizer);
 
 
 void
@@ -140,7 +145,7 @@ sctp_binary_heap_bubble_down(
 	sctp_binary_heap_node_t*);
 
 
-void
+int
 sctp_binary_heap_verify(
 	const sctp_binary_heap_t*);
 
@@ -151,5 +156,9 @@ sctp_binary_heap_node_compare_data(
 	const sctp_binary_heap_node_t*,
 	const sctp_binary_heap_node_t*);
 
+
+void 
+sctp_binary_heap_print(
+	const sctp_binary_heap_t*);
 
 #endif

--- a/usrsctplib/netinet/sctp_callout_queue.h
+++ b/usrsctplib/netinet/sctp_callout_queue.h
@@ -43,7 +43,7 @@ typedef struct sctp_binary_heap_node sctp_binary_heap_node_t;
 typedef struct sctp_binary_heap sctp_binary_heap_t;
 
 /* function to compare data stored in heap nodes */
-typedef int (*sctp_binary_heap_node_data_comparer)(void*, void*);
+typedef int (*sctp_binary_heap_node_data_comparer)(const void*, const void*);
 
 /* structure representing heap node */
 struct sctp_binary_heap_node

--- a/usrsctplib/netinet/sctp_callout_queue.h
+++ b/usrsctplib/netinet/sctp_callout_queue.h
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 2019, by https://github.com/sctplab. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * a) Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * b) Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *
+ * c) Neither the name of Cisco Systems, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef _SCTP_CALLOUT_QUEUE_H_
+#define _SCTP_CALLOUT_QUEUE_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+
+typedef struct sctp_binary_heap_node sctp_binary_heap_node_t;
+
+typedef struct sctp_binary_heap sctp_binary_heap_t;
+
+/* function to compare data stored in heap nodes */
+typedef int (*sctp_binary_heap_node_data_comparer)(void*, void*);
+
+/* structure representing heap node */
+struct sctp_binary_heap_node
+{
+	void* data; /* pointer to data associated with heap node */
+	sctp_binary_heap_node_t* parent; /* pointer to parent node in heap, can be null */
+	sctp_binary_heap_node_t* left; /* pointer to left child of node in heap, can be null */
+	sctp_binary_heap_node_t* right; /* pointer to right child of the heap, can be null */
+	sctp_binary_heap_t* heap; /* pointer to a heap containing this node */
+	uint32_t sequence; /* sequence number of this node, used to resolve priority collision in push order */
+};
+
+/* structure representing heap  */
+struct sctp_binary_heap
+{
+	sctp_binary_heap_node_t* root; /* pointer to root node of the heap */
+	uint32_t push_sequence; /* next assigned sequence number by push operation */
+	size_t size; /* number of nodes stored in this heap */
+	sctp_binary_heap_node_data_comparer comparer; /* function to compare data associated with nodes */
+};
+
+
+void
+sctp_binary_heap_node_get_traverse_path_from_index(
+	size_t,
+	size_t*, 
+	uint8_t*);
+
+
+int
+sctp_binary_heap_get_node_by_index(
+	sctp_binary_heap_t*,
+	size_t,
+	sctp_binary_heap_node_t**,
+	sctp_binary_heap_node_t***);
+
+
+void
+sctp_binary_heap_init(
+	sctp_binary_heap_t*,
+	sctp_binary_heap_node_data_comparer);
+
+
+void
+sctp_binary_heap_node_init(
+	sctp_binary_heap_node_t*,
+	void*);
+
+
+size_t
+sctp_binary_heap_size(
+	const sctp_binary_heap_t*);
+
+
+int
+sctp_binary_heap_contains_node(
+	const sctp_binary_heap_t*,
+	const sctp_binary_heap_node_t*);
+
+
+void
+sctp_binary_heap_push(
+	sctp_binary_heap_t*,
+	sctp_binary_heap_node_t*);
+
+
+void
+sctp_binary_heap_remove(
+	sctp_binary_heap_t*,
+	sctp_binary_heap_node_t*);
+
+
+int
+sctp_binary_heap_pop(
+	sctp_binary_heap_t*,
+	sctp_binary_heap_node_t**);
+
+
+int
+sctp_binary_heap_peek(
+	const sctp_binary_heap_t*,
+	sctp_binary_heap_node_t**);
+
+
+void
+sctp_binary_heap_bubble_up(
+	sctp_binary_heap_t*,
+	sctp_binary_heap_node_t*);
+
+
+void
+sctp_binary_heap_bubble_down(
+	sctp_binary_heap_t*,
+	sctp_binary_heap_node_t*);
+
+
+void
+sctp_binary_heap_verify(
+	const sctp_binary_heap_t*);
+
+
+int
+sctp_binary_heap_node_compare_data(
+	const sctp_binary_heap_t*,
+	const sctp_binary_heap_node_t*,
+	const sctp_binary_heap_node_t*);
+
+
+#endif

--- a/usrsctplib/netinet/sctp_callout_queue.h
+++ b/usrsctplib/netinet/sctp_callout_queue.h
@@ -63,7 +63,7 @@ struct sctp_binary_heap_node
 struct sctp_binary_heap
 {
 	sctp_binary_heap_node_t* root; /* pointer to root node of the heap */
-	uint32_t push_sequence; /* next assigned sequence number by push operation */
+	uint32_t mod_count; /* number of heap modification operations executed */
 	size_t size; /* number of nodes stored in this heap */
 	sctp_binary_heap_node_data_comparer comparer; /* function to compare data associated with nodes */
 	sctp_binary_heap_node_data_visualizer data_visualizer; /* optional user-provided function to provide human readable representation of node's data */

--- a/usrsctplib/netinet/sctp_callout_queue.h
+++ b/usrsctplib/netinet/sctp_callout_queue.h
@@ -103,6 +103,11 @@ sctp_binary_heap_size(
 	const sctp_binary_heap_t*);
 
 
+uint32_t
+sctp_binary_heap_version(
+	const sctp_binary_heap_t*);
+
+
 int
 sctp_binary_heap_contains_node(
 	const sctp_binary_heap_t*,

--- a/usrsctplib/netinet/sctp_callout_queue.h
+++ b/usrsctplib/netinet/sctp_callout_queue.h
@@ -138,28 +138,9 @@ sctp_binary_heap_peek(
 	sctp_binary_heap_node_t**);
 
 
-void
-sctp_binary_heap_bubble_up(
-	sctp_binary_heap_t*,
-	sctp_binary_heap_node_t*);
-
-
-void
-sctp_binary_heap_bubble_down(
-	sctp_binary_heap_t*,
-	sctp_binary_heap_node_t*);
-
-
 int
 sctp_binary_heap_verify(
 	const sctp_binary_heap_t*);
-
-
-int
-sctp_binary_heap_node_compare_data(
-	const sctp_binary_heap_t*,
-	const sctp_binary_heap_node_t*,
-	const sctp_binary_heap_node_t*);
 
 
 void 

--- a/usrsctplib/netinet/sctp_constants.h
+++ b/usrsctplib/netinet/sctp_constants.h
@@ -661,7 +661,7 @@ extern void getwintimeofday(struct timeval *tv);
 
 /* SCTP DEBUG Switch parameters */
 #define SCTP_DEBUG_TIMER1	0x00000001
-#define SCTP_DEBUG_TIMER2	0x00000002	/* unused */
+#define SCTP_DEBUG_TIMER2	0x00000002
 #define SCTP_DEBUG_TIMER3	0x00000004	/* unused */
 #define SCTP_DEBUG_TIMER4	0x00000008
 #define SCTP_DEBUG_OUTPUT1	0x00000010

--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -6845,8 +6845,7 @@ sctp_pcb_init(void)
 #if defined(_SCTP_NEEDS_CALLOUT_) || defined(_USER_SCTP_NEEDS_CALLOUT_)
 	/* allocate the lock for the callout/timer queue */
 	SCTP_TIMERQ_LOCK_INIT();
-	SCTP_TIMERWAIT_LOCK_INIT();
-	TAILQ_INIT(&SCTP_BASE_INFO(callqueue));
+	sctp_binary_heap_init(&SCTP_BASE_INFO(timers_queue), (sctp_binary_heap_node_data_comparer)sctp_os_timer_compare);
 #endif
 #if defined(__Userspace__)
 	mbuf_initialize(NULL);
@@ -7041,7 +7040,6 @@ retry:
 	/* free the locks and mutexes */
 #if defined(__APPLE__)
 	SCTP_TIMERQ_LOCK_DESTROY();
-	SCTP_TIMERWAIT_LOCK_DESTROY();
 #endif
 #ifdef SCTP_PACKET_LOGGING
 	SCTP_IP_PKTLOG_DESTROY();
@@ -7068,7 +7066,6 @@ retry:
 #endif
 #if defined(__Userspace__)
 	SCTP_TIMERQ_LOCK_DESTROY();
-	SCTP_TIMERWAIT_LOCK_DESTROY();
 	SCTP_ZONE_DESTROY(zone_mbuf);
 	SCTP_ZONE_DESTROY(zone_clust);
 	SCTP_ZONE_DESTROY(zone_ext_refcnt);

--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -6845,7 +6845,10 @@ sctp_pcb_init(void)
 #if defined(_SCTP_NEEDS_CALLOUT_) || defined(_USER_SCTP_NEEDS_CALLOUT_)
 	/* allocate the lock for the callout/timer queue */
 	SCTP_TIMERQ_LOCK_INIT();
-	sctp_binary_heap_init(&SCTP_BASE_INFO(timers_queue), (sctp_binary_heap_node_data_comparer)sctp_os_timer_compare, NULL);
+	sctp_binary_heap_init(
+		&SCTP_BASE_INFO(timers_queue), 
+		(sctp_binary_heap_node_data_comparer)sctp_os_timer_compare, 
+		(sctp_binary_heap_node_data_visualizer)sctp_os_timer_describe);
 #endif
 #if defined(__Userspace__)
 	mbuf_initialize(NULL);

--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -6845,7 +6845,7 @@ sctp_pcb_init(void)
 #if defined(_SCTP_NEEDS_CALLOUT_) || defined(_USER_SCTP_NEEDS_CALLOUT_)
 	/* allocate the lock for the callout/timer queue */
 	SCTP_TIMERQ_LOCK_INIT();
-	sctp_binary_heap_init(&SCTP_BASE_INFO(timers_queue), (sctp_binary_heap_node_data_comparer)sctp_os_timer_compare);
+	sctp_binary_heap_init(&SCTP_BASE_INFO(timers_queue), (sctp_binary_heap_node_data_comparer)sctp_os_timer_compare, NULL);
 #endif
 #if defined(__Userspace__)
 	mbuf_initialize(NULL);

--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -6985,7 +6985,6 @@ retry:
 	SCTP_ITERATOR_LOCK_DESTROY();
 #endif
 	SCTP_OS_TIMER_STOP_DRAIN(&SCTP_BASE_INFO(addr_wq_timer.timer));
-	SCTP_OS_TIMER_DEINIT(&SCTP_BASE_INFO(addr_wq_timer.timer));
 	SCTP_WQ_ADDR_LOCK();
 	LIST_FOREACH_SAFE(wi, &SCTP_BASE_INFO(addr_wq), sctp_nxt_addr, nwi) {
 		LIST_REMOVE(wi, sctp_nxt_addr);

--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -6982,6 +6982,7 @@ retry:
 	SCTP_ITERATOR_LOCK_DESTROY();
 #endif
 	SCTP_OS_TIMER_STOP_DRAIN(&SCTP_BASE_INFO(addr_wq_timer.timer));
+	SCTP_OS_TIMER_DEINIT(&SCTP_BASE_INFO(addr_wq_timer.timer));
 	SCTP_WQ_ADDR_LOCK();
 	LIST_FOREACH_SAFE(wi, &SCTP_BASE_INFO(addr_wq), sctp_nxt_addr, nwi) {
 		LIST_REMOVE(wi, sctp_nxt_addr);

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -57,6 +57,7 @@ TAILQ_HEAD(sctp_streamhead, sctp_stream_queue_pending);
 
 #include <netinet/sctp_structs.h>
 #include <netinet/sctp_auth.h>
+#include <netinet/sctp_callout_queue.h>
 
 #define SCTP_PCBHASH_ALLADDR(port, mask) (port & mask)
 #define SCTP_PCBHASH_ASOC(tag, mask) (tag & mask)
@@ -282,7 +283,7 @@ struct sctp_epinfo {
 	struct sctp_timer addr_wq_timer;
 
 #if defined(_SCTP_NEEDS_CALLOUT_) || defined(_USER_SCTP_NEEDS_CALLOUT_)
-	struct calloutlist callqueue;
+	sctp_binary_heap_t timers_queue;
 #endif
 };
 

--- a/usrsctplib/netinet/sctp_var.h
+++ b/usrsctplib/netinet/sctp_var.h
@@ -239,9 +239,9 @@ extern struct pr_usrreqs sctp_usrreqs;
 #define sctp_free_remote_addr(__net) { \
 	if ((__net)) { \
 		if (SCTP_DECREMENT_AND_CHECK_REFCOUNT(&(__net)->ref_count)) { \
-			(void)SCTP_OS_TIMER_STOP(&(__net)->rxt_timer.timer); \
-			(void)SCTP_OS_TIMER_STOP(&(__net)->pmtu_timer.timer); \
-			(void)SCTP_OS_TIMER_STOP(&(__net)->hb_timer.timer); \
+			(void)SCTP_OS_TIMER_STOP_DRAIN(&(__net)->rxt_timer.timer); \
+			(void)SCTP_OS_TIMER_STOP_DRAIN(&(__net)->pmtu_timer.timer); \
+			(void)SCTP_OS_TIMER_STOP_DRAIN(&(__net)->hb_timer.timer); \
 			if ((__net)->ro.ro_rt) { \
 				RTFREE((__net)->ro.ro_rt); \
 				(__net)->ro.ro_rt = NULL; \

--- a/usrsctplib/netinet/sctp_var.h
+++ b/usrsctplib/netinet/sctp_var.h
@@ -240,11 +240,8 @@ extern struct pr_usrreqs sctp_usrreqs;
 	if ((__net)) { \
 		if (SCTP_DECREMENT_AND_CHECK_REFCOUNT(&(__net)->ref_count)) { \
 			(void)SCTP_OS_TIMER_STOP_DRAIN(&(__net)->rxt_timer.timer); \
-			SCTP_OS_TIMER_DEINIT(&(__net)->rxt_timer.timer); \
 			(void)SCTP_OS_TIMER_STOP_DRAIN(&(__net)->pmtu_timer.timer); \
-			SCTP_OS_TIMER_DEINIT(&(__net)->pmtu_timer.timer); \
 			(void)SCTP_OS_TIMER_STOP_DRAIN(&(__net)->hb_timer.timer); \
-			SCTP_OS_TIMER_DEINIT(&(__net)->hb_timer.timer); \
 			if ((__net)->ro.ro_rt) { \
 				RTFREE((__net)->ro.ro_rt); \
 				(__net)->ro.ro_rt = NULL; \

--- a/usrsctplib/netinet/sctp_var.h
+++ b/usrsctplib/netinet/sctp_var.h
@@ -240,8 +240,11 @@ extern struct pr_usrreqs sctp_usrreqs;
 	if ((__net)) { \
 		if (SCTP_DECREMENT_AND_CHECK_REFCOUNT(&(__net)->ref_count)) { \
 			(void)SCTP_OS_TIMER_STOP_DRAIN(&(__net)->rxt_timer.timer); \
+			SCTP_OS_TIMER_DEINIT(&(__net)->rxt_timer.timer); \
 			(void)SCTP_OS_TIMER_STOP_DRAIN(&(__net)->pmtu_timer.timer); \
+			SCTP_OS_TIMER_DEINIT(&(__net)->pmtu_timer.timer); \
 			(void)SCTP_OS_TIMER_STOP_DRAIN(&(__net)->hb_timer.timer); \
+			SCTP_OS_TIMER_DEINIT(&(__net)->hb_timer.timer); \
 			if ((__net)->ro.ro_rt) { \
 				RTFREE((__net)->ro.ro_rt); \
 				(__net)->ro.ro_rt = NULL; \

--- a/usrsctplib/netinet/sctputil.c
+++ b/usrsctplib/netinet/sctputil.c
@@ -37,6 +37,7 @@
 __FBSDID("$FreeBSD: head/sys/netinet/sctputil.c 353518 2019-10-14 20:32:11Z tuexen $");
 #endif
 
+#include <inttypes.h>
 #include <netinet/sctp_os.h>
 #include <netinet/sctp_pcb.h>
 #include <netinet/sctputil.h>
@@ -1703,7 +1704,7 @@ sctp_timeout_handler(void *t)
 	}
 	type = tmr->type;
 	tmr->stopped_from = 0xa005;
-	SCTPDBG(SCTP_DEBUG_TIMER1, "Timer type %d goes off\n", type);
+	SCTPDBG(SCTP_DEBUG_TIMER1, "Timer %p of type %d goes off with callout is %p\n", tmr, type, &(tmr->timer));
 	if (!SCTP_OS_TIMER_ACTIVE(&tmr->timer)) {
 		if (inp) {
 			SCTP_INP_DECR_REF(inp);
@@ -2372,6 +2373,8 @@ sctp_timer_start(int t_type, struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 #ifndef __Panda__
 	tmr->ticks = sctp_get_tick_count();
 #endif
+	SCTPDBG(SCTP_DEBUG_TIMER1, "%s: Starting timer %p of type %d with delay %" PRIu32 " and callout %p\n",
+		__func__, tmr, t_type, to_ticks, &(tmr->timer));
 	(void)SCTP_OS_TIMER_START(&tmr->timer, to_ticks, sctp_timeout_handler, tmr);
 	return;
 }


### PR DESCRIPTION
This PR is proposed as a fix for #325 

#### Problem description

Deadlock in bug #325 happen due to way [`sctp_os_timer_stop`](https://github.com/sctplab/usrsctp/blob/1ab1d69ce8cbf20a4d0d1e41de6b5c11cd24da71/usrsctplib/netinet/sctp_callout.c#L162) is **implemented** and they way it is **used**.

With [changes introduced from `25-30 March 2019`](https://github.com/sctplab/usrsctp/compare/1de72ec158a133866cb630ea49b3a6d92af76071...dfe89db408f29b78d667b9698e36325286be27ed) **the behavior of the [`sctp_os_timer_stop`](https://github.com/sctplab/usrsctp/blob/1ab1d69ce8cbf20a4d0d1e41de6b5c11cd24da71/usrsctplib/netinet/sctp_callout.c#L162) function has changed** in scenario when stop is called, but timer's **callback is still executing** at that moment.

**Before changes** from March 2019 stop was just noop in that case, because there nothing you can do to stop callback from running in other thread.

**With changes** from March 2019 stop in that case **became blocking function** which waits until callback of the timer finishes it's execution.

Unfortunately they way [`sctp_os_timer_stop`](https://github.com/sctplab/usrsctp/blob/1ab1d69ce8cbf20a4d0d1e41de6b5c11cd24da71/usrsctplib/netinet/sctp_callout.c#L162) is used by callers **has not been correspondingly updated** to take into account **new blocking behavior of stop** function.
As far as I understand blocking stop is necessary in cases when timer's memory is going to be recycled after stop, basically caller want to stop timer and free it's memory and make sure no one from timer's callback or timer's thread will touch already freed memory.
In `usrsctp` there is single macro and many usages of it where blocking behavior of stop is definitely needed, because the memory of the timer is freed just after stop:
https://github.com/sctplab/usrsctp/blob/1ab1d69ce8cbf20a4d0d1e41de6b5c11cd24da71/usrsctplib/netinet/sctp_var.h#L191-L211

There are a lot of places in `usrsctp` library where blocking behavior of stop is completely **not necessary** and actually causing deadlocks like #325.
All that places actually just want to **cancel** a timer, they don't need to **wait for completion** of the timer.

The deadlock as it happen in `usrsctp` due to blocking stop usage can be visualized with simple example `C++` program:
```C++
#include <iostream>
#include <mutex>
#include <future>
#include <thread>

int main(void)
{
	// Simulates some code which calls to sctp_os_timer_stop
	std::mutex mutex;
	std::lock_guard<std::mutex> guard(mutex);
	std::cout << "Non-timer thread [tid=" << std::this_thread::get_id() << "] will call to sctp_os_timer_stop, while holding mutex" << std::endl;

	{
		// Simulates timer
		std::future<void> timer = std::async(std::launch::async, [&mutex]()
		{
			// Simulates code executing on timer thread by sctp_handle_tick
			std::cout << "Timer thread [tid=" << std::this_thread::get_id() << "] callback is before acquiring mutex" << std::endl;
			std::lock_guard<std::mutex> guard_inside_timer_callback(mutex);
			std::cout << "Timer thread [tid=" << std::this_thread::get_id() << "] callback is after acquiring mutex" << std::endl;
		});

	} /* <-- exiting scope will cause recycle std::future memory by calling destructor,
		 but std::future must wait for completion before that, so causing deadlock,
		 the same story as with timer in usrsctp */

	std::cout << "Never printed due to deadlock with timer's callback function" << std::endl;

	return 0;
}
```

#### Existing implementation description
Brief description of an existing implementation:
1. Timers are stored in the single doubly linked list;
2. Timers inspection routine [`sctp_handle_tick`](https://github.com/sctplab/usrsctp/blob/c38740ec838e701f994b5885a1e7318b93de4843/usrsctplib/netinet/sctp_callout.c#L221) does linear scan of timers list and invokes triggered timer during iteration;
3. During iteration over timers list it is protected by special `mutex`, but it is released when timer's callback is invoked. **During execution of timer callback the state of doubly linked list can be arbitrary modified by other threads or by timer's callback itself**;
4. To not to scan timers list from scratch (i.e. resume) after single timer callback executed, `sctp_handle_tick` does some tricky bookkeeping and synchronization with [`sctp_os_timer_start`](https://github.com/sctplab/usrsctp/blob/c38740ec838e701f994b5885a1e7318b93de4843/usrsctplib/netinet/sctp_callout.c#L109) and [`sctp_os_timer_stop`](https://github.com/sctplab/usrsctp/blob/c38740ec838e701f994b5885a1e7318b93de4843/usrsctplib/netinet/sctp_callout.c#L162) based on:
[`sctp_os_timer_next`](https://github.com/sctplab/usrsctp/blob/c38740ec838e701f994b5885a1e7318b93de4843/usrsctplib/netinet/sctp_callout.c#L86);
4. To provide blocking functionality of stop to **wait for timer completion** the following global state maintained [`sctp_os_timer_current `](https://github.com/sctplab/usrsctp/blob/c38740ec838e701f994b5885a1e7318b93de4843/usrsctplib/netinet/sctp_callout.c#L87), [`sctp_os_timer_waiting`](https://github.com/sctplab/usrsctp/blob/c38740ec838e701f994b5885a1e7318b93de4843/usrsctplib/netinet/sctp_callout.c#L88), [`sctp_os_timer_wait_ctr`](https://github.com/sctplab/usrsctp/blob/c38740ec838e701f994b5885a1e7318b93de4843/usrsctplib/netinet/sctp_callout.c#L89), [`sctp_os_timer_current_tid`](https://github.com/sctplab/usrsctp/blob/c38740ec838e701f994b5885a1e7318b93de4843/usrsctplib/netinet/sctp_callout.c#L90), [`sctp_os_timerwait_mtx`](https://github.com/sctplab/usrsctp/blob/c38740ec838e701f994b5885a1e7318b93de4843/usrsctplib/netinet/sctp_callout.c#L97), [`sctp_os_timer_wait_cond`](https://github.com/sctplab/usrsctp/blob/c38740ec838e701f994b5885a1e7318b93de4843/usrsctplib/netinet/sctp_callout.c#L98), [`sctp_os_timer_done_ctr`](https://github.com/sctplab/usrsctp/blob/c38740ec838e701f994b5885a1e7318b93de4843/usrsctplib/netinet/sctp_callout.c#L99).

#### Proposed implementation description
Brief description of proposed implementation:
1. Timers are stored in a linked binary heap (not very usual thing, usually binary heap is done based on dynamically allocated arrays. But linked heap implementation allow to avoid usage of explicitly allocated memory, so it's up to a caller where to store heap nodes).
2. During iteration and heap modification it's protected by same mutex as before;
3. `sctp_handle_tick` can no longer bother about heap modified arbitrary, because the state of the heap is maintained in such a way that soonest timer is always stored on top. So, the extra state and tricky synchronization between iteration, start and stop is no longer necessary, because `sctp_handle_tick` only check the top of the heap.
4. `sctp_os_timer_stop` behavior is left blocking, it does cancel of active timer and **waits until timer's callback finished execution**. `sctp_os_timer_stop` method still dangerous and has to be used carefully, but in scenarios where timer memory is need to be freed there is no other choice.
5. I've redefined several existing macroses and updated it's usage:
https://github.com/mstyura/usrsctp/blob/755599e1b226512ff0da7b8b9ad2963fd9bce6b9/usrsctplib/netinet/sctp_callout.h#L145-L149
* * `SCTP_OS_TIMER_STOP` - is defined to be cancel - the same as it was before [changes from `25-30 March 2019`](https://github.com/sctplab/usrsctp/compare/1de72ec158a133866cb630ea49b3a6d92af76071...dfe89db408f29b78d667b9698e36325286be27ed);
* * `SCTP_OS_TIMER_STOP_DRAIN` - is defined to be blocking, [`sctp_free_remote_addr`](https://github.com/sctplab/usrsctp/blob/1ab1d69ce8cbf20a4d0d1e41de6b5c11cd24da71/usrsctplib/netinet/sctp_var.h#L191-L211) macro which recycle timer memory defined to use blocking stop.
6. I've added stress test of `usrsctp` which reproduces deadlock #325. It was done as [CL to WebRTC project](https://webrtc-review.googlesource.com/c/src/+/157107). It is occurred it is a way easier to write examples using high level WebRTC API to reproduce issue in non-production environment.

This PR is likely to solve some of the deadlocks caused by usage of `sctp_os_timer_stop`, but it might be the case that there are still misuses of `sctp_os_timer_stop` and mutexes as shown in `C++` example - those cases need to be examined later once reproduced.

I'm really sorry that this PR is large and someone will have to review it. 

