### PR TITLE
Fix OOB read with sctp_getopt(SCTP_STATUS) and AF_CONN

### DIFF
--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -3390,10 +3390,17 @@ sctp_getopt(struct socket *so, int optname, void *optval, size_t *optsize,
 				memcpy(&sstat->sstat_primary.spinfo_address,
 				       &stcb->asoc.primary_destination->ro._l_addr,
 				       sizeof(struct sockaddr_in));
-			} else {
+			} else if (stcb->asoc.primary_destination->ro._l_addr.sa.sa_family == AF_INET6) {
 				memcpy(&sstat->sstat_primary.spinfo_address,
 				       &stcb->asoc.primary_destination->ro._l_addr,
 				       sizeof(struct sockaddr_in6));
+			} else if (stcb->asoc.primary_destination->ro._l_addr.sa.sa_family == AF_CONN) {
+				memcpy(&sstat->sstat_primary.spinfo_address,
+				       &stcb->asoc.primary_destination->ro._l_addr,
+				       sizeof(struct sockaddr_conn));
+			} else {
+				error = EAFNOSUPPORT;
+				break;
 			}
 #endif
 			((struct sockaddr_in *)&sstat->sstat_primary.spinfo_address)->sin_port = stcb->rport;


### PR DESCRIPTION
The code was assuming the address was either AF_INET or AF_INET6, resulting in an out of bounds read if it's actually AF_CONN.

I'm pretty confident this will just be reading some extra zeros, since new `sctp_nets`s are always memset to 0. But still, might as well fix it to err on the safe side.