### PR TITLE
Do proper reference counting with callouts

### DIFF
--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -95,6 +95,11 @@ int sctp_os_timer_stop(sctp_os_timer_t *);
 void sctp_handle_tick(uint32_t);
 
 #define SCTP_OS_TIMER_INIT	sctp_os_timer_init
+/*
+ * NOTE: These shouldn't be called directly outside of sctp_timer_start and
+ * sctp_timer_stop, since they don't handle incrementing/decrementing
+ * relevant reference counts.
+ */
 #define SCTP_OS_TIMER_START	sctp_os_timer_start
 #define SCTP_OS_TIMER_STOP	sctp_os_timer_stop
 /* MT FIXME: Is the following correct? */

--- a/usrsctplib/netinet/sctp_var.h
+++ b/usrsctplib/netinet/sctp_var.h
@@ -191,7 +191,6 @@ extern struct pr_usrreqs sctp_usrreqs;
 #define sctp_free_remote_addr(__net) { \
 	if ((__net)) {  \
 		if (SCTP_DECREMENT_AND_CHECK_REFCOUNT(&(__net)->ref_count)) { \
-			(void)SCTP_OS_TIMER_STOP(&(__net)->rxt_timer.timer); \
 			if ((__net)->ro.ro_rt) { \
 				RTFREE((__net)->ro.ro_rt); \
 				(__net)->ro.ro_rt = NULL; \
@@ -237,7 +236,6 @@ extern struct pr_usrreqs sctp_usrreqs;
 #define sctp_free_remote_addr(__net) { \
 	if ((__net)) { \
 		if (SCTP_DECREMENT_AND_CHECK_REFCOUNT(&(__net)->ref_count)) { \
-			(void)SCTP_OS_TIMER_STOP(&(__net)->rxt_timer.timer); \
 			if ((__net)->ro.ro_rt) { \
 				RTFREE((__net)->ro.ro_rt); \
 				(__net)->ro.ro_rt = NULL; \

--- a/usrsctplib/netinet/sctputil.h
+++ b/usrsctplib/netinet/sctputil.h
@@ -94,6 +94,13 @@ sctp_notify_stream_reset_add(struct sctp_tcb *stcb, uint16_t numberin,
 void
 sctp_notify_stream_reset_tsn(struct sctp_tcb *stcb, uint32_t sending_tsn, uint32_t recv_tsn, int flag);
 
+/*
+ * NOTE: sctp_timer_start will increment the reference count of any relevant
+ * structure the timer is referencing, in order to prevent a race condition
+ * between the timer executing and the structure being freed.
+ *
+ * When the timer fires or is stopped, these references must be removed.
+ */
 void
 sctp_timer_start(int, struct sctp_inpcb *, struct sctp_tcb *,
     struct sctp_nets *);


### PR DESCRIPTION
This handles the race condition between a timer executing and being deleted.

sctp_timer_start increments reference counts, and the timer executing or sctp_timer_stop being called decrements them.