### PR TITLE
Revert series of callout guard commits

### DIFF
--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -173,7 +173,7 @@ sctp_os_timer_stop(sctp_os_timer_t *c)
 		} else {
 			/* need to wait until the callout is finished */
 			sctp_os_timer_waiting = 1;
-			wakeup_cookie = ++sctp_os_timer_wait_ctr;
+			wakeup_cookie = sctp_os_timer_wait_ctr++;
 			SCTP_TIMERQ_UNLOCK();
 			SCTP_TIMERWAIT_LOCK();
 			/*

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -78,7 +78,6 @@ uint32_t sctp_get_tick_count(void) {
  * - SCTP_BASE_INFO(callqueue)
  * - sctp_os_timer_next: next timer to check
  * - sctp_os_timer_current: current callout callback in progress
- * - sctp_os_timer_current_tid: current callout thread id in progress
  * - sctp_os_timer_waiting: some thread is waiting for callout to complete
  * - sctp_os_timer_wait_ctr: incremented every time a thread wants to wait
  *                           for a callout to complete.
@@ -87,7 +86,6 @@ static sctp_os_timer_t *sctp_os_timer_next = NULL;
 static sctp_os_timer_t *sctp_os_timer_current = NULL;
 static int sctp_os_timer_waiting = 0;
 static int sctp_os_timer_wait_ctr = 0;
-static userland_thread_id_t sctp_os_timer_current_tid;
 
 /*
  * SCTP_TIMERWAIT_LOCK (sctp_os_timerwait_mtx) protects:
@@ -173,18 +171,6 @@ sctp_os_timer_stop(sctp_os_timer_t *c)
 			SCTP_TIMERQ_UNLOCK();
 			return (0);
 		} else {
-			/*
-			 * Deleting the callout from the currently running
-			 * callout from the same thread, so just return
-			 */
-			userland_thread_id_t tid;
-			sctp_userspace_thread_id(&tid);
-			if (sctp_userspace_thread_equal(tid,
-						sctp_os_timer_current_tid)) {
-				SCTP_TIMERQ_UNLOCK();
-				return (0);
-			}
-
 			/* need to wait until the callout is finished */
 			sctp_os_timer_waiting = 1;
 			wakeup_cookie = ++sctp_os_timer_wait_ctr;
@@ -237,7 +223,6 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 			c_arg = c->c_arg;
 			c->c_flags &= ~SCTP_CALLOUT_PENDING;
 			sctp_os_timer_current = c;
-			sctp_userspace_thread_id(&sctp_os_timer_current_tid);
 			SCTP_TIMERQ_UNLOCK();
 			c_func(c_arg);
 			SCTP_TIMERQ_LOCK();

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -77,18 +77,8 @@ uint32_t sctp_get_tick_count(void) {
  * SCTP_TIMERQ_LOCK protects:
  * - SCTP_BASE_INFO(callqueue)
  * - sctp_os_timer_next: next timer to check
- * - sctp_os_timer_current: current callout callback in progress
- * - sctp_os_timer_waiting: waiting for callout to complete
  */
 static sctp_os_timer_t *sctp_os_timer_next = NULL;
-static sctp_os_timer_t *sctp_os_timer_current = NULL;
-static int sctp_os_timer_waiting = 0;
-
-#if defined (__Userspace_os_Windows)
-static CONDITION_VARIABLE sctp_os_timer_wait_cond;
-#else
-static pthread_cond_t sctp_os_timer_wait_cond;
-#endif
 
 void
 sctp_os_timer_init(sctp_os_timer_t *c)
@@ -143,21 +133,8 @@ sctp_os_timer_stop(sctp_os_timer_t *c)
 	 */
 	if (!(c->c_flags & SCTP_CALLOUT_PENDING)) {
 		c->c_flags &= ~SCTP_CALLOUT_ACTIVE;
-		if (sctp_os_timer_current != c) {
-			SCTP_TIMERQ_UNLOCK();
-			return (0);
-		} else {
-			/* need to wait until the callout is finished */
-			sctp_os_timer_waiting = 1;
-#if defined (__Userspace_os_Windows)
-			SleepConditionVariableCS(&sctp_os_timer_wait_cond,
-						 &SCTP_BASE_VAR(timer_mtx),
-						 INFINITE);
-#else
-			pthread_cond_wait(&sctp_os_timer_wait_cond,
-					  &SCTP_BASE_VAR(timer_mtx));
-#endif
-		}
+		SCTP_TIMERQ_UNLOCK();
+		return (0);
 	}
 	c->c_flags &= ~(SCTP_CALLOUT_ACTIVE | SCTP_CALLOUT_PENDING);
 	if (c == sctp_os_timer_next) {
@@ -186,19 +163,9 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 			c_func = c->c_func;
 			c_arg = c->c_arg;
 			c->c_flags &= ~SCTP_CALLOUT_PENDING;
-			sctp_os_timer_current = c;
 			SCTP_TIMERQ_UNLOCK();
 			c_func(c_arg);
 			SCTP_TIMERQ_LOCK();
-			sctp_os_timer_current = NULL;
-			if (sctp_os_timer_waiting) {
-#if defined (__Userspace_os_Windows)
-				WakeAllConditionVariable(&sctp_os_timer_wait_cond);
-#else
-				pthread_cond_broadcast(&sctp_os_timer_wait_cond);
-#endif
-				sctp_os_timer_waiting = 0;
-			}
 			c = sctp_os_timer_next;
 		} else {
 			c = TAILQ_NEXT(c, tqe);
@@ -252,14 +219,6 @@ sctp_start_timer(void)
 	 * here, it is being done in sctp_pcb_init()
 	 */
 	int rc;
-
-#if defined(__Userspace_os_Windows)
-	InitializeConditionVariable(&sctp_os_timer_wait_cond);
-#else
-	rc = pthread_cond_init(&sctp_os_timer_wait_cond, NULL);
-	if (rc)
-		SCTP_PRINTF("ERROR; return code from pthread_cond_init is %d\n", rc);
-#endif
 
 	rc = sctp_userspace_thread_create(&SCTP_BASE_VAR(timer_thread), user_sctp_timer_iterate);
 	if (rc) {

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -113,21 +113,6 @@ sctp_os_timer_start(sctp_os_timer_t *c, uint32_t to_ticks, void (*ftn) (void *),
 
 	SCTP_TIMERQ_LOCK();
 	/* check to see if we're rescheduling a timer */
-	if (c == sctp_os_timer_current) {
-		/*
-		 * We're being asked to reschedule a callout which is
-		 * currently in progress.
-		 */
-		if (sctp_os_timer_waiting) {
-			/*
-			 * This callout is already being stopped.
-			 * callout.  Don't reschedule.
-			 */
-			SCTP_TIMERQ_UNLOCK();
-			return;
-		}
-	}
-
 	if (c->c_flags & SCTP_CALLOUT_PENDING) {
 		if (c == sctp_os_timer_next) {
 			sctp_os_timer_next = TAILQ_NEXT(c, tqe);
@@ -187,7 +172,7 @@ sctp_os_timer_stop(sctp_os_timer_t *c)
 							 INFINITE);
 #else
 				pthread_cond_wait(&sctp_os_timer_wait_cond,
-						  &sctp_os_timerwait_mtx);
+						  &SCTP_BASE_VAR(timer_mtx));
 #endif
 			}
 			SCTP_TIMERWAIT_UNLOCK();

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -52,35 +52,22 @@ __FBSDID("$FreeBSD$");
 
 #define SCTP_TICKS_PER_FASTTIMO 20	/* called about every 20ms */
 
-extern userland_mutex_t sctp_os_timerwait_mtx;
-
 #if defined(__Userspace__)
 #if defined(__Userspace_os_Windows)
 #define SCTP_TIMERQ_LOCK()          EnterCriticalSection(&SCTP_BASE_VAR(timer_mtx))
 #define SCTP_TIMERQ_UNLOCK()        LeaveCriticalSection(&SCTP_BASE_VAR(timer_mtx))
 #define SCTP_TIMERQ_LOCK_INIT()     InitializeCriticalSection(&SCTP_BASE_VAR(timer_mtx))
 #define SCTP_TIMERQ_LOCK_DESTROY()  DeleteCriticalSection(&SCTP_BASE_VAR(timer_mtx))
-
-#define SCTP_TIMERWAIT_LOCK()          EnterCriticalSection(&sctp_os_timerwait_mtx)
-#define SCTP_TIMERWAIT_UNLOCK()        LeaveCriticalSection(&sctp_os_timerwait_mtx)
-#define SCTP_TIMERWAIT_LOCK_INIT()     InitializeCriticalSection(&sctp_os_timerwait_mtx)
-#define SCTP_TIMERWAIT_LOCK_DESTROY()  DeleteCriticalSection(&sctp_os_timerwait_mtx)
 #else
 #ifdef INVARIANTS
 #define SCTP_TIMERQ_LOCK()          KASSERT(pthread_mutex_lock(&SCTP_BASE_VAR(timer_mtx)) == 0, ("%s: timer_mtx already locked", __func__))
 #define SCTP_TIMERQ_UNLOCK()        KASSERT(pthread_mutex_unlock(&SCTP_BASE_VAR(timer_mtx)) == 0, ("%s: timer_mtx not locked", __func__))
-#define SCTP_TIMERWAIT_LOCK()       KASSERT(pthread_mutex_lock(&sctp_os_timerwait_mtx) == 0, ("%s: sctp_os_timerwait_mtx already locked", __func__))
-#define SCTP_TIMERWAIT_UNLOCK()	    KASSERT(pthread_mutex_unlock(&sctp_os_timerwait_mtx) == 0, ("%s: sctp_os_timerwait_mtx not locked", __func__))
 #else
 #define SCTP_TIMERQ_LOCK()          (void)pthread_mutex_lock(&SCTP_BASE_VAR(timer_mtx))
 #define SCTP_TIMERQ_UNLOCK()        (void)pthread_mutex_unlock(&SCTP_BASE_VAR(timer_mtx))
-#define SCTP_TIMERWAIT_LOCK()       (void)pthread_mutex_lock(&sctp_os_timerwait_mtx)
-#define SCTP_TIMERWAIT_UNLOCK()     (void)pthread_mutex_unlock(&sctp_os_timerwait_mtx)
 #endif
 #define SCTP_TIMERQ_LOCK_INIT()     (void)pthread_mutex_init(&SCTP_BASE_VAR(timer_mtx), &SCTP_BASE_VAR(mtx_attr))
 #define SCTP_TIMERQ_LOCK_DESTROY()  (void)pthread_mutex_destroy(&SCTP_BASE_VAR(timer_mtx))
-#define SCTP_TIMERWAIT_LOCK_INIT()     (void)pthread_mutex_init(&sctp_os_timerwait_mtx, &SCTP_BASE_VAR(mtx_attr))
-#define SCTP_TIMERWAIT_LOCK_DESTROY()  (void)pthread_mutex_destroy(&sctp_os_timerwait_mtx)
 #endif
 #endif
 

--- a/usrsctplib/netinet/sctp_os_userspace.h
+++ b/usrsctplib/netinet/sctp_os_userspace.h
@@ -76,7 +76,6 @@ void WakeAllXPConditionVariable(userland_cond_t *);
 typedef CONDITION_VARIABLE userland_cond_t;
 #endif
 typedef HANDLE userland_thread_t;
-typedef DWORD userland_thread_id_t;
 #define ADDRESS_FAMILY	unsigned __int8
 #define IPVERSION  4
 #define MAXTTL     255
@@ -284,7 +283,6 @@ typedef char* caddr_t;
 typedef pthread_mutex_t userland_mutex_t;
 typedef pthread_cond_t userland_cond_t;
 typedef pthread_t userland_thread_t;
-typedef pthread_t userland_thread_id_t;
 #endif
 
 #if defined(__Userspace_os_Windows) || defined(__Userspace_os_NaCl)
@@ -1036,9 +1034,6 @@ sctp_userspace_thread_create(userland_thread_t *thread, start_routine_t start_ro
 
 void
 sctp_userspace_set_threadname(const char *name);
-
-int sctp_userspace_thread_id(userland_thread_id_t *thread);
-int sctp_userspace_thread_equal(userland_thread_id_t t1, userland_thread_id_t t2);
 
 /*
  * SCTP protocol specific mbuf flags.

--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -6845,7 +6845,6 @@ sctp_pcb_init(void)
 #if defined(_SCTP_NEEDS_CALLOUT_) || defined(_USER_SCTP_NEEDS_CALLOUT_)
 	/* allocate the lock for the callout/timer queue */
 	SCTP_TIMERQ_LOCK_INIT();
-	SCTP_TIMERWAIT_LOCK_INIT();
 	TAILQ_INIT(&SCTP_BASE_INFO(callqueue));
 #endif
 #if defined(__Userspace__)
@@ -7041,7 +7040,6 @@ retry:
 	/* free the locks and mutexes */
 #if defined(__APPLE__)
 	SCTP_TIMERQ_LOCK_DESTROY();
-	SCTP_TIMERWAIT_LOCK_DESTROY();
 #endif
 #ifdef SCTP_PACKET_LOGGING
 	SCTP_IP_PKTLOG_DESTROY();
@@ -7068,7 +7066,6 @@ retry:
 #endif
 #if defined(__Userspace__)
 	SCTP_TIMERQ_LOCK_DESTROY();
-	SCTP_TIMERWAIT_LOCK_DESTROY();
 	SCTP_ZONE_DESTROY(zone_mbuf);
 	SCTP_ZONE_DESTROY(zone_clust);
 	SCTP_ZONE_DESTROY(zone_ext_refcnt);

--- a/usrsctplib/netinet/sctp_userspace.c
+++ b/usrsctplib/netinet/sctp_userspace.c
@@ -68,19 +68,6 @@ sctp_userspace_thread_create(userland_thread_t *thread, start_routine_t start_ro
 	return 0;
 }
 
-int
-sctp_userspace_thread_id(userland_thread_id_t *thread)
-{
-	*thread = GetCurrentThreadId();
-	return 0;
-}
-
-int
-sctp_userspace_thread_equal(userland_thread_id_t t1, userland_thread_id_t t2)
-{
-	return (t1 == t2);
-}
-
 #if defined(__MINGW32__)
 #pragma GCC diagnostic pop
 #endif
@@ -90,19 +77,6 @@ int
 sctp_userspace_thread_create(userland_thread_t *thread, start_routine_t start_routine)
 {
 	return pthread_create(thread, NULL, start_routine, NULL);
-}
-
-int
-sctp_userspace_thread_id(userland_thread_id_t *thread)
-{
-	*thread = pthread_self();
-	return 0;
-}
-
-int
-sctp_userspace_thread_equal(userland_thread_id_t t1, userland_thread_id_t t2)
-{
-	return pthread_equal(t1, t2);
 }
 #endif
 


### PR DESCRIPTION
These commits attempted to fix a crash caused by freeing a timer's memory while the timer's callout is currently executing (meaning `sctp_timer_stop` couldn't stop it).

The attempted solution was to wait for the callout's completion in `sctp_timer_stop`. However, in the very likely case that the callout is waiting to acquire locks that the thread calling `sctp_timer_stop` owns, this will result in a deadlock.

This has a chance to happen not only when timers are being freed, but *any* time `sctp_timer_stop` is called. Effectively trading a low risk of a crash for a high risk of a deadlock.

Reverting these commits will fix #414 and fix #325.

Note that this PR attempts to solve the original problem in a different way, using pre-existing reference counts: https://github.com/sctplab/usrsctp/pull/417