### PR TITLE
Fix gcc compilation error

### DIFF
--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -1276,13 +1276,6 @@ sctp_disconnect(struct socket *so)
 				 * we will allow user data to be sent first
 				 * and move to SHUTDOWN-PENDING
 				 */
-				struct sctp_nets *netp;
-				if (stcb->asoc.alternate) {
-					netp = stcb->asoc.alternate;
-				} else {
-					netp = stcb->asoc.primary_destination;
-				}
-
 				SCTP_ADD_SUBSTATE(stcb, SCTP_STATE_SHUTDOWN_PENDING);
 				sctp_timer_start(SCTP_TIMER_TYPE_SHUTDOWNGUARD, stcb->sctp_ep, stcb, NULL);
 				if ((*asoc->ss_functions.sctp_ss_is_user_msgs_incomplete)(stcb, asoc)) {


### PR DESCRIPTION
The commit d07a5f27630b1250655337791adf2a4c171a6712 from yesterday causes gcc to fail with this error in `sctp_usrreq.c`:

```
netinet/sctp_usrreq.c: In function ‘sctp_disconnect’:
netinet/sctp_usrreq.c:1279:23: error: variable ‘netp’ set but not used [-Werror=unused-but-set-variable]
 1279 |     struct sctp_nets *netp;
      |                       ^~~~
```

Apparently it doesn't trigger any warning when using clang instead. This pull request simply gets rid of the `netp` inizialitation, since where the error occurs the variable is not used anymore (`NULL` is now always passed to `sctp_timer_start`).