### PR TITLE
meson: Need dependencies while linking shared library too

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -199,6 +199,7 @@ if compiler.get_id() == 'msvc' and get_option('default_library') == 'shared'
 
     usrsctp = shared_library('usrsctp',
         link_whole: usrsctp_static,
+        dependencies: dependencies,
         vs_module_defs: usrsctp_def,
         install: true,
         version: meson.project_version())


### PR DESCRIPTION
Otherwise we get linker errors for ws2_32, etc.