### PR TITLE
Get rid of unnecessary include in fuzzer.

### DIFF
--- a/fuzzer/fuzzer_connect.c
+++ b/fuzzer/fuzzer_connect.c
@@ -33,7 +33,6 @@
 #include <string.h>
 #include <stdarg.h>
 #include <assert.h>
-#include <sys/time.h>
 #include <usrsctp.h>
 #include "../programs/programs_helper.h"
 


### PR DESCRIPTION
The <sys/time.h> header is unused and is breaking the Windows build.