### PR TITLE
Fix error with -fsanitize=alignment.

### DIFF
--- a/usrsctplib/netinet/sctp_uio.h
+++ b/usrsctplib/netinet/sctp_uio.h
@@ -662,23 +662,19 @@ struct sctp_setpeerprim {
 	uint8_t sspp_padding[4];
 };
 
-/*
- * This is necessary to prevent misaligned access to a sockaddr_conn.
- *
- * On a 64 bit system, sockaddr_conn is 8-byte aligned due to one of its
- * members being a pointer. However, sockaddr is only 4-byte aligned, so
- * without this union the compiler would not insert the necessary padding
- * between sget_assoc_id and addr.
- */
-union sockaddr_union {
-	struct sockaddr addr;
-	struct sockaddr_conn addr_conn;
+union sctp_sockstore {
+	struct sockaddr_in sin;
+	struct sockaddr_in6 sin6;
+#if defined(__Userspace__)
+	struct sockaddr_conn sconn;
+#endif
+	struct sockaddr sa;
 };
 
 struct sctp_getaddresses {
 	sctp_assoc_t sget_assoc_id;
 	/* addr is filled in for N * sockaddr_storage */
-	union sockaddr_union addr[1];
+	union sctp_sockstore addr[1];
 };
 
 struct sctp_status {
@@ -1149,14 +1145,6 @@ struct sctpstat {
 #define SCTP_STAT_DECR_COUNTER64(_x) SCTP_STAT_DECR(_x)
 #define SCTP_STAT_DECR_GAUGE32(_x) SCTP_STAT_DECR(_x)
 
-union sctp_sockstore {
-	struct sockaddr_in sin;
-	struct sockaddr_in6 sin6;
-#if defined(__Userspace__)
-	struct sockaddr_conn sconn;
-#endif
-	struct sockaddr sa;
-};
 
 
 /***********************************/

--- a/usrsctplib/netinet/sctp_uio.h
+++ b/usrsctplib/netinet/sctp_uio.h
@@ -662,10 +662,23 @@ struct sctp_setpeerprim {
 	uint8_t sspp_padding[4];
 };
 
+/*
+ * This is necessary to prevent misaligned access to a sockaddr_conn.
+ *
+ * On a 64 bit system, sockaddr_conn is 8-byte aligned due to one of its
+ * members being a pointer. However, sockaddr is only 4-byte aligned, so
+ * without this union the compiler would not insert the necessary padding
+ * between sget_assoc_id and addr.
+ */
+union sockaddr_union {
+	struct sockaddr addr;
+	struct sockaddr_conn addr_conn;
+};
+
 struct sctp_getaddresses {
 	sctp_assoc_t sget_assoc_id;
 	/* addr is filled in for N * sockaddr_storage */
-	struct sockaddr addr[1];
+	union sockaddr_union addr[1];
 };
 
 struct sctp_status {

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -6965,7 +6965,7 @@ sctp_setopt(struct socket *so, int optname, void *optval, size_t optsize,
 		SCTP_CHECK_AND_CAST(addrs, optval, struct sctp_getaddresses,
 				    optsize);
 #ifdef INET
-		if (addrs->addr->sa_family == AF_INET) {
+		if (addrs->addr->sa.sa_family == AF_INET) {
 			if (optsize < sizeof(struct sctp_getaddresses) - sizeof(struct sockaddr) + sizeof(struct sockaddr_in)) {
 				SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_USRREQ, EINVAL);
 				error = EINVAL;
@@ -6980,7 +6980,7 @@ sctp_setopt(struct socket *so, int optname, void *optval, size_t optsize,
 		} else
 #endif
 #ifdef INET6
-		if (addrs->addr->sa_family == AF_INET6) {
+		if (addrs->addr->sa.sa_family == AF_INET6) {
 			if (optsize < sizeof(struct sctp_getaddresses) - sizeof(struct sockaddr) + sizeof(struct sockaddr_in6)) {
 				SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_USRREQ, EINVAL);
 				error = EINVAL;
@@ -6999,7 +6999,7 @@ sctp_setopt(struct socket *so, int optname, void *optval, size_t optsize,
 		       error = EAFNOSUPPORT;
 		       break;
 		}
-		sctp_bindx_add_address(so, inp, addrs->addr,
+		sctp_bindx_add_address(so, inp, &addrs->addr->sa,
 				       addrs->sget_assoc_id, vrf_id,
 				       &error, p);
 		break;
@@ -7014,7 +7014,7 @@ sctp_setopt(struct socket *so, int optname, void *optval, size_t optsize,
 #endif
 		SCTP_CHECK_AND_CAST(addrs, optval, struct sctp_getaddresses, optsize);
 #ifdef INET
-		if (addrs->addr->sa_family == AF_INET) {
+		if (addrs->addr->sa.sa_family == AF_INET) {
 			if (optsize < sizeof(struct sctp_getaddresses) - sizeof(struct sockaddr) + sizeof(struct sockaddr_in)) {
 				SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_USRREQ, EINVAL);
 				error = EINVAL;
@@ -7029,7 +7029,7 @@ sctp_setopt(struct socket *so, int optname, void *optval, size_t optsize,
 		} else
 #endif
 #ifdef INET6
-		if (addrs->addr->sa_family == AF_INET6) {
+		if (addrs->addr->sa.sa_family == AF_INET6) {
 			if (optsize < sizeof(struct sctp_getaddresses) - sizeof(struct sockaddr) + sizeof(struct sockaddr_in6)) {
 				SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_USRREQ, EINVAL);
 				error = EINVAL;
@@ -7050,7 +7050,7 @@ sctp_setopt(struct socket *so, int optname, void *optval, size_t optsize,
 			error = EAFNOSUPPORT;
 			break;
 		}
-		sctp_bindx_delete_address(inp, addrs->addr,
+		sctp_bindx_delete_address(inp, &addrs->addr->sa,
 					  addrs->sget_assoc_id, vrf_id,
 					  &error);
 		break;

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -3021,7 +3021,7 @@ usrsctp_freeladdrs(struct sockaddr *addrs)
 	/* Take away the hidden association id */
 	void *fr_addr;
 
-	fr_addr = (void *)((caddr_t)addrs - sizeof(sctp_assoc_t));
+	fr_addr = (void *)((caddr_t)addrs - offsetof(struct sctp_getaddresses,addr));
 	/* Now free it */
 	free(fr_addr);
 }

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -2695,7 +2695,7 @@ usrsctp_bindx(struct socket *so, struct sockaddr *addrs, int addrcnt, int flags)
 		memcpy(gaddrs->addr, sa, sa->sa_len);
 #if defined(INET) || defined(INET6)
 		if ((i == 0) && (sport != 0)) {
-			switch (gaddrs->addr->sa_family) {
+			switch (gaddrs->addr->sa.sa_family) {
 #ifdef INET
 			case AF_INET:
 				sin = (struct sockaddr_in *)gaddrs->addr;
@@ -2740,7 +2740,7 @@ usrsctp_bindx(struct socket *so, struct sockaddr *addrs, int addrcnt, int flags)
 		 */
 #if defined(INET) || defined(INET6)
 		if ((i == 0) && (sport != 0)) {
-			switch (gaddrs->addr->sa_family) {
+			switch (gaddrs->addr->sa.sa_family) {
 #ifdef INET
 			case AF_INET:
 				sin = (struct sockaddr_in *)gaddrs->addr;


### PR DESCRIPTION
The issue is with sctp_getaddresses, when casting addr to a sockaddr_conn.

On a 64 bit system, sockaddr_conn is 8-byte aligned due to one of its members
being a pointer. However, sockaddr is only 4-byte aligned, so the compiler
doesn't know it needs to insert four bytes of padding.

The solution is simply to use a union of sockaddr and sockaddr_conn.

Fixes #437.