### PR TITLE
meson: Fix sconn_len detection (#411)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -159,7 +159,7 @@ have_sin6_len = compiler.has_member('struct sockaddr_in6', 'sin6_len', prefix: p
 if have_sin6_len
     add_project_arguments('-DHAVE_SIN6_LEN', language: 'c')
 endif
-have_sconn_len = compiler.has_member('struct sockaddr_conn', 'sconn_len', prefix: '#include "usrsctp.h"')
+have_sconn_len = compiler.has_member('struct sockaddr_conn', 'sconn_len', prefix: '#include "usrsctp.h"', include_directories: include_directories('usrsctplib'))
 if have_sconn_len
     add_project_arguments('-DHAVE_SCONN_LEN', language: 'c')
 endif

--- a/meson.build
+++ b/meson.build
@@ -71,7 +71,6 @@ elif system == 'freebsd'
 elif ['darwin', 'ios'].contains(system)
     add_project_arguments([
             '-D__Userspace_os_Darwin',
-            '-U__APPLE__',
             '-D__APPLE_USE_RFC_2292',
         ] + compiler.get_supported_arguments([
             '-Wno-address-of-packed-member',
@@ -208,7 +207,8 @@ else
         dependencies: dependencies,
         include_directories: include_dirs,
         install: true,
-        version: meson.project_version())
+        version: meson.project_version(),
+        c_args: '-U__APPLE__')
 endif
 
 # Declare dependency


### PR DESCRIPTION
have_sconn_len was always false because compiler.has_member generates a C file
which does not build because the compiler can't include "usrsctp.h". Fixed by
specifying the include path.