### PR TITLE
meson: Fixes needed to build on Android

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,7 @@ add_project_arguments([
 
 # OS-specific settings
 system = host_machine.system()
-if system == 'linux'
+if ['linux', 'android'].contains(system)
     add_project_arguments([
         '-D__Userspace_os_Linux',
         '-D_GNU_SOURCE',
@@ -68,7 +68,7 @@ elif system == 'freebsd'
     ] + compiler.get_supported_arguments([
         '-Wno-address-of-packed-member',
     ]), language: 'c')
-elif system == 'darwin'
+elif ['darwin', 'ios'].contains(system)
     add_project_arguments([
             '-D__Userspace_os_Darwin',
             '-U__APPLE__',

--- a/usrsctplib/meson.build
+++ b/usrsctplib/meson.build
@@ -12,6 +12,9 @@ sources = files([
     'user_recv_thread.c',
     'user_socket.c',
 ])
+if system == 'android'
+    sources += files('ifaddrs.c')
+endif
 
 subdir('netinet')
 subdir('netinet6')


### PR DESCRIPTION
commit 48fee387dd98748bd3b4ed4e1dd80b016a228b17:

```
meson: add support for android/ios host_system
```

commit 5f1a0f75b3406688d8ad95cf616e43244a9c820e:

```
build: include ifaddrs.c definition for android
```

With these changes libusrsctp builds correctly on Android with Meson.

CC: @ystreet