### PR TITLE
Change type of to_ticks in sctp_os_timer_start to uint32_t.

### DIFF
--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -106,7 +106,7 @@ sctp_os_timer_init(sctp_os_timer_t *c)
 }
 
 void
-sctp_os_timer_start(sctp_os_timer_t *c, int to_ticks, void (*ftn) (void *),
+sctp_os_timer_start(sctp_os_timer_t *c, uint32_t to_ticks, void (*ftn) (void *),
                     void *arg)
 {
 	/* paranoia */
@@ -147,7 +147,7 @@ sctp_os_timer_start(sctp_os_timer_t *c, int to_ticks, void (*ftn) (void *),
 	 * We could unlock/splx here and lock/spl at the TAILQ_INSERT_TAIL,
 	 * but there's no point since doing this setup doesn't take much time.
 	 */
-	if (to_ticks <= 0)
+	if (to_ticks == 0)
 		to_ticks = 1;
 
 	c->c_arg = arg;

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -101,7 +101,7 @@ typedef struct sctp_callout sctp_os_timer_t;
 #define	SCTP_CALLOUT_PENDING	0x0004	/* callout is waiting for timeout */
 
 void sctp_os_timer_init(sctp_os_timer_t *tmr);
-void sctp_os_timer_start(sctp_os_timer_t *, int, void (*)(void *), void *);
+void sctp_os_timer_start(sctp_os_timer_t *, uint32_t, void (*)(void *), void *);
 int sctp_os_timer_stop(sctp_os_timer_t *);
 void sctp_handle_tick(uint32_t);
 


### PR DESCRIPTION
Type of `to_ticks` of function `sctp_os_timer_start` has changed to `uint32_t`. It was supposed to be done as part of #393, but accidentally forgotten.