### PR TITLE
CMake changes to import usrsctp as submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ endif ()
 # CHECK STRUCT MEMBERS
 #################################################
 
-set(CMAKE_REQUIRED_INCLUDES "${CMAKE_SOURCE_DIR}/usrsctplib")
+set(CMAKE_REQUIRED_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/usrsctplib")
 
 check_include_file(usrsctp.h have_usrsctp_h)
 if (NOT have_usrsctp_h)

--- a/usrsctplib/CMakeLists.txt
+++ b/usrsctplib/CMakeLists.txt
@@ -178,6 +178,9 @@ list(APPEND usrsctp_sources
 add_library(usrsctp SHARED ${usrsctp_sources} ${usrsctp_headers})
 add_library(usrsctp-static STATIC ${usrsctp_sources} ${usrsctp_headers})
 
+target_include_directories(usrsctp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(usrsctp-static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 if (WIN32)
 	message(STATUS "link library: ws2_32")
 	target_link_libraries(usrsctp ws2_32 iphlpapi.lib)


### PR DESCRIPTION
This PR suggests two small changes to `CMakeLists` to allow importing usrsctp as submodule with `add_subdirectory`:
- Replace `CMAKE_SOURCE_DIR` with `CMAKE_CURRENT_SOURCE_DIR`
- Export `usrsctplib` as include directory

These changes currently make for a cleaner import of usrsctp in my project [libdatachannel](https://github.com/paullouisageneau/libdatachannel) and should not introduce unwanted side effects.
