### PR TITLE
Clang module compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,11 +46,11 @@ APPCFLAGS=""
 case $host_os in
 darwin*)
   CFLAGS="$CFLAGS -std=c99 -Wno-deprecated-declarations -D__APPLE_USE_RFC_2292"
-  LIBCFLAGS="$LIBCFLAGS -U__APPLE__ -D__Userspace_os_Darwin"
+  LIBCFLAGS="$LIBCFLAGS -D__Userspace_os_Darwin"
   ;;
 dragonfly*)
   CFLAGS="$CFLAGS -std=c99 -pthread"
-  LIBCFLAGS="$LIBCFLAGS -U__DragonFly__ -D__Userspace_os_DragonFly"
+  LIBCFLAGS="$LIBCFLAGS -D__Userspace_os_DragonFly"
   ;;
 freebsd*)
   CFLAGS="$CFLAGS -std=c99 -pthread"
@@ -58,7 +58,7 @@ freebsd*)
     CFLAGS="$CFLAGS -Wno-unknown-warning-option"
     LDFLAGS="$LDFLAGS -Qunused-arguments"
   fi
-  LIBCFLAGS="$LIBCFLAGS -U__FreeBSD__ -D__Userspace_os_FreeBSD"
+  LIBCFLAGS="$LIBCFLAGS -D__Userspace_os_FreeBSD"
   ;;
 linux*)
   CFLAGS="$CFLAGS -std=c99 -pthread -D_GNU_SOURCE -Wno-address-of-packed-member"
@@ -66,11 +66,11 @@ linux*)
   ;;
 netbsd*)
   CFLAGS="$CFLAGS -std=c99 -pthread"
-  LIBCFLAGS="$LIBCFLAGS -U__NetBSD__ -D__Userspace_os_NetBSD"
+  LIBCFLAGS="$LIBCFLAGS -D__Userspace_os_NetBSD"
   ;;
 openbsd*)
   CFLAGS="$CFLAGS -std=c99 -pthread"
-  LIBCFLAGS="$LIBCFLAGS -U__OpenBSD__ -D__Userspace_os_OpenBSD"
+  LIBCFLAGS="$LIBCFLAGS -D__Userspace_os_OpenBSD"
   ;;
 solaris*)
   CFLAGS="$CFLAGS -D_XPG4_2"

--- a/meson.build
+++ b/meson.build
@@ -64,7 +64,6 @@ if system in ['linux', 'android']
 elif system == 'freebsd'
     add_project_arguments([
         '-D__Userspace_os_FreeBSD',
-        '-U__FreeBSD__',
     ] + compiler.get_supported_arguments([
         '-Wno-address-of-packed-member',
     ]), language: 'c')
@@ -79,17 +78,14 @@ elif system in ['darwin', 'ios']
 elif system == 'dragonfly'
     add_project_arguments([
         '-D__Userspace_os_DragonFly',
-        '-U__DragonFly__',
     ], language: 'c')
 elif system == 'netbsd'
     add_project_arguments([
         '-D__Userspace_os_NetBSD',
-        '-U__NetBSD__',
     ], language: 'c')
 elif system == 'openbsd'
     add_project_arguments([
         '-D__Userspace_os_OpenBSD',
-        '-U__OpenBSD__',
     ], language: 'c')
 elif system == 'windows'
     add_project_arguments('-D__Userspace_os_Windows', language: 'c')
@@ -207,8 +203,7 @@ else
         dependencies: dependencies,
         include_directories: include_dirs,
         install: true,
-        version: meson.project_version(),
-        c_args: '-U__APPLE__')
+        version: meson.project_version())
 endif
 
 # Declare dependency

--- a/programs/ekr_client.c
+++ b/programs/ekr_client.c
@@ -76,7 +76,7 @@ handle_packets(void *arg)
 	fdp = (int *)arg;
 #endif
 	for (;;) {
-#if defined(__NetBSD__)
+#if defined(SCTP_KERNEL_NetBSD)
 		pthread_testcancel();
 #endif
 		length = recv(*fdp, buf, MAX_PACKET_SIZE, 0);

--- a/programs/ekr_loop.c
+++ b/programs/ekr_loop.c
@@ -77,7 +77,7 @@ handle_packets(void *arg)
 	fdp = (int *)arg;
 #endif
 	for (;;) {
-#if defined(__NetBSD__)
+#if defined(SCTP_KERNEL_NetBSD)
 		pthread_testcancel();
 #endif
 		length = recv(*fdp, buf, MAX_PACKET_SIZE, 0);

--- a/programs/ekr_loop_offload.c
+++ b/programs/ekr_loop_offload.c
@@ -78,7 +78,7 @@ handle_packets(void *arg)
 	fdp = (int *)arg;
 #endif
 	for (;;) {
-#if defined(__NetBSD__)
+#if defined(SCTP_KERNEL_NetBSD)
 		pthread_testcancel();
 #endif
 		length = recv(*fdp, buffer, MAX_PACKET_SIZE, 0);

--- a/programs/ekr_loop_upcall.c
+++ b/programs/ekr_loop_upcall.c
@@ -78,7 +78,7 @@ handle_packets(void *arg)
 	fdp = (int *)arg;
 #endif
 	for (;;) {
-#if defined(__NetBSD__)
+#if defined(SCTP_KERNEL_NetBSD)
 		pthread_testcancel();
 #endif
 		length = recv(*fdp, buf, MAX_PACKET_SIZE, 0);

--- a/programs/ekr_peer.c
+++ b/programs/ekr_peer.c
@@ -76,7 +76,7 @@ handle_packets(void *arg)
 	fdp = (int *)arg;
 #endif
 	for (;;) {
-#if defined(__NetBSD__)
+#if defined(SCTP_KERNEL_NetBSD)
 		pthread_testcancel();
 #endif
 		length = recv(*fdp, buf, MAX_PACKET_SIZE, 0);

--- a/programs/ekr_server.c
+++ b/programs/ekr_server.c
@@ -77,7 +77,7 @@ handle_packets(void *arg)
 	fdp = (int *)arg;
 #endif
 	for (;;) {
-#if defined(__NetBSD__)
+#if defined(SCTP_KERNEL_NetBSD)
 		pthread_testcancel();
 #endif
 		length = recv(*fdp, buf, MAX_PACKET_SIZE, 0);

--- a/usrsctplib/CMakeLists.txt
+++ b/usrsctplib/CMakeLists.txt
@@ -69,26 +69,10 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
 	add_definitions(-D_GNU_SOURCE)
 endif ()
 
-if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-	add_definitions(-U__FreeBSD__)
-endif ()
-
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
-	add_definitions(-U__APPLE__)
 	add_definitions(-D__APPLE_USE_RFC_2292)
 endif ()
 
-if (CMAKE_SYSTEM_NAME MATCHES "DragonFly")
-	add_definitions(-U__DragonFly__)
-endif ()
-
-if (CMAKE_SYSTEM_NAME MATCHES "NetBSD")
-	add_definitions(-U__NetBSD__)
-endif ()
-
-if (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
-	add_definitions(-U__OpenBSD__)
-endif ()
 
 #################################################
 # MISC

--- a/usrsctplib/netinet/sctp.h
+++ b/usrsctplib/netinet/sctp.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp.h 356357 2020-01-04 20:33:12Z tuexen $");
 #endif
@@ -40,7 +40,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp.h 356357 2020-01-04 20:33:12Z tuexen $
 #ifndef _NETINET_SCTP_H_
 #define _NETINET_SCTP_H_
 
-#if (defined(__APPLE__) || defined(__Userspace_os_Linux) || defined(__Userspace_os_Darwin))
+#if (defined(SCTP_KERNEL_APPLE) || defined(__Userspace_os_Linux) || defined(__Userspace_os_Darwin))
 #include <stdint.h>
 #endif
 
@@ -286,7 +286,7 @@ struct sctp_paramhdr {
 #define SCTP_PEELOFF                    0x0000800a
 /* the real worker for sctp_getaddrlen() */
 #define SCTP_GET_ADDR_LEN               0x0000800b
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 /* temporary workaround for Apple listen() issue, no args used */
 #define SCTP_LISTEN_FIX			0x0000800c
 #endif

--- a/usrsctplib/netinet/sctp_asconf.c
+++ b/usrsctplib/netinet/sctp_asconf.c
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_asconf.c 359195 2020-03-21 16:12:19Z tuexen $");
 #endif
@@ -53,7 +53,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_asconf.c 359195 2020-03-21 16:12:19Z t
  * SCTP_DEBUG_ASCONF2: detailed info
  */
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #define APPLE_FILE_NO 1
 #endif
 
@@ -1057,7 +1057,7 @@ sctp_assoc_immediate_retrans(struct sctp_tcb *stcb, struct sctp_nets *dstnet)
 	return;
 }
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Userspace__)
 static int
 sctp_asconf_queue_mgmt(struct sctp_tcb *, struct sctp_ifa *, uint16_t);
 
@@ -1186,7 +1186,7 @@ sctp_path_check_and_react(struct sctp_tcb *stcb, struct sctp_ifa *newifa)
 		}
 	}
 }
-#endif /* __FreeBSD__  __APPLE__  __Userspace__ */
+#endif /* SCTP_KERNEL_FreeBSD  SCTP_KERNEL_APPLE  __Userspace__ */
 
 /*
  * process an ADD/DELETE IP ack from peer.
@@ -1210,7 +1210,7 @@ sctp_asconf_addr_mgmt_ack(struct sctp_tcb *stcb, struct sctp_ifa *addr, uint32_t
 		/* success case, so remove from the restricted list */
 		sctp_del_local_addr_restricted(stcb, addr);
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Userspace__)
 		if (sctp_is_mobility_feature_on(stcb->sctp_ep,
 		                                SCTP_MOBILITY_BASE) ||
 		    sctp_is_mobility_feature_on(stcb->sctp_ep,
@@ -1218,7 +1218,7 @@ sctp_asconf_addr_mgmt_ack(struct sctp_tcb *stcb, struct sctp_ifa *addr, uint32_t
 			sctp_path_check_and_react(stcb, addr);
 			return;
 		}
-#endif /* __FreeBSD__ __APPLE__ __Userspace__ */
+#endif /* SCTP_KERNEL_FreeBSD SCTP_KERNEL_APPLE __Userspace__ */
 		/* clear any cached/topologically incorrect source addresses */
 		sctp_asconf_nets_cleanup(stcb, addr->ifn_p);
 	}
@@ -1925,7 +1925,7 @@ sctp_addr_mgmt_assoc(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 	switch (ifa->address.sa.sa_family) {
 #ifdef INET6
 	case AF_INET6:
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		if (prison_check_ip6(inp->ip_inp.inp.inp_cred,
 		                     &ifa->address.sin6.sin6_addr) != 0) {
 			return;
@@ -1935,7 +1935,7 @@ sctp_addr_mgmt_assoc(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 #endif
 #ifdef INET
 	case AF_INET:
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		if (prison_check_ip4(inp->ip_inp.inp.inp_cred,
 		                     &ifa->address.sin.sin_addr) != 0) {
 			return;
@@ -2164,7 +2164,7 @@ sctp_asconf_iterator_stcb(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 				/* we skip unspecifed addresses */
 				continue;
 			}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			if (prison_check_ip6(inp->ip_inp.inp.inp_cred,
 			                     &sin6->sin6_addr) != 0) {
 				continue;
@@ -2198,7 +2198,7 @@ sctp_asconf_iterator_stcb(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 				/* we skip unspecifed addresses */
 				continue;
 			}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			if (prison_check_ip4(inp->ip_inp.inp.inp_cred,
 			                     &sin->sin_addr) != 0) {
 				continue;
@@ -2487,7 +2487,7 @@ sctp_find_valid_localaddr(struct sctp_tcb *stcb, int addr_locked)
 						/* skip unspecifed addresses */
 						continue;
 					}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 					if (prison_check_ip4(stcb->sctp_ep->ip_inp.inp.inp_cred,
 					                     &sin->sin_addr) != 0) {
 						continue;
@@ -2521,7 +2521,7 @@ sctp_find_valid_localaddr(struct sctp_tcb *stcb, int addr_locked)
 						/* we skip unspecifed addresses */
 						continue;
 					}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 					if (prison_check_ip6(stcb->sctp_ep->ip_inp.inp.inp_cred,
 					                     &sin6->sin6_addr) != 0) {
 						continue;
@@ -3119,7 +3119,7 @@ sctp_check_address_list_all(struct sctp_tcb *stcb, struct mbuf *m, int offset,
 #ifdef INET
 			case AF_INET:
 				sin = &sctp_ifa->address.sin;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				if (prison_check_ip4(stcb->sctp_ep->ip_inp.inp.inp_cred,
 				                     &sin->sin_addr) != 0) {
 					continue;
@@ -3135,7 +3135,7 @@ sctp_check_address_list_all(struct sctp_tcb *stcb, struct mbuf *m, int offset,
 #ifdef INET6
 			case AF_INET6:
 				sin6 = &sctp_ifa->address.sin6;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				if (prison_check_ip6(stcb->sctp_ep->ip_inp.inp.inp_cred,
 				                     &sin6->sin6_addr) != 0) {
 					continue;
@@ -3445,7 +3445,7 @@ sctp_asconf_send_nat_state_update(struct sctp_tcb *stcb,
 #ifdef INET
 				case AF_INET:
 					to = &sctp_ifap->address.sin;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 					if (prison_check_ip4(stcb->sctp_ep->ip_inp.inp.inp_cred,
 					                     &to->sin_addr) != 0) {
 						continue;
@@ -3462,7 +3462,7 @@ sctp_asconf_send_nat_state_update(struct sctp_tcb *stcb,
 #ifdef INET6
 				case AF_INET6:
 					to6 = &sctp_ifap->address.sin6;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 					if (prison_check_ip6(stcb->sctp_ep->ip_inp.inp.inp_cred,
 					                     &to6->sin6_addr) != 0) {
 						continue;

--- a/usrsctplib/netinet/sctp_asconf.h
+++ b/usrsctplib/netinet/sctp_asconf.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_asconf.h 359152 2020-03-19 21:01:16Z tuexen $");
 #endif
@@ -80,7 +80,7 @@ sctp_check_address_list(struct sctp_tcb *, struct mbuf *, int, int,
 
 extern void
 sctp_assoc_immediate_retrans(struct sctp_tcb *, struct sctp_nets *);
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Userspace__)
 extern void
 sctp_net_immediate_retrans(struct sctp_tcb *, struct sctp_nets *);
 #endif

--- a/usrsctplib/netinet/sctp_auth.c
+++ b/usrsctplib/netinet/sctp_auth.c
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_auth.c 355931 2019-12-20 15:25:08Z tuexen $");
 #endif
@@ -568,7 +568,7 @@ sctp_auth_key_acquire(struct sctp_tcb *stcb, uint16_t key_id)
 
 void
 sctp_auth_key_release(struct sctp_tcb *stcb, uint16_t key_id, int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
 	SCTP_UNUSED
 #endif
 )
@@ -1751,7 +1751,7 @@ sctp_handle_auth(struct sctp_tcb *stcb, struct sctp_auth_chunk *auth,
 void
 sctp_notify_authentication(struct sctp_tcb *stcb, uint32_t indication,
 			   uint16_t keyid, uint16_t alt_keyid, int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
 	SCTP_UNUSED
 #endif
 )

--- a/usrsctplib/netinet/sctp_auth.h
+++ b/usrsctplib/netinet/sctp_auth.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_auth.h 338749 2018-09-18 10:53:07Z tuexen $");
 #endif

--- a/usrsctplib/netinet/sctp_bsd_addr.h
+++ b/usrsctplib/netinet/sctp_bsd_addr.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_bsd_addr.h 353480 2019-10-13 18:17:08Z tuexen $");
 #endif
@@ -64,7 +64,7 @@ int sctp_copy_out_packet_log(uint8_t *target, int length);
 #if !defined(__Panda__)
 void sctp_addr_change(struct ifaddr *ifa, int cmd);
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 
 void sctp_addr_change_event_handler(void *, struct ifaddr *, int);
 #endif

--- a/usrsctplib/netinet/sctp_callout.c
+++ b/usrsctplib/netinet/sctp_callout.c
@@ -59,7 +59,7 @@
 /*
  * Callout/Timer routines for OS that doesn't have them
  */
-#if defined(__APPLE__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_APPLE) || defined(__Userspace__)
 static uint32_t ticks = 0;
 #else
 extern int ticks;
@@ -180,7 +180,7 @@ sctp_handle_tick(uint32_t elapsed_ticks)
 	SCTP_TIMERQ_UNLOCK();
 }
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 void
 sctp_timeout(void *arg SCTP_UNUSED)
 {

--- a/usrsctplib/netinet/sctp_callout.h
+++ b/usrsctplib/netinet/sctp_callout.h
@@ -30,7 +30,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 #endif
@@ -106,7 +106,7 @@ void sctp_handle_tick(uint32_t);
 #if defined(__Userspace__)
 void sctp_start_timer(void);
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 void sctp_timeout(void *);
 #endif
 

--- a/usrsctplib/netinet/sctp_cc_functions.c
+++ b/usrsctplib/netinet/sctp_cc_functions.c
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_cc_functions.c 359405 2020-03-28 20:25:45Z tuexen $");
 #endif
@@ -50,7 +50,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_cc_functions.c 359405 2020-03-28 20:25
 #include <netinet/sctp_timer.h>
 #include <netinet/sctp_auth.h>
 #include <netinet/sctp_asconf.h>
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #include <netinet/sctp_kdtrace.h>
 #endif
 
@@ -101,7 +101,7 @@ sctp_set_initial_cc_param(struct sctp_tcb *stcb, struct sctp_nets *net)
 	}
 	sctp_enforce_cwnd_limit(assoc, net);
 	net->ssthresh = assoc->peers_rwnd;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	SDT_PROBE5(sctp, cwnd, net, init,
 	          stcb->asoc.my_vtag, ((stcb->sctp_ep->sctp_lport << 16) | (stcb->rport)), net,
 	          0, net->cwnd);
@@ -196,7 +196,7 @@ sctp_cwnd_update_after_fr(struct sctp_tcb *stcb,
 				}
 				net->cwnd = net->ssthresh;
 				sctp_enforce_cwnd_limit(asoc, net);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 				SDT_PROBE5(sctp, cwnd, net, fr,
 					  stcb->asoc.my_vtag, ((stcb->sctp_ep->sctp_lport << 16) | (stcb->rport)), net,
 					  old_cwnd, net->cwnd);
@@ -252,7 +252,7 @@ sctp_cwnd_update_after_fr(struct sctp_tcb *stcb,
 #define SCTP_INST_GAINING 3 /* Gaining, step down possible */
 
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 static int
 cc_bw_same(struct sctp_tcb *stcb, struct sctp_nets *net, uint64_t nbw,
 	   uint64_t rtt_offset, uint64_t vtag, uint8_t inst_ind)
@@ -262,11 +262,11 @@ cc_bw_same(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_t nb
 	   uint64_t rtt_offset, uint8_t inst_ind)
 #endif
 {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	uint64_t oth, probepoint;
 #endif
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	probepoint = (((uint64_t)net->cwnd) << 32);
 #endif
 	if (net->rtt > net->cc_mod.rtcc.lbw_rtt + rtt_offset) {
@@ -275,7 +275,7 @@ cc_bw_same(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_t nb
 		 * we don't update bw.. so we don't
 		 * update the rtt either.
 		 */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		/* Probe point 5 */
 		probepoint |=  ((5 << 16) | 1);
 		SDT_PROBE5(sctp, cwnd, net, rttvar,
@@ -295,7 +295,7 @@ cc_bw_same(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_t nb
 			    ((net->cc_mod.rtcc.step_cnt > net->cc_mod.rtcc.steady_step) &&
 			     ((net->cc_mod.rtcc.step_cnt % net->cc_mod.rtcc.steady_step) == 0))) {
 				/* Try a step down */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 				oth = net->cc_mod.rtcc.vol_reduce;
 				oth <<= 16;
 				oth |= net->cc_mod.rtcc.step_cnt;
@@ -324,7 +324,7 @@ cc_bw_same(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_t nb
 		 * we update both the bw and the rtt here to
 		 * lock this in as a good step down.
 		 */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		/* Probe point 6 */
 		probepoint |=  ((6 << 16) | 0);
 		SDT_PROBE5(sctp, cwnd, net, rttvar,
@@ -335,7 +335,7 @@ cc_bw_same(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_t nb
 			  probepoint);
 #endif
 		if (net->cc_mod.rtcc.steady_step) {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 			oth = net->cc_mod.rtcc.vol_reduce;
 			oth <<= 16;
 			oth |= net->cc_mod.rtcc.step_cnt;
@@ -370,7 +370,7 @@ cc_bw_same(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_t nb
 	}
 	/* Ok bw and rtt remained the same .. no update to any
 	 */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	/* Probe point 7 */
 	probepoint |=  ((7 << 16) | net->cc_mod.rtcc.ret_from_eq);
 	SDT_PROBE5(sctp, cwnd, net, rttvar,
@@ -407,7 +407,7 @@ cc_bw_same(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_t nb
 		return ((int)net->cc_mod.rtcc.ret_from_eq);
 }
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 static int
 cc_bw_decrease(struct sctp_tcb *stcb, struct sctp_nets *net, uint64_t nbw, uint64_t rtt_offset,
 	       uint64_t vtag, uint8_t inst_ind)
@@ -417,12 +417,12 @@ cc_bw_decrease(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_
 	       uint8_t inst_ind)
 #endif
 {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	uint64_t oth, probepoint;
 #endif
 
 	/* Bandwidth decreased.*/
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	probepoint = (((uint64_t)net->cwnd) << 32);
 #endif
 	if (net->rtt  > net->cc_mod.rtcc.lbw_rtt+rtt_offset) {
@@ -431,7 +431,7 @@ cc_bw_decrease(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_
 		if ((net->cwnd > net->cc_mod.rtcc.cwnd_at_bw_set) &&
 		    (inst_ind != SCTP_INST_LOOSING)) {
 			/* We caused it maybe.. back off? */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 			/* PROBE POINT 1 */
 			probepoint |=  ((1 << 16) | 1);
 			SDT_PROBE5(sctp, cwnd, net, rttvar,
@@ -448,7 +448,7 @@ cc_bw_decrease(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_
 			}
 			return (1);
 		}
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		/* Probe point 2 */
 		probepoint |=  ((2 << 16) | 0);
 		SDT_PROBE5(sctp, cwnd, net, rttvar,
@@ -460,7 +460,7 @@ cc_bw_decrease(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_
 #endif
 		/* Someone else - fight for more? */
 		if (net->cc_mod.rtcc.steady_step) {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 			oth = net->cc_mod.rtcc.vol_reduce;
 			oth <<= 16;
 			oth |= net->cc_mod.rtcc.step_cnt;
@@ -488,7 +488,7 @@ cc_bw_decrease(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_
 		goto out_decision;
 	} else  if (net->rtt  < net->cc_mod.rtcc.lbw_rtt-rtt_offset) {
 		/* bw & rtt decreased */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		/* Probe point 3 */
 		probepoint |=  ((3 << 16) | 0);
 		SDT_PROBE5(sctp, cwnd, net, rttvar,
@@ -499,7 +499,7 @@ cc_bw_decrease(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_
 			  probepoint);
 #endif
 		if (net->cc_mod.rtcc.steady_step) {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 			oth = net->cc_mod.rtcc.vol_reduce;
 			oth <<= 16;
 			oth |= net->cc_mod.rtcc.step_cnt;
@@ -524,7 +524,7 @@ cc_bw_decrease(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_
 		goto out_decision;
 	}
 	/* The bw decreased but rtt stayed the same */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	/* Probe point 4 */
 	probepoint |=  ((4 << 16) | 0);
 	SDT_PROBE5(sctp, cwnd, net, rttvar,
@@ -535,7 +535,7 @@ cc_bw_decrease(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_
 		  probepoint);
 #endif
 	if (net->cc_mod.rtcc.steady_step) {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		oth = net->cc_mod.rtcc.vol_reduce;
 		oth <<= 16;
 		oth |= net->cc_mod.rtcc.step_cnt;
@@ -568,7 +568,7 @@ out_decision:
 	}
 }
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 static int
 cc_bw_increase(struct sctp_tcb *stcb, struct sctp_nets *net, uint64_t nbw, uint64_t vtag)
 #else
@@ -576,7 +576,7 @@ static int
 cc_bw_increase(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_t nbw)
 #endif
 {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	uint64_t oth, probepoint;
 
 #endif
@@ -586,7 +586,7 @@ cc_bw_increase(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_
 	 * update. Note that we pay no attention to
 	 * the inst_ind since our overall sum is increasing.
 	 */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	/* PROBE POINT 0 */
 	probepoint = (((uint64_t)net->cwnd) << 32);
 	SDT_PROBE5(sctp, cwnd, net, rttvar,
@@ -597,7 +597,7 @@ cc_bw_increase(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net, uint64_
 		  probepoint);
 #endif
 	if (net->cc_mod.rtcc.steady_step) {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		oth = net->cc_mod.rtcc.vol_reduce;
 		oth <<= 16;
 		oth |= net->cc_mod.rtcc.step_cnt;
@@ -627,7 +627,7 @@ static int
 cc_bw_limit(struct sctp_tcb *stcb, struct sctp_nets *net, uint64_t nbw)
 {
 	uint64_t bw_offset, rtt_offset;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	uint64_t probepoint, rtt, vtag;
 #endif
 	uint64_t bytes_for_this_rtt, inst_bw;
@@ -673,7 +673,7 @@ cc_bw_limit(struct sctp_tcb *stcb, struct sctp_nets *net, uint64_t nbw)
 	 * change within 1/32nd
 	 */
 	bw_shift = SCTP_BASE_SYSCTL(sctp_rttvar_bw);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	rtt = stcb->asoc.my_vtag;
 	vtag = (rtt << 32) | (((uint32_t)(stcb->sctp_ep->sctp_lport)) << 16) | (stcb->rport);
 	probepoint = (((uint64_t)net->cwnd) << 32);
@@ -694,12 +694,12 @@ cc_bw_limit(struct sctp_tcb *stcb, struct sctp_nets *net, uint64_t nbw)
 					inst_ind = SCTP_INST_LOOSING;
 				else
 					inst_ind = SCTP_INST_NEUTRAL;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 				probepoint |=  ((0xb << 16) | inst_ind);
 #endif
 			} else {
 				inst_ind = net->cc_mod.rtcc.last_inst_ind;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 				inst_bw = bytes_for_this_rtt / (uint64_t)(net->rtt);
 				/* Can't determine do not change */
 				probepoint |=  ((0xc << 16) | inst_ind);
@@ -707,13 +707,13 @@ cc_bw_limit(struct sctp_tcb *stcb, struct sctp_nets *net, uint64_t nbw)
 			}
 		} else {
 			inst_ind = net->cc_mod.rtcc.last_inst_ind;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 			inst_bw = bytes_for_this_rtt;
 			/* Can't determine do not change */
 			probepoint |=  ((0xd << 16) | inst_ind);
 #endif
 		}
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		SDT_PROBE5(sctp, cwnd, net, rttvar,
 			  vtag,
 			  ((nbw << 32) | inst_bw),
@@ -727,7 +727,7 @@ cc_bw_limit(struct sctp_tcb *stcb, struct sctp_nets *net, uint64_t nbw)
 	}
 	bw_offset = net->cc_mod.rtcc.lbw >> bw_shift;
 	if (nbw > net->cc_mod.rtcc.lbw + bw_offset) {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		ret = cc_bw_increase(stcb, net, nbw, vtag);
 #else
 		ret = cc_bw_increase(stcb, net, nbw);
@@ -736,7 +736,7 @@ cc_bw_limit(struct sctp_tcb *stcb, struct sctp_nets *net, uint64_t nbw)
 	}
 	rtt_offset = net->cc_mod.rtcc.lbw_rtt >> SCTP_BASE_SYSCTL(sctp_rttvar_rtt);
 	if (nbw < net->cc_mod.rtcc.lbw - bw_offset) {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		ret = cc_bw_decrease(stcb, net, nbw, rtt_offset, vtag, inst_ind);
 #else
 		ret = cc_bw_decrease(stcb, net, nbw, rtt_offset, inst_ind);
@@ -747,7 +747,7 @@ cc_bw_limit(struct sctp_tcb *stcb, struct sctp_nets *net, uint64_t nbw)
 	 * we are in a situation where
 	 * the bw stayed the same.
 	 */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	ret = cc_bw_same(stcb, net, nbw, rtt_offset, vtag, inst_ind);
 #else
 	ret = cc_bw_same(stcb, net, nbw, rtt_offset, inst_ind);
@@ -763,7 +763,7 @@ sctp_cwnd_update_after_sack_common(struct sctp_tcb *stcb,
 				   int accum_moved, int reneged_all SCTP_UNUSED, int will_exit, int use_rtcc)
 {
 	struct sctp_nets *net;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	int old_cwnd;
 #endif
 	uint32_t t_ssthresh, t_cwnd, incr;
@@ -879,7 +879,7 @@ sctp_cwnd_update_after_sack_common(struct sctp_tcb *stcb,
 					continue;
 				}
 			} else {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 				uint64_t vtag, probepoint;
 
 				probepoint = (((uint64_t)net->cwnd) << 32);
@@ -915,7 +915,7 @@ sctp_cwnd_update_after_sack_common(struct sctp_tcb *stcb,
 				if (net->flight_size + net->net_ack >= net->cwnd) {
 					uint32_t limit;
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 					old_cwnd = net->cwnd;
 #endif
 					switch (asoc->sctp_cmt_on_off) {
@@ -987,7 +987,7 @@ sctp_cwnd_update_after_sack_common(struct sctp_tcb *stcb,
 						sctp_log_cwnd(stcb, net, incr,
 						              SCTP_CWND_LOG_FROM_SS);
 					}
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 					SDT_PROBE5(sctp, cwnd, net, ack,
 					          stcb->asoc.my_vtag,
 					          ((stcb->sctp_ep->sctp_lport << 16) | (stcb->rport)),
@@ -1010,7 +1010,7 @@ sctp_cwnd_update_after_sack_common(struct sctp_tcb *stcb,
 				if ((net->flight_size + net->net_ack >= net->cwnd) &&
                                     (net->partial_bytes_acked >= net->cwnd)) {
 					net->partial_bytes_acked -= net->cwnd;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 					old_cwnd = net->cwnd;
 #endif
 					switch (asoc->sctp_cmt_on_off) {
@@ -1051,7 +1051,7 @@ sctp_cwnd_update_after_sack_common(struct sctp_tcb *stcb,
 					}
 					net->cwnd += incr;
 					sctp_enforce_cwnd_limit(asoc, net);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 					SDT_PROBE5(sctp, cwnd, net, ack,
 						  stcb->asoc.my_vtag,
 						  ((stcb->sctp_ep->sctp_lport << 16) | (stcb->rport)),
@@ -1078,7 +1078,7 @@ sctp_cwnd_update_after_sack_common(struct sctp_tcb *stcb,
 	}
 }
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 static void
 sctp_cwnd_update_exit_pf_common(struct sctp_tcb *stcb, struct sctp_nets *net)
 #else
@@ -1086,13 +1086,13 @@ static void
 sctp_cwnd_update_exit_pf_common(struct sctp_tcb *stcb SCTP_UNUSED, struct sctp_nets *net)
 #endif
 {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	int old_cwnd;
 
 	old_cwnd = net->cwnd;
 #endif
 	net->cwnd = net->mtu;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	SDT_PROBE5(sctp, cwnd, net, ack,
 	          stcb->asoc.my_vtag, ((stcb->sctp_ep->sctp_lport << 16) | (stcb->rport)), net,
 	          old_cwnd, net->cwnd);
@@ -1165,7 +1165,7 @@ sctp_cwnd_update_after_timeout(struct sctp_tcb *stcb, struct sctp_nets *net)
 	}
 	net->cwnd = net->mtu;
 	net->partial_bytes_acked = 0;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	SDT_PROBE5(sctp, cwnd, net, to,
 		  stcb->asoc.my_vtag,
 		  ((stcb->sctp_ep->sctp_lport << 16) | (stcb->rport)),
@@ -1220,7 +1220,7 @@ sctp_cwnd_update_after_ecn_echo_common(struct sctp_tcb *stcb, struct sctp_nets *
 				net->RTO <<= 1;
 			}
 			net->cwnd = net->ssthresh;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 			SDT_PROBE5(sctp, cwnd, net, ecn,
 				  stcb->asoc.my_vtag,
 				  ((stcb->sctp_ep->sctp_lport << 16) | (stcb->rport)),
@@ -1341,7 +1341,7 @@ sctp_cwnd_update_after_packet_dropped(struct sctp_tcb *stcb,
 	sctp_enforce_cwnd_limit(&stcb->asoc, net);
 	if (net->cwnd - old_cwnd != 0) {
 		/* log only changes */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		SDT_PROBE5(sctp, cwnd, net, pd,
 			  stcb->asoc.my_vtag,
 			  ((stcb->sctp_ep->sctp_lport << 16) | (stcb->rport)),
@@ -1366,7 +1366,7 @@ sctp_cwnd_update_after_output(struct sctp_tcb *stcb,
 	if (burst_limit) {
 		net->cwnd = (net->flight_size + (burst_limit * net->mtu));
 		sctp_enforce_cwnd_limit(&stcb->asoc, net);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		SDT_PROBE5(sctp, cwnd, net, bl,
 			  stcb->asoc.my_vtag,
 			  ((stcb->sctp_ep->sctp_lport << 16) | (stcb->rport)),
@@ -1433,12 +1433,12 @@ static void
 sctp_cwnd_new_rtcc_transmission_begins(struct sctp_tcb *stcb,
 				       struct sctp_nets *net)
 {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	uint64_t vtag, probepoint;
 
 #endif
 	if (net->cc_mod.rtcc.lbw) {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 		/* Clear the old bw.. we went to 0 in-flight */
 		vtag = (net->rtt << 32) | (((uint32_t)(stcb->sctp_ep->sctp_lport)) << 16) |
 			(stcb->rport);
@@ -1494,13 +1494,13 @@ static void
 sctp_set_rtcc_initial_cc_param(struct sctp_tcb *stcb,
 			       struct sctp_nets *net)
 {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	uint64_t vtag, probepoint;
 
 #endif
 	sctp_set_initial_cc_param(stcb, net);
 	stcb->asoc.use_precise_time = 1;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 803000
 	probepoint = (((uint64_t)net->cwnd) << 32);
 	probepoint |=  ((9 << 16) | 0);
 	vtag = (net->rtt << 32) |

--- a/usrsctplib/netinet/sctp_constants.h
+++ b/usrsctplib/netinet/sctp_constants.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_constants.h 359405 2020-03-28 20:25:45Z tuexen $");
 #endif
@@ -563,7 +563,7 @@ extern void getwintimeofday(struct timeval *tv);
 					 ((t) < SCTP_TIMER_TYPE_LAST))
 
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 /* Number of ticks to run the main timer at in msec */
 #define SCTP_MAIN_TIMER_DEFAULT		10
 #endif
@@ -863,7 +863,7 @@ extern void getwintimeofday(struct timeval *tv);
 #define SCTP_CHUNKQUEUE_SCALE 10
 #endif
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 /* clock variance is 1 ms */
 #define SCTP_CLOCK_GRANULARITY	1
 #else
@@ -970,7 +970,7 @@ extern void getwintimeofday(struct timeval *tv);
 
 /*-
  * defines for socket lock states.
- * Used by __APPLE__ and SCTP_SO_LOCK_TESTING
+ * Used by SCTP_KERNEL_APPLE and SCTP_SO_LOCK_TESTING
  */
 #define SCTP_SO_LOCKED		1
 #define SCTP_SO_NOT_LOCKED	0
@@ -1025,7 +1025,7 @@ do { \
 	} \
 } while (0)
 
-#if defined(__FreeBSD__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(__Windows__) || defined(__Userspace__)
 #define sctp_sowwakeup_locked(inp, so) \
 do { \
 	if (inp->sctp_flags & SCTP_PCB_FLAGS_DONT_WAKE) { \
@@ -1056,7 +1056,7 @@ do { \
 	} \
 } while (0)
 
-#if defined(__FreeBSD__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(__Windows__) || defined(__Userspace__)
 #define sctp_sorwakeup_locked(inp, so) \
 do { \
 	if (inp->sctp_flags & SCTP_PCB_FLAGS_DONT_WAKE) { \

--- a/usrsctplib/netinet/sctp_crc32.c
+++ b/usrsctplib/netinet/sctp_crc32.c
@@ -32,13 +32,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_crc32.c 352361 2019-09-15 18:29:45Z tuexen $");
 
 #include "opt_sctp.h"
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #include <sys/gsb_crc32.h>
 #endif
 #ifdef SCTP
@@ -60,7 +60,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_crc32.c 352361 2019-09-15 18:29:45Z tu
 #include <netinet/sctp_pcb.h>
 #endif
 
-#if !defined(__FreeBSD__)
+#if !defined(SCTP_KERNEL_FreeBSD)
 /**
  *
  * Routine Description:
@@ -799,7 +799,7 @@ sctp_calculate_cksum(struct mbuf *m, uint32_t offset)
 	return (base);
 }
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef SCTP
 /*
  * Compute and insert the SCTP checksum in network byte order for a given

--- a/usrsctplib/netinet/sctp_crc32.h
+++ b/usrsctplib/netinet/sctp_crc32.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_crc32.h 327200 2017-12-26 12:35:02Z tuexen $");
 #endif
@@ -42,7 +42,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_crc32.h 327200 2017-12-26 12:35:02Z tu
 
 #if defined(_KERNEL)
 uint32_t sctp_calculate_cksum(struct mbuf *, uint32_t);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef SCTP
 void sctp_delayed_cksum(struct mbuf *, uint32_t offset);
 #endif

--- a/usrsctplib/netinet/sctp_header.h
+++ b/usrsctplib/netinet/sctp_header.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_header.h 309682 2016-12-07 19:30:59Z tuexen $");
 #endif

--- a/usrsctplib/netinet/sctp_indata.c
+++ b/usrsctplib/netinet/sctp_indata.c
@@ -32,13 +32,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_indata.c 359152 2020-03-19 21:01:16Z tuexen $");
 #endif
 
 #include <netinet/sctp_os.h>
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/proc.h>
 #endif
 #include <netinet/sctp_var.h>
@@ -55,7 +55,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_indata.c 359152 2020-03-19 21:01:16Z t
 #include <netinet/sctp_bsd_addr.h>
 #include <netinet/sctp_input.h>
 #include <netinet/sctp_crc32.h>
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <netinet/sctp_lock_bsd.h>
 #endif
 /*
@@ -567,7 +567,7 @@ sctp_queue_data_to_stream(struct sctp_tcb *stcb,
 	sctp_ucount_incr(asoc->cnt_on_all_streams);
 	nxt_todel = strm->last_mid_delivered + 1;
 	if (SCTP_MID_EQ(asoc->idata_supported, nxt_todel, control->mid)) {
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		struct socket *so;
 
 		so = SCTP_INP_SO(stcb->sctp_ep);
@@ -650,7 +650,7 @@ sctp_queue_data_to_stream(struct sctp_tcb *stcb,
 			}
 			break;
 		}
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 	}
@@ -1936,7 +1936,7 @@ sctp_process_a_data_chunk(struct sctp_tcb *stcb, struct sctp_association *asoc,
 		 */
 		if (stcb->sctp_socket->so_rcv.sb_cc) {
 			/* some to read, wake-up */
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 			struct socket *so;
 
 			so = SCTP_INP_SO(stcb->sctp_ep);
@@ -1952,7 +1952,7 @@ sctp_process_a_data_chunk(struct sctp_tcb *stcb, struct sctp_association *asoc,
 			}
 #endif
 			sctp_sorwakeup(stcb->sctp_ep, stcb->sctp_socket);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 			SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 		}
@@ -3369,7 +3369,7 @@ sctp_strike_gap_ack_chunks(struct sctp_tcb *stcb, struct sctp_association *asoc,
 		if (stcb->asoc.prsctp_supported) {
 			if ((PR_SCTP_TTL_ENABLED(tp1->flags)) && tp1->sent < SCTP_DATAGRAM_ACKED) {
 				/* Is it expired? */
-#ifndef __FreeBSD__
+#ifndef SCTP_KERNEL_FreeBSD
 				if (timercmp(&now, &tp1->rec.data.timetodrop, >)) {
 #else
 				if (timevalcmp(&now, &tp1->rec.data.timetodrop, >)) {
@@ -3797,7 +3797,7 @@ sctp_try_advance_peer_ack_point(struct sctp_tcb *stcb,
 			 * Now is this one marked for resend and its time is
 			 * now up?
 			 */
-#ifndef __FreeBSD__
+#ifndef SCTP_KERNEL_FreeBSD
 			if (timercmp(&now, &tp1->rec.data.timetodrop, >)) {
 #else
 			if (timevalcmp(&now, &tp1->rec.data.timetodrop, >)) {
@@ -4170,7 +4170,7 @@ sctp_express_handle_sack(struct sctp_tcb *stcb, uint32_t cumack,
 	/* sa_ignore NO_NULL_CHK */
 	if (stcb->sctp_socket) {
 #endif
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		struct socket *so;
 
 #endif
@@ -4179,7 +4179,7 @@ sctp_express_handle_sack(struct sctp_tcb *stcb, uint32_t cumack,
 			/* sa_ignore NO_NULL_CHK */
 			sctp_wakeup_log(stcb, 1, SCTP_WAKESND_FROM_SACK);
 		}
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		so = SCTP_INP_SO(stcb->sctp_ep);
 		atomic_add_int(&stcb->asoc.refcnt, 1);
 		SCTP_TCB_UNLOCK(stcb);
@@ -4193,7 +4193,7 @@ sctp_express_handle_sack(struct sctp_tcb *stcb, uint32_t cumack,
 		}
 #endif
 		sctp_sowwakeup_locked(stcb->sctp_ep, stcb->sctp_socket);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 	} else {
@@ -4892,7 +4892,7 @@ sctp_handle_sack(struct mbuf *m, int offset_seg, int offset_dup,
 	/* sa_ignore NO_NULL_CHK */
 	if ((wake_him) && (stcb->sctp_socket)) {
 #endif
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		struct socket *so;
 
 #endif
@@ -4900,7 +4900,7 @@ sctp_handle_sack(struct mbuf *m, int offset_seg, int offset_dup,
 		if (SCTP_BASE_SYSCTL(sctp_logging_level) & SCTP_WAKE_LOGGING_ENABLE) {
 			sctp_wakeup_log(stcb, wake_him, SCTP_WAKESND_FROM_SACK);
 		}
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		so = SCTP_INP_SO(stcb->sctp_ep);
 		atomic_add_int(&stcb->asoc.refcnt, 1);
 		SCTP_TCB_UNLOCK(stcb);
@@ -4914,7 +4914,7 @@ sctp_handle_sack(struct mbuf *m, int offset_seg, int offset_dup,
 		}
 #endif
 		sctp_sowwakeup_locked(stcb->sctp_ep, stcb->sctp_socket);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 	} else {

--- a/usrsctplib/netinet/sctp_indata.h
+++ b/usrsctplib/netinet/sctp_indata.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_indata.h 351655 2019-09-01 10:39:16Z tuexen $");
 #endif

--- a/usrsctplib/netinet/sctp_input.c
+++ b/usrsctplib/netinet/sctp_input.c
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_input.c 359405 2020-03-28 20:25:45Z tuexen $");
 #endif
@@ -51,7 +51,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_input.c 359405 2020-03-28 20:25:45Z tu
 #include <netinet/sctp_bsd_addr.h>
 #include <netinet/sctp_timer.h>
 #include <netinet/sctp_crc32.h>
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #include <netinet/sctp_kdtrace.h>
 #endif
 #if defined(INET) || defined(INET6)
@@ -59,11 +59,11 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_input.c 359405 2020-03-28 20:25:45Z tu
 #include <netinet/udp.h>
 #endif
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #include <sys/smp.h>
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #define APPLE_FILE_NO 2
 #endif
 
@@ -100,7 +100,7 @@ sctp_handle_init(struct mbuf *m, int iphlen, int offset,
                  struct sockaddr *src, struct sockaddr *dst, struct sctphdr *sh,
                  struct sctp_init_chunk *cp, struct sctp_inpcb *inp,
                  struct sctp_tcb *stcb, struct sctp_nets *net, int *abort_no_unlock,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                  uint8_t mflowtype, uint32_t mflowid,
 #endif
                  uint32_t vrf_id, uint16_t port)
@@ -117,7 +117,7 @@ sctp_handle_init(struct mbuf *m, int iphlen, int offset,
 	if (ntohs(cp->ch.chunk_length) < sizeof(struct sctp_init_chunk)) {
 		op_err = sctp_generate_cause(SCTP_CAUSE_INVALID_PARAM, "");
 		sctp_abort_association(inp, stcb, m, iphlen, src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 				       vrf_id, port);
@@ -131,7 +131,7 @@ sctp_handle_init(struct mbuf *m, int iphlen, int offset,
 		/* protocol error... send abort */
 		op_err = sctp_generate_cause(SCTP_CAUSE_INVALID_PARAM, "");
 		sctp_abort_association(inp, stcb, m, iphlen, src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 				       vrf_id, port);
@@ -143,7 +143,7 @@ sctp_handle_init(struct mbuf *m, int iphlen, int offset,
 		/* invalid parameter... send abort */
 		op_err = sctp_generate_cause(SCTP_CAUSE_INVALID_PARAM, "");
 		sctp_abort_association(inp, stcb, m, iphlen, src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 				       vrf_id, port);
@@ -155,7 +155,7 @@ sctp_handle_init(struct mbuf *m, int iphlen, int offset,
 		/* protocol error... send abort */
 		op_err = sctp_generate_cause(SCTP_CAUSE_INVALID_PARAM, "");
 		sctp_abort_association(inp, stcb, m, iphlen, src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 				       vrf_id, port);
@@ -167,7 +167,7 @@ sctp_handle_init(struct mbuf *m, int iphlen, int offset,
 		/* protocol error... send abort */
 		op_err = sctp_generate_cause(SCTP_CAUSE_INVALID_PARAM, "");
 		sctp_abort_association(inp, stcb, m, iphlen, src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 				       vrf_id, port);
@@ -181,7 +181,7 @@ sctp_handle_init(struct mbuf *m, int iphlen, int offset,
 		op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 		                             "Problem with AUTH parameters");
 		sctp_abort_association(inp, stcb, m, iphlen, src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 		                       vrf_id, port);
@@ -210,7 +210,7 @@ sctp_handle_init(struct mbuf *m, int iphlen, int offset,
 			op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 			                             "No listener");
 			sctp_send_abort(m, iphlen, src, dst, sh, 0, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                mflowtype, mflowid, inp->fibnum,
 #endif
 			                vrf_id, port);
@@ -226,7 +226,7 @@ sctp_handle_init(struct mbuf *m, int iphlen, int offset,
 		SCTPDBG(SCTP_DEBUG_INPUT3, "sctp_handle_init: sending INIT-ACK\n");
 		sctp_send_initiate_ack(inp, stcb, net, m, iphlen, offset,
 		                       src, dst, sh, cp,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 		                       vrf_id, port);
@@ -243,7 +243,7 @@ sctp_handle_init(struct mbuf *m, int iphlen, int offset,
 
 int
 sctp_is_there_unsent_data(struct sctp_tcb *stcb, int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
 	SCTP_UNUSED
 #endif
 )
@@ -466,7 +466,7 @@ sctp_process_init_ack(struct mbuf *m, int iphlen, int offset,
                       struct sockaddr *src, struct sockaddr *dst, struct sctphdr *sh,
                       struct sctp_init_ack_chunk *cp, struct sctp_tcb *stcb,
                       struct sctp_nets *net, int *abort_no_unlock,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		      uint8_t mflowtype, uint32_t mflowid,
 #endif
                       uint32_t vrf_id)
@@ -514,7 +514,7 @@ sctp_process_init_ack(struct mbuf *m, int iphlen, int offset,
 		}
 		sctp_abort_association(stcb->sctp_ep, stcb, m, iphlen,
 				       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				       mflowtype, mflowid,
 #endif
 				       vrf_id, net->port);
@@ -546,7 +546,7 @@ sctp_process_init_ack(struct mbuf *m, int iphlen, int offset,
 			retval);
 		sctp_abort_association(stcb->sctp_ep, stcb, m, iphlen,
 		                       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 		                       vrf_id, net->port);
@@ -857,7 +857,7 @@ static int
 sctp_handle_abort(struct sctp_abort_chunk *abort,
     struct sctp_tcb *stcb, struct sctp_nets *net)
 {
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	struct socket *so;
 #endif
 	uint16_t len;
@@ -907,7 +907,7 @@ sctp_handle_abort(struct sctp_abort_chunk *abort,
 #ifdef SCTP_ASOCLOG_OF_TSNS
 	sctp_print_out_track_log(stcb);
 #endif
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	so = SCTP_INP_SO(stcb->sctp_ep);
 	atomic_add_int(&stcb->asoc.refcnt, 1);
 	SCTP_TCB_UNLOCK(stcb);
@@ -918,7 +918,7 @@ sctp_handle_abort(struct sctp_abort_chunk *abort,
 	SCTP_ADD_SUBSTATE(stcb, SCTP_STATE_WAS_ABORTED);
 	(void)sctp_free_assoc(stcb->sctp_ep, stcb, SCTP_NORMAL_PROC,
 			      SCTP_FROM_SCTP_INPUT + SCTP_LOC_8);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 	SCTPDBG(SCTP_DEBUG_INPUT2, "sctp_handle_abort: finished\n");
@@ -963,7 +963,7 @@ sctp_handle_shutdown(struct sctp_shutdown_chunk *cp,
 	struct sctp_association *asoc;
 	int some_on_streamwheel;
 	int old_state;
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	struct socket *so;
 #endif
 
@@ -1014,7 +1014,7 @@ sctp_handle_shutdown(struct sctp_shutdown_chunk *cp,
 		asoc->control_pdapi->pdapi_aborted = 1;
 		asoc->control_pdapi = NULL;
 		SCTP_INP_READ_UNLOCK(stcb->sctp_ep);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		so = SCTP_INP_SO(stcb->sctp_ep);
 		atomic_add_int(&stcb->asoc.refcnt, 1);
 		SCTP_TCB_UNLOCK(stcb);
@@ -1030,7 +1030,7 @@ sctp_handle_shutdown(struct sctp_shutdown_chunk *cp,
 		if (stcb->sctp_socket) {
 			sctp_sorwakeup(stcb->sctp_ep, stcb->sctp_socket);
 		}
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 	}
@@ -1089,7 +1089,7 @@ sctp_handle_shutdown_ack(struct sctp_shutdown_ack_chunk *cp SCTP_UNUSED,
                          struct sctp_nets *net)
 {
 	struct sctp_association *asoc;
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	struct socket *so;
 
 	so = SCTP_INP_SO(stcb->sctp_ep);
@@ -1123,7 +1123,7 @@ sctp_handle_shutdown_ack(struct sctp_shutdown_ack_chunk *cp SCTP_UNUSED,
 		asoc->control_pdapi->pdapi_aborted = 1;
 		asoc->control_pdapi = NULL;
 		SCTP_INP_READ_UNLOCK(stcb->sctp_ep);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		atomic_add_int(&stcb->asoc.refcnt, 1);
 		SCTP_TCB_UNLOCK(stcb);
 		SCTP_SOCKET_LOCK(so, 1);
@@ -1136,7 +1136,7 @@ sctp_handle_shutdown_ack(struct sctp_shutdown_ack_chunk *cp SCTP_UNUSED,
 		}
 #endif
 		sctp_sorwakeup(stcb->sctp_ep, stcb->sctp_socket);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 	}
@@ -1162,7 +1162,7 @@ sctp_handle_shutdown_ack(struct sctp_shutdown_ack_chunk *cp SCTP_UNUSED,
 	}
 	SCTP_STAT_INCR_COUNTER32(sctps_shutdown);
 	/* free the TCB but first save off the ep */
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	atomic_add_int(&stcb->asoc.refcnt, 1);
 	SCTP_TCB_UNLOCK(stcb);
 	SCTP_SOCKET_LOCK(so, 1);
@@ -1171,7 +1171,7 @@ sctp_handle_shutdown_ack(struct sctp_shutdown_ack_chunk *cp SCTP_UNUSED,
 #endif
 	(void)sctp_free_assoc(stcb->sctp_ep, stcb, SCTP_NORMAL_PROC,
 			      SCTP_FROM_SCTP_INPUT + SCTP_LOC_11);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 }
@@ -1244,7 +1244,7 @@ sctp_handle_error(struct sctp_chunkhdr *ch,
 	struct sctp_association *asoc;
 	uint32_t remaining_length, adjust;
 	uint16_t code, cause_code, cause_length;
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	struct socket *so;
 #endif
 
@@ -1320,7 +1320,7 @@ sctp_handle_error(struct sctp_chunkhdr *ch,
 				    asoc->max_init_times) {
 					sctp_abort_notification(stcb, 0, 0, NULL, SCTP_SO_NOT_LOCKED);
 					/* now free the asoc */
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 					so = SCTP_INP_SO(stcb->sctp_ep);
 					atomic_add_int(&stcb->asoc.refcnt, 1);
 					SCTP_TCB_UNLOCK(stcb);
@@ -1330,7 +1330,7 @@ sctp_handle_error(struct sctp_chunkhdr *ch,
 #endif
 					(void)sctp_free_assoc(stcb->sctp_ep, stcb, SCTP_NORMAL_PROC,
 							      SCTP_FROM_SCTP_INPUT + SCTP_LOC_12);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 					SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 					return (-1);
@@ -1421,7 +1421,7 @@ sctp_handle_init_ack(struct mbuf *m, int iphlen, int offset,
                      struct sockaddr *src, struct sockaddr *dst, struct sctphdr *sh,
                      struct sctp_init_ack_chunk *cp, struct sctp_tcb *stcb,
                      struct sctp_nets *net, int *abort_no_unlock,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                      uint8_t mflowtype, uint32_t mflowid,
 #endif
                      uint32_t vrf_id)
@@ -1442,7 +1442,7 @@ sctp_handle_init_ack(struct mbuf *m, int iphlen, int offset,
 		op_err = sctp_generate_cause(SCTP_CAUSE_INVALID_PARAM, "");
 		sctp_abort_association(stcb->sctp_ep, stcb, m, iphlen,
 		                       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 		                       vrf_id, net->port);
@@ -1456,7 +1456,7 @@ sctp_handle_init_ack(struct mbuf *m, int iphlen, int offset,
 		op_err = sctp_generate_cause(SCTP_CAUSE_INVALID_PARAM, "");
 		sctp_abort_association(stcb->sctp_ep, stcb, m, iphlen,
 		                       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 		                       vrf_id, net->port);
@@ -1468,7 +1468,7 @@ sctp_handle_init_ack(struct mbuf *m, int iphlen, int offset,
 		op_err = sctp_generate_cause(SCTP_CAUSE_INVALID_PARAM, "");
 		sctp_abort_association(stcb->sctp_ep, stcb, m, iphlen,
 		                       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 		                       vrf_id, net->port);
@@ -1480,7 +1480,7 @@ sctp_handle_init_ack(struct mbuf *m, int iphlen, int offset,
 		op_err = sctp_generate_cause(SCTP_CAUSE_INVALID_PARAM, "");
 		sctp_abort_association(stcb->sctp_ep, stcb, m, iphlen,
 		                       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 		                       vrf_id, net->port);
@@ -1492,7 +1492,7 @@ sctp_handle_init_ack(struct mbuf *m, int iphlen, int offset,
 		op_err = sctp_generate_cause(SCTP_CAUSE_INVALID_PARAM, "");
 		sctp_abort_association(stcb->sctp_ep, stcb, m, iphlen,
 		                       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 		                       vrf_id, net->port);
@@ -1519,7 +1519,7 @@ sctp_handle_init_ack(struct mbuf *m, int iphlen, int offset,
 		}
 		if (sctp_process_init_ack(m, iphlen, offset, src, dst, sh, cp, stcb,
 		                          net, abort_no_unlock,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                          mflowtype, mflowid,
 #endif
 		                          vrf_id) < 0) {
@@ -1578,7 +1578,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
     struct sctp_inpcb *inp, struct sctp_nets **netp,
     struct sockaddr *init_src, int *notification,
     int auth_skipped, uint32_t auth_offset, uint32_t auth_len,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
     uint8_t mflowtype, uint32_t mflowid,
 #endif
     uint32_t vrf_id, uint16_t port);
@@ -1597,7 +1597,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
     struct sctp_inpcb *inp, struct sctp_tcb *stcb, struct sctp_nets **netp,
     struct sockaddr *init_src, int *notification,
     int auth_skipped, uint32_t auth_offset, uint32_t auth_len,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
     uint8_t mflowtype, uint32_t mflowid,
 #endif
     uint32_t vrf_id, uint16_t port)
@@ -1631,7 +1631,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 		sctp_send_shutdown_ack(stcb, stcb->asoc.primary_destination);
 		op_err = sctp_generate_cause(SCTP_CAUSE_COOKIE_IN_SHUTDOWN, "");
 		sctp_send_operr_to(src, dst, sh, cookie->peers_vtag, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                   mflowtype, mflowid, inp->fibnum,
 #endif
 		                   vrf_id, net->port);
@@ -1736,7 +1736,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 				if (((stcb->sctp_ep->sctp_flags & SCTP_PCB_FLAGS_TCPTYPE) ||
 				     (stcb->sctp_ep->sctp_flags & SCTP_PCB_FLAGS_IN_TCPPOOL)) &&
 				    (!SCTP_IS_LISTENING(inp))) {
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 					struct socket *so;
 #endif
 					/*
@@ -1747,7 +1747,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 					 */
 					stcb->sctp_ep->sctp_flags |=
 						SCTP_PCB_FLAGS_CONNECTED;
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 					so = SCTP_INP_SO(stcb->sctp_ep);
 					atomic_add_int(&stcb->asoc.refcnt, 1);
 					SCTP_TCB_UNLOCK(stcb);
@@ -1760,7 +1760,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 					}
 #endif
 					soisconnected(stcb->sctp_socket);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 					SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 				}
@@ -1840,7 +1840,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 		 */
 		op_err = sctp_generate_cause(SCTP_CAUSE_NAT_COLLIDING_STATE, "");
 		sctp_send_abort(m, iphlen,  src, dst, sh, 0, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                mflowtype, mflowid, inp->fibnum,
 #endif
 		                vrf_id, port);
@@ -1934,12 +1934,12 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 			if (((stcb->sctp_ep->sctp_flags & SCTP_PCB_FLAGS_TCPTYPE) ||
 			     (stcb->sctp_ep->sctp_flags & SCTP_PCB_FLAGS_IN_TCPPOOL)) &&
 			    (!SCTP_IS_LISTENING(inp))) {
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 				struct socket *so;
 #endif
 				stcb->sctp_ep->sctp_flags |=
 					SCTP_PCB_FLAGS_CONNECTED;
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 				so = SCTP_INP_SO(stcb->sctp_ep);
 				atomic_add_int(&stcb->asoc.refcnt, 1);
 				SCTP_TCB_UNLOCK(stcb);
@@ -1952,7 +1952,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 				}
 #endif
 				soisconnected(stcb->sctp_socket);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 				SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 			}
@@ -1994,7 +1994,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 	    cookie->tie_tag_peer_vtag == asoc->peer_vtag_nonce &&
 	    cookie->tie_tag_peer_vtag != 0) {
 		struct sctpasochead *head;
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		struct socket *so;
 #endif
 
@@ -2008,7 +2008,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 			                                sh, cookie, cookie_len,
 			                                inp, netp, init_src,notification,
 			                                auth_skipped, auth_offset, auth_len,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                                mflowtype, mflowid,
 #endif
 			                                vrf_id, port));
@@ -2066,7 +2066,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 			    asoc->mapping_array_size);
 		}
 		SCTP_TCB_UNLOCK(stcb);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		so = SCTP_INP_SO(stcb->sctp_ep);
 		SCTP_SOCKET_LOCK(so, 1);
 #endif
@@ -2112,7 +2112,7 @@ sctp_process_cookie_existing(struct mbuf *m, int iphlen, int offset,
 		SCTP_TCB_SEND_UNLOCK(stcb);
 		SCTP_INP_WUNLOCK(stcb->sctp_ep);
 		SCTP_INP_INFO_WUNLOCK();
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 		asoc->total_flight = 0;
@@ -2169,7 +2169,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
     struct sctp_inpcb *inp, struct sctp_nets **netp,
     struct sockaddr *init_src, int *notification,
     int auth_skipped, uint32_t auth_offset, uint32_t auth_len,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
     uint8_t mflowtype, uint32_t mflowid,
 #endif
     uint32_t vrf_id, uint16_t port)
@@ -2183,7 +2183,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 	int retval;
 	int error = 0;
 	uint8_t auth_chunk_buf[SCTP_PARAM_BUFFER_SIZE];
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	struct socket *so;
 
 	so = SCTP_INP_SO(inp);
@@ -2247,7 +2247,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 	                       ntohl(initack_cp->init.initiate_tag), vrf_id,
 	                       ntohs(initack_cp->init.num_outbound_streams),
 	                       port,
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 	                       (struct thread *)NULL,
 #elif defined(__Windows__)
 	                       (PKTHREAD)NULL,
@@ -2264,7 +2264,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 		op_err = sctp_generate_cause(SCTP_CAUSE_OUT_OF_RESC, "");
 		sctp_abort_association(inp, (struct sctp_tcb *)NULL, m, iphlen,
 		                       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 		                       vrf_id, port);
@@ -2299,11 +2299,11 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 		op_err = sctp_generate_cause(SCTP_CAUSE_OUT_OF_RESC, "");
 		sctp_abort_association(inp, (struct sctp_tcb *)NULL, m, iphlen,
 				       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                       mflowtype, mflowid,
 #endif
 		                       vrf_id, port);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		atomic_add_int(&stcb->asoc.refcnt, 1);
 		SCTP_TCB_UNLOCK(stcb);
 		SCTP_SOCKET_LOCK(so, 1);
@@ -2312,7 +2312,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 #endif
 		(void)sctp_free_assoc(inp, stcb, SCTP_NORMAL_PROC,
 				      SCTP_FROM_SCTP_INPUT + SCTP_LOC_18);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 		return (NULL);
@@ -2335,7 +2335,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 	else
 		retval = 0;
 	if (retval < 0) {
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		atomic_add_int(&stcb->asoc.refcnt, 1);
 		SCTP_TCB_UNLOCK(stcb);
 		SCTP_SOCKET_LOCK(so, 1);
@@ -2344,7 +2344,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 #endif
 		(void)sctp_free_assoc(inp, stcb, SCTP_NORMAL_PROC,
 		                      SCTP_FROM_SCTP_INPUT + SCTP_LOC_19);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 		return (NULL);
@@ -2353,7 +2353,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 	if (sctp_load_addresses_from_init(stcb, m,
 	    init_offset + sizeof(struct sctp_init_chunk), initack_offset,
 	    src, dst, init_src, port)) {
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		atomic_add_int(&stcb->asoc.refcnt, 1);
 		SCTP_TCB_UNLOCK(stcb);
 		SCTP_SOCKET_LOCK(so, 1);
@@ -2362,7 +2362,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 #endif
 		(void)sctp_free_assoc(inp, stcb, SCTP_NORMAL_PROC,
 		                      SCTP_FROM_SCTP_INPUT + SCTP_LOC_20);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 		return (NULL);
@@ -2383,7 +2383,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 			/* auth HMAC failed, dump the assoc and packet */
 			SCTPDBG(SCTP_DEBUG_AUTH1,
 				"COOKIE-ECHO: AUTH failed\n");
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 			atomic_add_int(&stcb->asoc.refcnt, 1);
 			SCTP_TCB_UNLOCK(stcb);
 			SCTP_SOCKET_LOCK(so, 1);
@@ -2392,7 +2392,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 #endif
 			(void)sctp_free_assoc(inp, stcb, SCTP_NORMAL_PROC,
 			                      SCTP_FROM_SCTP_INPUT + SCTP_LOC_21);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 			SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 			return (NULL);
@@ -2449,7 +2449,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 		break;
 #endif
 	default:
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		atomic_add_int(&stcb->asoc.refcnt, 1);
 		SCTP_TCB_UNLOCK(stcb);
 		SCTP_SOCKET_LOCK(so, 1);
@@ -2458,7 +2458,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 #endif
 		(void)sctp_free_assoc(inp, stcb, SCTP_NORMAL_PROC,
 		                      SCTP_FROM_SCTP_INPUT + SCTP_LOC_22);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 		return (NULL);
@@ -2489,7 +2489,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 		 * a bit of protection is worth having..
 		 */
 		stcb->sctp_ep->sctp_flags |= SCTP_PCB_FLAGS_CONNECTED;
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		atomic_add_int(&stcb->asoc.refcnt, 1);
 		SCTP_TCB_UNLOCK(stcb);
 		SCTP_SOCKET_LOCK(so, 1);
@@ -2501,7 +2501,7 @@ sctp_process_cookie_new(struct mbuf *m, int iphlen, int offset,
 		}
 #endif
 		soisconnected(stcb->sctp_socket);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 	} else if ((stcb->sctp_ep->sctp_flags & SCTP_PCB_FLAGS_TCPTYPE) &&
@@ -2571,7 +2571,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
     struct sctp_inpcb **inp_p, struct sctp_tcb **stcb, struct sctp_nets **netp,
     int auth_skipped, uint32_t auth_offset, uint32_t auth_len,
     struct sctp_tcb **locked_tcb,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
     uint8_t mflowtype, uint32_t mflowid,
 #endif
     uint32_t vrf_id, uint16_t port)
@@ -2726,7 +2726,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 	/* Expire time is in Ticks, so we convert to seconds */
 	time_expires.tv_sec = cookie->time_entered.tv_sec + sctp_ticks_to_secs(cookie->cookie_life);
 	time_expires.tv_usec = cookie->time_entered.tv_usec;
-#ifndef __FreeBSD__
+#ifndef SCTP_KERNEL_FreeBSD
 	if (timercmp(&now, &time_expires, >))
 #else
 	if (timevalcmp(&now, &time_expires, >))
@@ -2750,7 +2750,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 		cause->cause.code = htons(SCTP_CAUSE_STALE_COOKIE);
 		cause->cause.length = htons((sizeof(struct sctp_paramhdr) +
 		    (sizeof(uint32_t))));
-#ifndef __FreeBSD__
+#ifndef SCTP_KERNEL_FreeBSD
 		timersub(&now, &time_expires, &diff);
 #else
 		diff = now;
@@ -2768,7 +2768,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 		}
 		cause->stale_time = htonl(staleness);
 		sctp_send_operr_to(src, dst, sh, cookie->peers_vtag, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                   mflowtype, mflowid, l_inp->fibnum,
 #endif
 		                   vrf_id, port);
@@ -2871,7 +2871,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 		                                cookie, cookie_len, *inp_p,
 		                                netp, to, &notification,
 		                                auth_skipped, auth_offset, auth_len,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                                mflowtype, mflowid,
 #endif
 		                                vrf_id, port);
@@ -2882,7 +2882,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 		                                     src, dst, sh,
 						     cookie, cookie_len, *inp_p, *stcb, netp, to,
 						     &notification, auth_skipped, auth_offset, auth_len,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                                     mflowtype, mflowid,
 #endif
 		                                     vrf_id, port);
@@ -2892,7 +2892,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 		/* still no TCB... must be bad cookie-echo */
 		return (NULL);
 	}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	if (*netp != NULL) {
 		(*netp)->flowtype = mflowtype;
 		(*netp)->flowid = mflowid;
@@ -2947,7 +2947,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 				return (m);
 			}
 			oso = (*inp_p)->sctp_socket;
-#if (defined(__FreeBSD__) && __FreeBSD_version < 700000)
+#if (defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 700000)
 			/*
 			 * We do this to keep the sockets side happy during
 			 * the sonewcon ONLY.
@@ -2956,27 +2956,27 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 #endif
 			atomic_add_int(&(*stcb)->asoc.refcnt, 1);
 			SCTP_TCB_UNLOCK((*stcb));
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 			CURVNET_SET(oso->so_vnet);
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 			SCTP_SOCKET_LOCK(oso, 1);
 #endif
 			so = sonewconn(oso, 0
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 			    ,NULL
 #endif
 #ifdef __Panda__
 			     ,NULL , (*inp_p)->def_vrf_id
 #endif
 			    );
-#if (defined(__FreeBSD__) && __FreeBSD_version < 700000)
+#if (defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 700000)
 			NET_UNLOCK_GIANT();
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 			SCTP_SOCKET_UNLOCK(oso, 1);
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 			CURVNET_RESTORE();
 #endif
 			SCTP_TCB_LOCK((*stcb));
@@ -2984,7 +2984,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 
 			if (so == NULL) {
 				struct mbuf *op_err;
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 				struct socket *pcb_so;
 #endif
 				/* Too many sockets */
@@ -2992,11 +2992,11 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 				op_err = sctp_generate_cause(SCTP_CAUSE_OUT_OF_RESC, "");
 				sctp_abort_association(*inp_p, NULL, m, iphlen,
 						       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				                       mflowtype, mflowid,
 #endif
 				                       vrf_id, port);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 				pcb_so = SCTP_INP_SO(*inp_p);
 				atomic_add_int(&(*stcb)->asoc.refcnt, 1);
 				SCTP_TCB_UNLOCK((*stcb));
@@ -3006,7 +3006,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 #endif
 				(void)sctp_free_assoc(*inp_p, *stcb, SCTP_NORMAL_PROC,
 				                      SCTP_FROM_SCTP_INPUT + SCTP_LOC_23);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 				SCTP_SOCKET_UNLOCK(pcb_so, 1);
 #endif
 				return (NULL);
@@ -3077,7 +3077,7 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 			atomic_add_int(&(*stcb)->asoc.refcnt, 1);
 			SCTP_TCB_UNLOCK((*stcb));
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			sctp_pull_off_control_to_new_inp((*inp_p), inp, *stcb,
 			    0);
 #else
@@ -3109,13 +3109,13 @@ sctp_handle_cookie_echo(struct mbuf *m, int iphlen, int offset,
 			}
 
 			/* Pull it from the incomplete queue and wake the guy */
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 			atomic_add_int(&(*stcb)->asoc.refcnt, 1);
 			SCTP_TCB_UNLOCK((*stcb));
 			SCTP_SOCKET_LOCK(so, 1);
 #endif
 			soisconnected(so);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 			SCTP_TCB_LOCK((*stcb));
 			atomic_subtract_int(&(*stcb)->asoc.refcnt, 1);
 			SCTP_SOCKET_UNLOCK(so, 1);
@@ -3178,12 +3178,12 @@ sctp_handle_cookie_ack(struct sctp_cookie_ack_chunk *cp SCTP_UNUSED,
 		sctp_ulp_notify(SCTP_NOTIFY_ASSOC_UP, stcb, 0, NULL, SCTP_SO_NOT_LOCKED);
 		if ((stcb->sctp_ep->sctp_flags & SCTP_PCB_FLAGS_TCPTYPE) ||
 		    (stcb->sctp_ep->sctp_flags & SCTP_PCB_FLAGS_IN_TCPPOOL)) {
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 			struct socket *so;
 
 #endif
 			stcb->sctp_ep->sctp_flags |= SCTP_PCB_FLAGS_CONNECTED;
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 			so = SCTP_INP_SO(stcb->sctp_ep);
 			atomic_add_int(&stcb->asoc.refcnt, 1);
 			SCTP_TCB_UNLOCK(stcb);
@@ -3194,7 +3194,7 @@ sctp_handle_cookie_ack(struct sctp_cookie_ack_chunk *cp SCTP_UNUSED,
 			if ((stcb->asoc.state & SCTP_STATE_CLOSED_SOCKET) == 0) {
 				soisconnected(stcb->sctp_socket);
 			}
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 			SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 		}
@@ -3413,7 +3413,7 @@ static void
 sctp_handle_shutdown_complete(struct sctp_shutdown_complete_chunk *cp SCTP_UNUSED,
     struct sctp_tcb *stcb, struct sctp_nets *net)
 {
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	struct socket *so;
 #endif
 
@@ -3448,7 +3448,7 @@ sctp_handle_shutdown_complete(struct sctp_shutdown_complete_chunk *cp SCTP_UNUSE
 	/* free the TCB */
 	SCTPDBG(SCTP_DEBUG_INPUT2,
 		"sctp_handle_shutdown_complete: calls free-asoc\n");
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	so = SCTP_INP_SO(stcb->sctp_ep);
 	atomic_add_int(&stcb->asoc.refcnt, 1);
 	SCTP_TCB_UNLOCK(stcb);
@@ -3458,7 +3458,7 @@ sctp_handle_shutdown_complete(struct sctp_shutdown_complete_chunk *cp SCTP_UNUSE
 #endif
 	(void)sctp_free_assoc(stcb->sctp_ep, stcb, SCTP_NORMAL_PROC,
 	                      SCTP_FROM_SCTP_INPUT + SCTP_LOC_25);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 	return;
@@ -4719,7 +4719,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
     struct sockaddr *src, struct sockaddr *dst,
     struct sctphdr *sh, struct sctp_chunkhdr *ch, struct sctp_inpcb *inp,
     struct sctp_tcb *stcb, struct sctp_nets **netp, int *fwd_tsn_seen,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
     uint8_t mflowtype, uint32_t mflowid, uint16_t fibnum,
 #endif
     uint32_t vrf_id, uint16_t port)
@@ -4743,7 +4743,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 	uint32_t auth_offset = 0, auth_len = 0;
 	int auth_skipped = 0;
 	int asconf_cnt = 0;
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	struct socket *so;
 #endif
 
@@ -4868,7 +4868,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 			                             msg);
 			/* no association, so it's out of the blue... */
 			sctp_handle_ootb(m, iphlen, *offset, src, dst, sh, inp, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                 mflowtype, mflowid, inp->fibnum,
 #endif
 					 vrf_id, port);
@@ -4912,7 +4912,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 				                             msg);
 				sctp_handle_ootb(m, iphlen, *offset, src, dst,
 				                 sh, inp, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				                 mflowtype, mflowid, fibnum,
 #endif
 				                 vrf_id, port);
@@ -5029,7 +5029,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 				op_err = sctp_generate_cause(SCTP_CAUSE_OUT_OF_RESC, "");
 				sctp_abort_association(inp, stcb, m, iphlen,
 						       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				                       mflowtype, mflowid,
 #endif
 				                       vrf_id, port);
@@ -5039,7 +5039,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 			sctp_handle_init(m, iphlen, *offset, src, dst, sh,
 			                 (struct sctp_init_chunk *)ch, inp,
 			                 stcb, *netp, &abort_no_unlock,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                 mflowtype, mflowid,
 #endif
 			                 vrf_id, port);
@@ -5060,7 +5060,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 				} else {
 					*offset = length;
 					if (stcb != NULL) {
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 						so = SCTP_INP_SO(inp);
 						atomic_add_int(&stcb->asoc.refcnt, 1);
 						SCTP_TCB_UNLOCK(stcb);
@@ -5070,7 +5070,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 #endif
 						(void)sctp_free_assoc(inp, stcb, SCTP_NORMAL_PROC,
 						                      SCTP_FROM_SCTP_INPUT + SCTP_LOC_29);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 						SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 					}
@@ -5089,7 +5089,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 				                           (struct sctp_init_ack_chunk *)ch,
 				                           stcb, *netp,
 				                           &abort_no_unlock,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				                           mflowtype, mflowid,
 #endif
 				                           vrf_id);
@@ -5329,7 +5329,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 			if ((stcb == NULL) &&
 			    (!SCTP_IS_LISTENING(inp) ||
 			     (!(inp->sctp_flags & SCTP_PCB_FLAGS_UDPTYPE) &&
-#if defined(__FreeBSD__) && __FreeBSD_version >= 1200034
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 1200034
 			      inp->sctp_socket->sol_qlen >= inp->sctp_socket->sol_qlimit))) {
 #else
 			      inp->sctp_socket->so_qlen >= inp->sctp_socket->so_qlimit))) {
@@ -5339,7 +5339,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 					op_err = sctp_generate_cause(SCTP_CAUSE_OUT_OF_RESC, "");
 					sctp_abort_association(inp, stcb, m, iphlen,
 					                       src, dst, sh, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 					                       mflowtype, mflowid,
 #endif
 					                       vrf_id, port);
@@ -5379,7 +5379,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 						                        auth_offset,
 						                        auth_len,
 						                        &locked_stcb,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 						                        mflowtype,
 						                        mflowid,
 #endif
@@ -5433,7 +5433,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 				if ((stcb) && (stcb->asoc.total_output_queue_size)) {
 					;
 				} else if (stcb) {
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 					so = SCTP_INP_SO(inp);
 					atomic_add_int(&stcb->asoc.refcnt, 1);
 					SCTP_TCB_UNLOCK(stcb);
@@ -5443,7 +5443,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 #endif
 					(void)sctp_free_assoc(inp, stcb, SCTP_NORMAL_PROC,
 					                      SCTP_FROM_SCTP_INPUT + SCTP_LOC_30);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 					SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 					*offset = length;
@@ -5548,7 +5548,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 				*fwd_tsn_seen = 1;
 				if (inp->sctp_flags & SCTP_PCB_FLAGS_SOCKET_GONE) {
 					/* We are not interested anymore */
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 					so = SCTP_INP_SO(inp);
 					atomic_add_int(&stcb->asoc.refcnt, 1);
 					SCTP_TCB_UNLOCK(stcb);
@@ -5558,7 +5558,7 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 #endif
 					(void)sctp_free_assoc(inp, stcb, SCTP_NORMAL_PROC,
 					                      SCTP_FROM_SCTP_INPUT + SCTP_LOC_31);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 					SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 					*offset = length;
@@ -5717,7 +5717,7 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
                              struct sctphdr *sh, struct sctp_chunkhdr *ch,
                              uint8_t compute_crc,
                              uint8_t ecn_bits,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                              uint8_t mflowtype, uint32_t mflowid, uint16_t fibnum,
 #endif
                              uint32_t vrf_id, uint16_t port)
@@ -5769,7 +5769,7 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 				net->port = port;
 			}
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			if (net != NULL) {
 				net->flowtype = mflowtype;
 				net->flowid = mflowid;
@@ -5811,25 +5811,25 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 		net->port = port;
 	}
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	if (net != NULL) {
 		net->flowtype = mflowtype;
 		net->flowid = mflowid;
 	}
 #endif
 	if (inp == NULL) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		SCTP_PROBE5(receive, NULL, stcb, m, stcb, sh);
 #endif
 		SCTP_STAT_INCR(sctps_noport);
-#if defined(__FreeBSD__) && (((__FreeBSD_version < 900000) && (__FreeBSD_version >= 804000)) || (__FreeBSD_version > 900000))
+#if defined(SCTP_KERNEL_FreeBSD) && (((__FreeBSD_version < 900000) && (__FreeBSD_version >= 804000)) || (__FreeBSD_version > 900000))
 		if (badport_bandlim(BANDLIM_SCTP_OOTB) < 0) {
 			goto out;
 		}
 #endif
 		if (ch->chunk_type == SCTP_SHUTDOWN_ACK) {
 			sctp_send_shutdown_complete2(src, dst, sh,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                             mflowtype, mflowid, fibnum,
 #endif
 			                             vrf_id, port);
@@ -5846,7 +5846,7 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 				                             "Out of the blue");
 				sctp_send_abort(m, iphlen, src, dst,
 				                sh, 0, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				                mflowtype, mflowid, fibnum,
 #endif
 				                vrf_id, port);
@@ -5875,14 +5875,14 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 			 */
 			SCTP_TCB_UNLOCK(stcb);
 			stcb = NULL;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			SCTP_PROBE5(receive, NULL, stcb, m, stcb, sh);
 #endif
 			snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __func__);
 			op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 			                             msg);
 			sctp_handle_ootb(m, iphlen, offset, src, dst, sh, inp, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                 mflowtype, mflowid, inp->fibnum,
 #endif
 			                 vrf_id, port);
@@ -5909,7 +5909,7 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 		stcb = sctp_process_control(m, iphlen, &offset, length,
 		                            src, dst, sh, ch,
 		                            inp, stcb, &net, &fwd_tsn_seen,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                            mflowtype, mflowid, fibnum,
 #endif
 		                            vrf_id, port);
@@ -5950,7 +5950,7 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 		if ((stcb != NULL) &&
 		    sctp_auth_is_required_chunk(SCTP_DATA, stcb->asoc.local_auth_chunks)) {
 			/* "silently" ignore */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			SCTP_PROBE5(receive, NULL, stcb, m, stcb, sh);
 #endif
 			SCTP_STAT_INCR(sctps_recvauthmissing);
@@ -5958,14 +5958,14 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 		}
 		if (stcb == NULL) {
 			/* out of the blue DATA chunk */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			SCTP_PROBE5(receive, NULL, NULL, m, NULL, sh);
 #endif
 			snprintf(msg, sizeof(msg), "OOTB, %s:%d at %s", __FILE__, __LINE__, __func__);
 			op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 			                             msg);
 			sctp_handle_ootb(m, iphlen, offset, src, dst, sh, inp, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                 mflowtype, mflowid, fibnum,
 #endif
 					 vrf_id, port);
@@ -5973,7 +5973,7 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 		}
 		if (stcb->asoc.my_vtag != ntohl(sh->v_tag)) {
 			/* v_tag mismatch! */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			SCTP_PROBE5(receive, NULL, stcb, m, stcb, sh);
 #endif
 			SCTP_STAT_INCR(sctps_badvtag);
@@ -5981,7 +5981,7 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 		}
 	}
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	SCTP_PROBE5(receive, NULL, stcb, m, stcb, sh);
 #endif
 	if (stcb == NULL) {
@@ -6051,7 +6051,7 @@ sctp_common_input_processing(struct mbuf **mm, int iphlen, int offset, int lengt
 			op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 			                             msg);
 			sctp_handle_ootb(m, iphlen, offset, src, dst, sh, inp, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                 mflowtype, mflowid, inp->fibnum,
 #endif
 					 vrf_id, port);
@@ -6169,7 +6169,7 @@ trigger_send:
 
 #ifdef INET
 #if !defined(__Userspace__)
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 void
 sctp_input_with_port(struct mbuf *i_pak, int off, uint16_t port)
 #elif defined(__Panda__)
@@ -6195,12 +6195,12 @@ sctp_input(i_pak, va_alist)
 	struct sctp_chunkhdr *ch;
 	int length, offset;
 	uint8_t compute_crc;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	uint32_t mflowid;
 	uint8_t mflowtype;
 	uint16_t fibnum;
 #endif
-#if !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__))
 	uint16_t port = 0;
 #endif
 
@@ -6230,7 +6230,7 @@ sctp_input(i_pak, va_alist)
 		sctp_packet_log(m);
 	}
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version > 1000049
 	SCTPDBG(SCTP_DEBUG_CRCOFFLOAD,
 	        "sctp_input(): Packet of length %d received on %s with csum_flags 0x%b.\n",
@@ -6251,7 +6251,7 @@ sctp_input(i_pak, va_alist)
 	        m->m_pkthdr.csum_flags);
 #endif
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	SCTPDBG(SCTP_DEBUG_CRCOFFLOAD,
 	        "sctp_input(): Packet of length %d received on %s%d with csum_flags 0x%x.\n",
 	        m->m_pkthdr.len,
@@ -6266,7 +6266,7 @@ sctp_input(i_pak, va_alist)
 	        m->m_pkthdr.rcvif->if_xname,
 	        m->m_pkthdr.csum_flags);
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	mflowid = m->m_pkthdr.flowid;
 	mflowtype = M_HASHTYPE_GET(m);
 	fibnum = M_GETFIB(m);
@@ -6305,13 +6305,13 @@ sctp_input(i_pak, va_alist)
 #if defined(__Userspace_os_Linux) || defined(__Userspace_os_Windows)
 	ip->ip_len = ntohs(ip->ip_len);
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version >= 1000000
 	length = ntohs(ip->ip_len);
 #else
 	length = ip->ip_len + iphlen;
 #endif
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 	length = ip->ip_len + iphlen;
 #elif defined(__Userspace__)
 #if defined(__Userspace_os_Linux) || defined(__Userspace_os_Windows)
@@ -6337,7 +6337,7 @@ sctp_input(i_pak, va_alist)
 		goto out;
 	}
 	ecn_bits = ip->ip_tos;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800000
 	if (m->m_pkthdr.csum_flags & CSUM_SCTP_VALID) {
 		SCTP_STAT_INCR(sctps_recvhwcrc);
 		compute_crc = 0;
@@ -6359,7 +6359,7 @@ sctp_input(i_pak, va_alist)
 	                             sh, ch,
 	                             compute_crc,
 	                             ecn_bits,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	                             mflowtype, mflowid, fibnum,
 #endif
 	                             vrf_id, port);
@@ -6370,11 +6370,11 @@ sctp_input(i_pak, va_alist)
 	return;
 }
 
-#if defined(__FreeBSD__) && defined(SCTP_MCORE_INPUT) && defined(SMP)
+#if defined(SCTP_KERNEL_FreeBSD) && defined(SCTP_MCORE_INPUT) && defined(SMP)
 extern int *sctp_cpuarry;
 #endif
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 1100020
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 1100020
 int
 sctp_input(struct mbuf **mp, int *offp, int proto SCTP_UNUSED)
 {
@@ -6388,7 +6388,7 @@ void
 sctp_input(struct mbuf *m, int off)
 {
 #endif
-#if defined(__FreeBSD__) && defined(SCTP_MCORE_INPUT) && defined(SMP)
+#if defined(SCTP_KERNEL_FreeBSD) && defined(SCTP_MCORE_INPUT) && defined(SMP)
 	if (mp_ncpus > 1) {
 		struct ip *ip;
 		struct sctphdr *sh;
@@ -6406,7 +6406,7 @@ sctp_input(struct mbuf *m, int off)
 			if (SCTP_BUF_LEN(m) < offset) {
 				if ((m = m_pullup(m, offset)) == NULL) {
 					SCTP_STAT_INCR(sctps_hdrops);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 1100020
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 1100020
 					return (IPPROTO_DONE);
 #else
 					return;
@@ -6422,7 +6422,7 @@ sctp_input(struct mbuf *m, int off)
 		}
 		cpu_to_use = sctp_cpuarry[flowid % mp_ncpus];
 		sctp_queue_to_mcore(m, off, cpu_to_use);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 1100020
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 1100020
 		return (IPPROTO_DONE);
 #else
 		return;
@@ -6430,7 +6430,7 @@ sctp_input(struct mbuf *m, int off)
 	}
 #endif
 	sctp_input_with_port(m, off, 0);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 1100020
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 1100020
 	return (IPPROTO_DONE);
 #endif
 }

--- a/usrsctplib/netinet/sctp_input.h
+++ b/usrsctplib/netinet/sctp_input.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_input.h 326672 2017-12-07 22:19:08Z tuexen $");
 #endif
@@ -47,7 +47,7 @@ sctp_common_input_processing(struct mbuf **, int, int, int,
                              struct sctphdr *, struct sctp_chunkhdr *,
                              uint8_t,
                              uint8_t,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                              uint8_t, uint32_t, uint16_t,
 #endif
                              uint32_t, uint16_t);

--- a/usrsctplib/netinet/sctp_lock_userspace.h
+++ b/usrsctplib/netinet/sctp_lock_userspace.h
@@ -33,7 +33,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 #endif

--- a/usrsctplib/netinet/sctp_os.h
+++ b/usrsctplib/netinet/sctp_os.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_os.h 235828 2012-05-23 11:26:28Z tuexen $");
 #endif
@@ -64,7 +64,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_os.h 235828 2012-05-23 11:26:28Z tuexe
  * SCTP_ZONE_DESTROY(zone)
  */
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #include <netinet/sctp_os_bsd.h>
 #else
 #define MODULE_GLOBAL(_B) (_B)
@@ -74,7 +74,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_os.h 235828 2012-05-23 11:26:28Z tuexe
 #include <netinet/sctp_os_userspace.h>
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #include <netinet/sctp_os_macosx.h>
 #endif
 

--- a/usrsctplib/netinet/sctp_os_userspace.h
+++ b/usrsctplib/netinet/sctp_os_userspace.h
@@ -459,11 +459,11 @@ struct sx {int dummy;};
 #include <user_mbuf.h>
 /* #include <sys/uio.h> */
 /* #include <sys/lock.h> */
-#if defined(__FreeBSD__) && __FreeBSD_version > 602000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 602000
 #include <sys/rwlock.h>
 #endif
 /* #include <sys/kthread.h> */
-#if defined(__FreeBSD__) && __FreeBSD_version > 602000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 602000
 #include <sys/priv.h>
 #endif
 /* #include <sys/random.h> */

--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -32,13 +32,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_output.c 359156 2020-03-19 23:07:52Z tuexen $");
 #endif
 
 #include <netinet/sctp_os.h>
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/proc.h>
 #endif
 #include <netinet/sctp_var.h>
@@ -56,7 +56,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_output.c 359156 2020-03-19 23:07:52Z t
 #include <netinet/sctp_bsd_addr.h>
 #include <netinet/sctp_input.h>
 #include <netinet/sctp_crc32.h>
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #include <netinet/sctp_kdtrace.h>
 #endif
 #if defined(__Userspace_os_Linux)
@@ -67,11 +67,11 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_output.c 359156 2020-03-19 23:07:52Z t
 #include <netinet/udp.h>
 #endif
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #include <netinet/in.h>
 #endif
-#if defined(__FreeBSD__)
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800000
+#if defined(SCTP_KERNEL_FreeBSD)
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800000
 #include <netinet/udp_var.h>
 #endif
 #include <machine/in_cksum.h>
@@ -80,11 +80,11 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_output.c 359156 2020-03-19 23:07:52Z t
 #include <netinet6/sctp6_var.h>
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #define APPLE_FILE_NO 3
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if !(defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD))
 #define SCTP_MAX_LINKHDR 16
 #endif
@@ -2103,7 +2103,7 @@ sctp_add_addresses_to_i_ia(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 				continue;
 			}
 			LIST_FOREACH(sctp_ifap, &sctp_ifnp->ifalist, next_ifa) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef INET
 				if ((sctp_ifap->address.sa.sa_family == AF_INET) &&
 				    (prison_check_ip4(inp->ip_inp.inp.inp_cred,
@@ -2153,7 +2153,7 @@ sctp_add_addresses_to_i_ia(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 					continue;
 				}
 				LIST_FOREACH(sctp_ifap, &sctp_ifnp->ifalist, next_ifa) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef INET
 					if ((sctp_ifap->address.sa.sa_family == AF_INET) &&
 					    (prison_check_ip4(inp->ip_inp.inp.inp_cred,
@@ -2541,7 +2541,7 @@ sctp_choose_boundspecific_inp(struct sctp_inpcb *inp,
 	if (sctp_ifn) {
 		/* is a preferred one on the interface we route out? */
 		LIST_FOREACH(sctp_ifa, &sctp_ifn->ifalist, next_ifa) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef INET
 			if ((sctp_ifa->address.sa.sa_family == AF_INET) &&
 			    (prison_check_ip4(inp->ip_inp.inp.inp_cred,
@@ -2683,7 +2683,7 @@ sctp_choose_boundspecific_stcb(struct sctp_inpcb *inp,
 	if (sctp_ifn) {
 		/* first try for a preferred address on the ep */
 		LIST_FOREACH(sctp_ifa, &sctp_ifn->ifalist, next_ifa) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef INET
 			if ((sctp_ifa->address.sa.sa_family == AF_INET) &&
 			    (prison_check_ip4(inp->ip_inp.inp.inp_cred,
@@ -2719,7 +2719,7 @@ sctp_choose_boundspecific_stcb(struct sctp_inpcb *inp,
 		}
 		/* next try for an acceptable address on the ep */
 		LIST_FOREACH(sctp_ifa, &sctp_ifn->ifalist, next_ifa) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef INET
 			if ((sctp_ifa->address.sa.sa_family == AF_INET) &&
 			    (prison_check_ip4(inp->ip_inp.inp.inp_cred,
@@ -2840,7 +2840,7 @@ sctp_choose_boundspecific_stcb(struct sctp_inpcb *inp,
 
 static struct sctp_ifa *
 sctp_select_nth_preferred_addr_from_ifn_boundall(struct sctp_ifn *ifn,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                                                  struct sctp_inpcb *inp,
 #else
                                                  struct sctp_inpcb *inp SCTP_UNUSED,
@@ -2871,7 +2871,7 @@ sctp_select_nth_preferred_addr_from_ifn_boundall(struct sctp_ifn *ifn,
 #endif  /* SCTP_EMBEDDED_V6_SCOPE */
 #endif	/* INET6 */
 	LIST_FOREACH(ifa, &ifn->ifalist, next_ifa) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef INET
 		if ((ifa->address.sa.sa_family == AF_INET) &&
 		    (prison_check_ip4(inp->ip_inp.inp.inp_cred,
@@ -2921,7 +2921,7 @@ sctp_select_nth_preferred_addr_from_ifn_boundall(struct sctp_ifn *ifn,
 #endif  /* SCTP_EMBEDDED_V6_SCOPE */
 #endif	/* INET6 */
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Userspace__)
 		/* Check if the IPv6 address matches to next-hop.
 		   In the mobile case, old IPv6 address may be not deleted
 		   from the interface. Then, the interface has previous and
@@ -2974,7 +2974,7 @@ sctp_select_nth_preferred_addr_from_ifn_boundall(struct sctp_ifn *ifn,
 
 static int
 sctp_count_num_preferred_boundall(struct sctp_ifn *ifn,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                                   struct sctp_inpcb *inp,
 #else
                                   struct sctp_inpcb *inp SCTP_UNUSED,
@@ -2989,7 +2989,7 @@ sctp_count_num_preferred_boundall(struct sctp_ifn *ifn,
 	int num_eligible_addr = 0;
 
 	LIST_FOREACH(ifa, &ifn->ifalist, next_ifa) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef INET
 		if ((ifa->address.sa.sa_family == AF_INET) &&
 		    (prison_check_ip4(inp->ip_inp.inp.inp_cred,
@@ -3199,7 +3199,7 @@ again_with_private_addresses_allowed:
 	}
 	LIST_FOREACH(sctp_ifa, &emit_ifn->ifalist, next_ifa) {
 		SCTPDBG(SCTP_DEBUG_OUTPUT2, "ifa:%p\n", (void *)sctp_ifa);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef INET
 		if ((sctp_ifa->address.sa.sa_family == AF_INET) &&
 		    (prison_check_ip4(inp->ip_inp.inp.inp_cred,
@@ -3265,7 +3265,7 @@ again_with_private_addresses_allowed:
 			continue;
 		}
 		LIST_FOREACH(sctp_ifa, &sctp_ifn->ifalist, next_ifa) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef INET
 			if ((sctp_ifa->address.sa.sa_family == AF_INET) &&
 			    (prison_check_ip4(inp->ip_inp.inp.inp_cred,
@@ -3333,7 +3333,7 @@ out:
 				LIST_FOREACH(sctp_ifa, &sctp_ifn->ifalist, next_ifa) {
 					struct sctp_ifa *tmp_sifa;
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef INET
 					if ((sctp_ifa->address.sa.sa_family == AF_INET) &&
 					    (prison_check_ip4(inp->ip_inp.inp.inp_cred,
@@ -4105,10 +4105,10 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
     uint32_t v_tag,
     uint16_t port,
     union sctp_sockstore *over_addr,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
     uint8_t mflowtype, uint32_t mflowid,
 #endif
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     int so_locked SCTP_UNUSED
 #else
     int so_locked
@@ -4147,11 +4147,11 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 	struct udphdr *udp = NULL;
 #endif
 	uint8_t tos_value;
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	struct socket *so = NULL;
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	if (so_locked) {
 		sctp_lock_assert(SCTP_INP_SO(inp));
 		SCTP_TCB_LOCK_ASSERT(stcb);
@@ -4206,7 +4206,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 		SCTP_BUF_LEN(newm) = len;
 		SCTP_BUF_NEXT(newm) = m;
 		m = newm;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		if (net != NULL) {
 			m->m_pkthdr.flowid = net->flowid;
 			M_HASHTYPE_SET(m, net->flowtype);
@@ -4224,7 +4224,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 			 * This means especially, that it is not set at the
 			 * SCTP layer. So use the value from the IP layer.
 			 */
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Panda__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Panda__) || defined(__Windows__) || defined(__Userspace__)
 			tos_value = inp->ip_inp.inp.inp_ip_tos;
 #else
 			tos_value = inp->inp_ip_tos;
@@ -4235,28 +4235,28 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 			tos_value |= sctp_get_ect(stcb);
 		}
 		if ((nofragment_flag) && (port == 0)) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version >= 1000000
 			ip->ip_off = htons(IP_DF);
 #else
 			ip->ip_off = IP_DF;
 #endif
-#elif defined(WITH_CONVERT_IP_OFF) || defined(__APPLE__) || defined(__Userspace_os_Darwin)
+#elif defined(WITH_CONVERT_IP_OFF) || defined(SCTP_KERNEL_APPLE) || defined(__Userspace_os_Darwin)
 			ip->ip_off = IP_DF;
 #else
 			ip->ip_off = htons(IP_DF);
 #endif
 		} else {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 1000000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 1000000
 			ip->ip_off = htons(0);
 #else
 			ip->ip_off = 0;
 #endif
 		}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		/* FreeBSD has a function for ip_id's */
 		ip_fillid(ip);
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 #if RANDOM_IP_ID
 		ip->ip_id = ip_randomid();
 #else
@@ -4268,12 +4268,12 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 		ip->ip_id = SCTP_IP_ID(inp)++;
 #endif
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Panda__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Panda__) || defined(__Windows__) || defined(__Userspace__)
 		ip->ip_ttl = inp->ip_inp.inp.inp_ip_ttl;
 #else
 		ip->ip_ttl = inp->inp_ip_ttl;
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version >= 1000000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 1000000
 		ip->ip_len = htons(packet_length);
 #else
 		ip->ip_len = packet_length;
@@ -4359,7 +4359,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 			udp->uh_dport = port;
 			udp->uh_ulen = htons((uint16_t)(packet_length - sizeof(struct ip)));
 #if !defined(__Windows__) && !defined(__Userspace__)
-#if defined(__FreeBSD__) && ((__FreeBSD_version > 803000 && __FreeBSD_version < 900000) || __FreeBSD_version > 900000)
+#if defined(SCTP_KERNEL_FreeBSD) && ((__FreeBSD_version > 803000 && __FreeBSD_version < 900000) || __FreeBSD_version > 900000)
 			if (V_udp_cksum) {
 				udp->uh_sum = in_pseudo(ip->ip_src.s_addr, ip->ip_dst.s_addr, udp->uh_ulen + htons(IPPROTO_UDP));
 			} else {
@@ -4420,7 +4420,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 			sctphdr->checksum = sctp_calculate_cksum(m, sizeof(struct ip) + sizeof(struct udphdr));
 			SCTP_STAT_INCR(sctps_sendswcrc);
 #if !defined(__Windows__) && !defined(__Userspace__)
-#if defined(__FreeBSD__) && ((__FreeBSD_version > 803000 && __FreeBSD_version < 900000) || __FreeBSD_version > 900000)
+#if defined(SCTP_KERNEL_FreeBSD) && ((__FreeBSD_version > 803000 && __FreeBSD_version < 900000) || __FreeBSD_version > 900000)
 			if (V_udp_cksum) {
 				SCTP_ENABLE_UDP_CSUM(o_pak);
 			}
@@ -4429,7 +4429,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 #endif
 #endif
 		} else {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800000
 			m->m_pkthdr.csum_flags = CSUM_SCTP;
 			m->m_pkthdr.csum_data = offsetof(struct sctphdr, checksum);
 			SCTP_STAT_INCR(sctps_sendhwcrc);
@@ -4448,17 +4448,17 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 			sctp_packet_log(o_pak);
 #endif
 		/* send it out.  table id is taken from stcb */
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		if ((SCTP_BASE_SYSCTL(sctp_output_unlocked)) && (so_locked)) {
 			so = SCTP_INP_SO(inp);
 			SCTP_SOCKET_UNLOCK(so, 0);
 		}
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		SCTP_PROBE5(send, NULL, stcb, ip, stcb, sctphdr);
 #endif
 		SCTP_IP_OUTPUT(ret, o_pak, ro, stcb, vrf_id);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		if ((SCTP_BASE_SYSCTL(sctp_output_unlocked)) && (so_locked)) {
 			atomic_add_int(&stcb->asoc.refcnt, 1);
 			SCTP_TCB_UNLOCK(stcb);
@@ -4467,7 +4467,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 			atomic_subtract_int(&stcb->asoc.refcnt, 1);
 		}
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		if (port) {
 			UDPSTAT_INC(udps_opackets);
 		}
@@ -4480,7 +4480,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 		SCTPDBG(SCTP_DEBUG_OUTPUT3, "IP output returns %d\n", ret);
 		if (net == NULL) {
 			/* free tempy routes */
-#if defined(__FreeBSD__) && __FreeBSD_version > 901000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 901000
 			RO_RTFREE(ro);
 #else
 			if (ro->ro_rt) {
@@ -4548,7 +4548,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 			 * This means especially, that it is not set at the
 			 * SCTP layer. So use the value from the IP layer.
 			 */
-#if defined(__APPLE__) && (!defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION))
+#if defined(SCTP_KERNEL_APPLE) && (!defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION))
 			flowlabel = ntohl(inp->ip_inp.inp.inp_flow);
 #else
 			flowlabel = ntohl(((struct inpcb *)inp)->inp_flow);
@@ -4569,7 +4569,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 		SCTP_BUF_LEN(newm) = len;
 		SCTP_BUF_NEXT(newm) = m;
 		m = newm;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		if (net != NULL) {
 			m->m_pkthdr.flowid = net->flowid;
 			M_HASHTYPE_SET(m, net->flowtype);
@@ -4588,7 +4588,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 
 #ifdef SCTP_EMBEDDED_V6_SCOPE
 		/* KAME hack: embed scopeid */
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD)
 		if (in6_embedscope(&sin6->sin6_addr, sin6, NULL, NULL) != 0)
 #else
@@ -4625,8 +4625,8 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 			 * This means especially, that it is not set at the
 			 * SCTP layer. So use the value from the IP layer.
 			 */
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Panda__) || defined(__Windows__) || defined(__Userspace__)
-#if defined(__APPLE__) && (!defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION))
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Panda__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_APPLE) && (!defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION))
 			tos_value = (ntohl(inp->ip_inp.inp.inp_flow) >> 20) & 0xff;
 #else
 			tos_value = (ntohl(((struct inpcb *)inp)->inp_flow) >> 20) & 0xff;
@@ -4676,7 +4676,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 #ifdef SCTP_EMBEDDED_V6_SCOPE
 				sin6 = (struct sockaddr_in6 *)&net->ro._l_addr;
 				/* KAME hack: embed scopeid */
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD)
 				if (in6_embedscope(&sin6->sin6_addr, sin6, NULL, NULL) != 0)
 #else
@@ -4722,7 +4722,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 #ifdef SCTP_EMBEDDED_V6_SCOPE
 			sin6 = (struct sockaddr_in6 *)&ro->ro_dst;
 			/* KAME hack: embed scopeid */
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD)
 			if (in6_embedscope(&sin6->sin6_addr, sin6, NULL, NULL) != 0)
 #else
@@ -4876,7 +4876,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 			}
 #endif
 		} else {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800000
 #if __FreeBSD_version < 900000
 			sctphdr->checksum = sctp_calculate_cksum(m, sizeof(struct ip6_hdr));
 			SCTP_STAT_INCR(sctps_sendswcrc);
@@ -4900,7 +4900,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 #endif
 		}
 		/* send it out. table id is taken from stcb */
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		if ((SCTP_BASE_SYSCTL(sctp_output_unlocked)) && (so_locked)) {
 			so = SCTP_INP_SO(inp);
 			SCTP_SOCKET_UNLOCK(so, 0);
@@ -4911,14 +4911,14 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 			sctp_packet_log(o_pak);
 #endif
 #if !(defined(__Panda__) || defined(__Userspace__))
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		SCTP_PROBE5(send, NULL, stcb, ip6h, stcb, sctphdr);
 #endif
 		SCTP_IP6_OUTPUT(ret, o_pak, (struct route_in6 *)ro, &ifp, stcb, vrf_id);
 #else
 		SCTP_IP6_OUTPUT(ret, o_pak, (struct route_in6 *)ro, NULL, stcb, vrf_id);
 #endif
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 		if ((SCTP_BASE_SYSCTL(sctp_output_unlocked)) && (so_locked)) {
 			atomic_add_int(&stcb->asoc.refcnt, 1);
 			SCTP_TCB_UNLOCK(stcb);
@@ -4933,7 +4933,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 			sin6->sin6_port = prev_port;
 		}
 		SCTPDBG(SCTP_DEBUG_OUTPUT3, "return from send is %d\n", ret);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		if (port) {
 			UDPSTAT_INC(udps_opackets);
 		}
@@ -4945,7 +4945,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 		}
 		if (net == NULL) {
 			/* Now if we had a temp route free it */
-#if defined(__FreeBSD__) && __FreeBSD_version > 901000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 901000
 			RO_RTFREE(ro);
 #else
 			if (ro->ro_rt) {
@@ -5061,7 +5061,7 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 
 void
 sctp_send_initiate(struct sctp_inpcb *inp, struct sctp_tcb *stcb, int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
     )
@@ -5077,7 +5077,7 @@ sctp_send_initiate(struct sctp_inpcb *inp, struct sctp_tcb *stcb, int so_locked
 	int error;
 	uint16_t num_ext, chunk_len, padding_len, parameter_len;
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	if (so_locked) {
 		sctp_lock_assert(SCTP_INP_SO(inp));
 	} else {
@@ -5342,7 +5342,7 @@ sctp_send_initiate(struct sctp_inpcb *inp, struct sctp_tcb *stcb, int so_locked
 	                                        m, 0, NULL, 0, 0, 0, 0,
 	                                        inp->sctp_lport, stcb->rport, htonl(0),
 	                                        net->port, NULL,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	                                        0, 0,
 #endif
 	                                        so_locked))) {
@@ -5917,7 +5917,7 @@ sctp_send_initiate_ack(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
                        int iphlen, int offset,
                        struct sockaddr *src, struct sockaddr *dst,
                        struct sctphdr *sh, struct sctp_init_chunk *init_chk,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		       uint8_t mflowtype, uint32_t mflowid,
 #endif
                        uint32_t vrf_id, uint16_t port)
@@ -5976,7 +5976,7 @@ sctp_send_initiate_ack(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 			op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 			                             "Address added");
 			sctp_send_abort(init_pkt, iphlen, src, dst, sh, 0, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                mflowtype, mflowid, inp->fibnum,
 #endif
 			                vrf_id, port);
@@ -5994,7 +5994,7 @@ sctp_send_initiate_ack(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 			op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 			                             "Remote encapsulation port changed");
 			sctp_send_abort(init_pkt, iphlen, src, dst, sh, 0, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                mflowtype, mflowid, inp->fibnum,
 #endif
 			                vrf_id, port);
@@ -6018,7 +6018,7 @@ sctp_send_initiate_ack(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 		}
 		sctp_send_abort(init_pkt, iphlen, src, dst, sh,
 				init_chk->init.initiate_tag, op_err,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                mflowtype, mflowid, inp->fibnum,
 #endif
 		                vrf_id, port);
@@ -6133,7 +6133,7 @@ sctp_send_initiate_ack(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 		{
 			stc.addr_type = SCTP_IPV6_ADDRESS;
 			memcpy(&stc.address, &src6->sin6_addr, sizeof(struct in6_addr));
-#if defined(__FreeBSD__) && (((__FreeBSD_version < 900000) && (__FreeBSD_version >= 804000)) || (__FreeBSD_version > 900000))
+#if defined(SCTP_KERNEL_FreeBSD) && (((__FreeBSD_version < 900000) && (__FreeBSD_version >= 804000)) || (__FreeBSD_version > 900000))
 			stc.scope_id = ntohs(in6_getscope(&src6->sin6_addr));
 #else
 			stc.scope_id = 0;
@@ -6154,7 +6154,7 @@ sctp_send_initiate_ack(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 				 * because we share one link that all links are
 				 * common.
 				 */
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 				/* Mac OS X currently doesn't have in6_getscope() */
 				stc.scope_id = src6->sin6_addr.s6_addr16[1];
 #endif
@@ -6646,7 +6646,7 @@ sctp_send_initiate_ack(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 	                                        0, 0,
 	                                        inp->sctp_lport, sh->src_port, init_chk->init.initiate_tag,
 	                                        port, over_addr,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	                                        mflowtype, mflowid,
 #endif
 	                                        SCTP_SO_NOT_LOCKED))) {
@@ -6828,7 +6828,7 @@ sctp_set_prsctp_policy(struct sctp_stream_queue_pending *sp)
 		/* TODO sctp_constants.h needs alternative time macros when
 		 *  _KERNEL is undefined.
 		 */
-#ifndef __FreeBSD__
+#ifndef SCTP_KERNEL_FreeBSD
 		timeradd(&sp->ts, &tv, &sp->ts);
 #else
 		timevaladd(&sp->ts, &tv);
@@ -7113,7 +7113,7 @@ sctp_med_chunk_output(struct sctp_inpcb *inp,
 		      int *reason_code,
 		      int control_only, int from_where,
 		      struct timeval *now, int *now_filled, int frag_point, int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
 		      SCTP_UNUSED
 #endif
                       );
@@ -7372,7 +7372,7 @@ sctp_sendall(struct sctp_inpcb *inp, struct uio *uio, struct mbuf *m,
 		/* There is another. */
 		return (EBUSY);
 	}
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 	if (uio->uio_resid > SCTP_BASE_SYSCTL(sctp_sendall_limit)) {
 #else
@@ -7404,7 +7404,7 @@ sctp_sendall(struct sctp_inpcb *inp, struct uio *uio, struct mbuf *m,
 	ca->sndrcv.sinfo_flags &= ~SCTP_SENDALL;
 	/* get length and mbuf chain */
 	if (uio) {
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 		ca->sndlen = uio->uio_resid;
 #else
@@ -7413,11 +7413,11 @@ sctp_sendall(struct sctp_inpcb *inp, struct uio *uio, struct mbuf *m,
 #else
 		ca->sndlen = uio->uio_resid;
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 		SCTP_SOCKET_UNLOCK(SCTP_INP_SO(inp), 0);
 #endif
 		ca->m = sctp_copy_out_all(uio, ca->sndlen);
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 		SCTP_SOCKET_LOCK(SCTP_INP_SO(inp), 0);
 #endif
 		if (ca->m == NULL) {
@@ -7592,7 +7592,7 @@ sctp_clean_up_datalist(struct sctp_tcb *stcb,
 
 static void
 sctp_clean_up_ctl(struct sctp_tcb *stcb, struct sctp_association *asoc, int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
 	SCTP_UNUSED
 #endif
 )
@@ -7699,7 +7699,7 @@ sctp_move_to_outqueue(struct sctp_tcb *stcb,
                       int eeor_mode,
                       int *bail,
                       int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
                       SCTP_UNUSED
 #endif
 	)
@@ -8101,7 +8101,7 @@ re_look:
 		sctp_auth_key_acquire(stcb, chk->auth_keyid);
 		chk->holds_key_ref = 1;
 	}
-#if defined(__FreeBSD__) || defined(__Panda__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(__Panda__)
 	chk->rec.data.tsn = atomic_fetchadd_int(&asoc->sending_seq, 1);
 #else
 	chk->rec.data.tsn = asoc->sending_seq++;
@@ -8225,7 +8225,7 @@ out_of:
 static void
 sctp_fill_outqueue(struct sctp_tcb *stcb,
     struct sctp_nets *net, int frag_point, int eeor_mode, int *quit_now, int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
 	SCTP_UNUSED
 #endif
 )
@@ -8349,7 +8349,7 @@ sctp_med_chunk_output(struct sctp_inpcb *inp,
 		      int *reason_code,
 		      int control_only, int from_where,
 		      struct timeval *now, int *now_filled, int frag_point, int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
 		      SCTP_UNUSED
 #endif
 	)
@@ -8389,7 +8389,7 @@ sctp_med_chunk_output(struct sctp_inpcb *inp,
 	   the destination. */
 	int quit_now = 0;
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	if (so_locked) {
 		sctp_lock_assert(SCTP_INP_SO(inp));
 	} else {
@@ -8762,7 +8762,7 @@ again_one_more_time:
 					                                        inp->sctp_lport, stcb->rport,
 					                                        htonl(stcb->asoc.peer_vtag),
 					                                        net->port, NULL,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 					                                        0, 0,
 #endif
 					                                        so_locked))) {
@@ -9033,7 +9033,7 @@ again_one_more_time:
 					                                        inp->sctp_lport, stcb->rport,
 					                                        htonl(stcb->asoc.peer_vtag),
 					                                        net->port, NULL,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 					                                        0, 0,
 #endif
 					                                        so_locked))) {
@@ -9375,7 +9375,7 @@ again_one_more_time:
 			                                        inp->sctp_lport, stcb->rport,
 			                                        htonl(stcb->asoc.peer_vtag),
 			                                        net->port, NULL,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                                        0, 0,
 #endif
 			                                        so_locked))) {
@@ -9973,7 +9973,7 @@ sctp_chunk_retransmission(struct sctp_inpcb *inp,
     struct sctp_tcb *stcb,
     struct sctp_association *asoc,
     int *cnt_out, struct timeval *now, int *now_filled, int *fr_done, int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
     )
@@ -10005,7 +10005,7 @@ sctp_chunk_retransmission(struct sctp_inpcb *inp,
 	int data_auth_reqd = 0;
 	uint32_t dmtu = 0;
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	if (so_locked) {
 		sctp_lock_assert(SCTP_INP_SO(inp));
 	} else {
@@ -10086,7 +10086,7 @@ sctp_chunk_retransmission(struct sctp_inpcb *inp,
 		                                        no_fragmentflg, 0, 0,
 		                                        inp->sctp_lport, stcb->rport, htonl(stcb->asoc.peer_vtag),
 		                                        chk->whoTo->port, NULL,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		                                        0, 0,
 #endif
 		                                        so_locked))) {
@@ -10367,7 +10367,7 @@ sctp_chunk_retransmission(struct sctp_inpcb *inp,
 			                                        no_fragmentflg, 0, 0,
 			                                        inp->sctp_lport, stcb->rport, htonl(stcb->asoc.peer_vtag),
 			                                        net->port, NULL,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			                                        0, 0,
 #endif
 			                                        so_locked))) {
@@ -10537,7 +10537,7 @@ sctp_chunk_output(struct sctp_inpcb *inp,
     struct sctp_tcb *stcb,
     int from_where,
     int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
     )
@@ -10567,7 +10567,7 @@ sctp_chunk_output(struct sctp_inpcb *inp,
 	int fr_done;
 	unsigned int tot_frs = 0;
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	if (so_locked) {
 		sctp_lock_assert(SCTP_INP_SO(inp));
 	} else {
@@ -10828,12 +10828,12 @@ sctp_output(
 #else
 	struct mbuf *control,
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 	struct thread *p,
 #elif defined(__Windows__)
 	PKTHREAD p,
 #else
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	struct proc *p SCTP_UNUSED,
 #else
 	struct proc *p,
@@ -10855,7 +10855,7 @@ sctp_output(
 			    (struct uio *)NULL,
 			    m,
 			    control,
-#if defined(__APPLE__) || defined(__Panda__)
+#if defined(SCTP_KERNEL_APPLE) || defined(__Panda__)
 			    flags
 #else
 			    flags, p
@@ -11081,7 +11081,7 @@ sctp_fill_in_rest:
 
 void
 sctp_send_sack(struct sctp_tcb *stcb, int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
 	SCTP_UNUSED
 #endif
 )
@@ -11477,7 +11477,7 @@ sctp_send_sack(struct sctp_tcb *stcb, int so_locked
 
 void
 sctp_send_abort_tcb(struct sctp_tcb *stcb, struct mbuf *operr, int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
     )
@@ -11492,7 +11492,7 @@ sctp_send_abort_tcb(struct sctp_tcb *stcb, struct mbuf *operr, int so_locked
 	int error;
 	uint16_t cause_len, chunk_len, padding_len;
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	if (so_locked) {
 		sctp_lock_assert(SCTP_INP_SO(stcb->sctp_ep));
 	} else {
@@ -11573,7 +11573,7 @@ sctp_send_abort_tcb(struct sctp_tcb *stcb, struct mbuf *operr, int so_locked
 	                                        m_out, auth_offset, auth, stcb->asoc.authinfo.active_keyid, 1, 0, 0,
 	                                        stcb->sctp_ep->sctp_lport, stcb->rport, htonl(vtag),
 	                                        stcb->asoc.primary_destination->port, NULL,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	                                        0, 0,
 #endif
 	                                        so_locked))) {
@@ -11623,7 +11623,7 @@ sctp_send_shutdown_complete(struct sctp_tcb *stcb,
 	                                        stcb->sctp_ep->sctp_lport, stcb->rport,
 	                                        htonl(vtag),
 	                                        net->port, NULL,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	                                        0, 0,
 #endif
 	                                        SCTP_SO_NOT_LOCKED))) {
@@ -11639,7 +11639,7 @@ sctp_send_shutdown_complete(struct sctp_tcb *stcb,
 	return;
 }
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 static void
 sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
                    struct sctphdr *sh, uint32_t vtag,
@@ -11667,7 +11667,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 #endif
 	int ret, len, cause_len, padding_len;
 #ifdef INET
-#if defined(__APPLE__) || defined(__Panda__)
+#if defined(SCTP_KERNEL_APPLE) || defined(__Panda__)
 	sctp_route_t ro;
 #endif
 	struct sockaddr_in *src_sin, *dst_sin;
@@ -11722,7 +11722,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 		len += sizeof(struct udphdr);
 	}
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD)
 	mout = sctp_get_mbuf_for_msg(len + max_linkhdr, 1, M_NOWAIT, 1, MT_DATA);
 #else
@@ -11737,7 +11737,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 		}
 		return;
 	}
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD)
 	SCTP_BUF_RESV_UF(mout, max_linkhdr);
 #else
@@ -11748,7 +11748,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 #endif
 	SCTP_BUF_LEN(mout) = len;
 	SCTP_BUF_NEXT(mout) = cause;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	M_SETFIB(mout, fibnum);
 	mout->m_pkthdr.flowid = mflowid;
 	M_HASHTYPE_SET(mout, mflowtype);
@@ -11768,20 +11768,20 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 		ip->ip_v = IPVERSION;
 		ip->ip_hl = (sizeof(struct ip) >> 2);
 		ip->ip_tos = 0;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version >= 1000000
 		ip->ip_off = htons(IP_DF);
 #else
 		ip->ip_off = IP_DF;
 #endif
-#elif defined(WITH_CONVERT_IP_OFF) || defined(__APPLE__) || defined(__Userspace_os_Darwin)
+#elif defined(WITH_CONVERT_IP_OFF) || defined(SCTP_KERNEL_APPLE) || defined(__Userspace_os_Darwin)
 		ip->ip_off = IP_DF;
 #else
 		ip->ip_off = htons(IP_DF);
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		ip_fillid(ip);
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 #if RANDOM_IP_ID
 		ip->ip_id = ip_randomid();
 #else
@@ -11811,7 +11811,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 		dst_sin6 = (struct sockaddr_in6 *)dst;
 		ip6 = mtod(mout, struct ip6_hdr *);
 		ip6->ip6_flow = htonl(0x60000000);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		if (V_ip6_auto_flowlabel) {
 			ip6->ip6_flow |= (htonl(ip6_randomflowlabel()) & IPV6_FLOWLABEL_MASK);
 		}
@@ -11885,7 +11885,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 	switch (dst->sa_family) {
 #ifdef INET
 	case AF_INET:
-#if defined(__APPLE__) || defined(__Panda__)
+#if defined(SCTP_KERNEL_APPLE) || defined(__Panda__)
 		/* zap the stack pointer to the route */
 		memset(&ro, 0, sizeof(sctp_route_t));
 #if defined(__Panda__)
@@ -11894,7 +11894,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 #endif
 		if (port) {
 #if !defined(__Windows__) && !defined(__Userspace__)
-#if defined(__FreeBSD__) && ((__FreeBSD_version > 803000 && __FreeBSD_version < 900000) || __FreeBSD_version > 900000)
+#if defined(SCTP_KERNEL_FreeBSD) && ((__FreeBSD_version > 803000 && __FreeBSD_version < 900000) || __FreeBSD_version > 900000)
 			if (V_udp_cksum) {
 				udp->uh_sum = in_pseudo(ip->ip_src.s_addr, ip->ip_dst.s_addr, udp->uh_ulen + htons(IPPROTO_UDP));
 			} else {
@@ -11907,13 +11907,13 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 			udp->uh_sum = 0;
 #endif
 		}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version >= 1000000
 		ip->ip_len = htons(len);
 #else
 		ip->ip_len = len;
 #endif
-#elif defined(__APPLE__) || defined(__Userspace__)
+#elif defined(SCTP_KERNEL_APPLE) || defined(__Userspace__)
 		ip->ip_len = len;
 #else
 		ip->ip_len = htons(len);
@@ -11922,7 +11922,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 			shout->checksum = sctp_calculate_cksum(mout, sizeof(struct ip) + sizeof(struct udphdr));
 			SCTP_STAT_INCR(sctps_sendswcrc);
 #if !defined(__Windows__) && !defined(__Userspace__)
-#if defined(__FreeBSD__) && ((__FreeBSD_version > 803000 && __FreeBSD_version < 900000) || __FreeBSD_version > 900000)
+#if defined(SCTP_KERNEL_FreeBSD) && ((__FreeBSD_version > 803000 && __FreeBSD_version < 900000) || __FreeBSD_version > 900000)
 			if (V_udp_cksum) {
 				SCTP_ENABLE_UDP_CSUM(o_pak);
 			}
@@ -11931,7 +11931,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 #endif
 #endif
 		} else {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800000
 			mout->m_pkthdr.csum_flags = CSUM_SCTP;
 			mout->m_pkthdr.csum_data = offsetof(struct sctphdr, checksum);
 			SCTP_STAT_INCR(sctps_sendhwcrc);
@@ -11945,7 +11945,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 			sctp_packet_log(o_pak);
 		}
 #endif
-#if defined(__APPLE__) || defined(__Panda__)
+#if defined(SCTP_KERNEL_APPLE) || defined(__Panda__)
 		SCTP_IP_OUTPUT(ret, o_pak, &ro, NULL, vrf_id);
 		/* Free the route if we got one back */
 		if (ro.ro_rt) {
@@ -11953,7 +11953,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 			ro.ro_rt = NULL;
 		}
 #else
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		SCTP_PROBE5(send, NULL, NULL, ip, NULL, shout);
 #endif
 		SCTP_IP_OUTPUT(ret, o_pak, NULL, NULL, vrf_id);
@@ -11974,7 +11974,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 			}
 #endif
 		} else {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 900000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 900000
 #if __FreeBSD_version > 901000
 			mout->m_pkthdr.csum_flags = CSUM_SCTP_IPV6;
 #else
@@ -11992,7 +11992,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 			sctp_packet_log(o_pak);
 		}
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		SCTP_PROBE5(send, NULL, NULL, ip6, NULL, shout);
 #endif
 		SCTP_IP6_OUTPUT(ret, o_pak, NULL, NULL, NULL, vrf_id);
@@ -12036,7 +12036,7 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 		return;
 	}
 	SCTPDBG(SCTP_DEBUG_OUTPUT3, "return from send is %d\n", ret);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	if (port) {
 		UDPSTAT_INC(udps_opackets);
 	}
@@ -12053,13 +12053,13 @@ sctp_send_resp_msg(struct sockaddr *src, struct sockaddr *dst,
 void
 sctp_send_shutdown_complete2(struct sockaddr *src, struct sockaddr *dst,
                              struct sctphdr *sh,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                              uint8_t mflowtype, uint32_t mflowid, uint16_t fibnum,
 #endif
                              uint32_t vrf_id, uint16_t port)
 {
 	sctp_send_resp_msg(src, dst, sh, 0, SCTP_SHUTDOWN_COMPLETE, NULL,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	                   mflowtype, mflowid, fibnum,
 #endif
 	                   vrf_id, port);
@@ -12067,7 +12067,7 @@ sctp_send_shutdown_complete2(struct sockaddr *src, struct sockaddr *dst,
 
 void
 sctp_send_hb(struct sctp_tcb *stcb, struct sctp_nets *net,int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
 	SCTP_UNUSED
 #endif
 )
@@ -13078,7 +13078,7 @@ skip_stuff:
 void
 sctp_send_abort(struct mbuf *m, int iphlen, struct sockaddr *src, struct sockaddr *dst,
                 struct sctphdr *sh, uint32_t vtag, struct mbuf *cause,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                 uint8_t mflowtype, uint32_t mflowid, uint16_t fibnum,
 #endif
                 uint32_t vrf_id, uint16_t port)
@@ -13090,7 +13090,7 @@ sctp_send_abort(struct mbuf *m, int iphlen, struct sockaddr *src, struct sockadd
 		return;
 	}
 	sctp_send_resp_msg(src, dst, sh, vtag, SCTP_ABORT_ASSOCIATION, cause,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	                   mflowtype, mflowid, fibnum,
 #endif
 	                   vrf_id, port);
@@ -13100,13 +13100,13 @@ sctp_send_abort(struct mbuf *m, int iphlen, struct sockaddr *src, struct sockadd
 void
 sctp_send_operr_to(struct sockaddr *src, struct sockaddr *dst,
                    struct sctphdr *sh, uint32_t vtag, struct mbuf *cause,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                    uint8_t mflowtype, uint32_t mflowid, uint16_t fibnum,
 #endif
                    uint32_t vrf_id, uint16_t port)
 {
 	sctp_send_resp_msg(src, dst, sh, vtag, SCTP_OPERATION_ERROR, cause,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	                   mflowtype, mflowid, fibnum,
 #endif
 	                   vrf_id, port);
@@ -13116,7 +13116,7 @@ sctp_send_operr_to(struct sockaddr *src, struct sockaddr *dst,
 static struct mbuf *
 sctp_copy_resume(struct uio *uio,
 		 int max_send_len,
-#if (defined(__FreeBSD__) && __FreeBSD_version > 602000) || defined(__Userspace__)
+#if (defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 602000) || defined(__Userspace__)
 		 int user_marks_eor,
 #endif
 		 int *error,
@@ -13136,7 +13136,7 @@ sctp_copy_resume(struct uio *uio,
 		*new_tail = m_last(m);
 	}
 	return (m);
-#elif defined(__FreeBSD__) && __FreeBSD_version > 602000 || defined(__Userspace__)
+#elif defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 602000 || defined(__Userspace__)
 	struct mbuf *m;
 
 	m = m_uiotombuf(uio, M_WAITOK, max_send_len, 0,
@@ -13153,7 +13153,7 @@ sctp_copy_resume(struct uio *uio,
 	int left, cancpy, willcpy;
 	struct mbuf *m, *head;
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 	left = (int)min(uio->uio_resid, max_send_len);
 #else
@@ -13229,7 +13229,7 @@ sctp_copy_one(struct sctp_stream_queue_pending *sp,
 
 	sp->tail_mbuf = m_last(sp->data);
 	return (0);
-#elif defined(__FreeBSD__) && __FreeBSD_version > 602000 || defined(__Userspace__)
+#elif defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 602000 || defined(__Userspace__)
 	sp->data = m_uiotombuf(uio, M_WAITOK, sp->length,
 	                       resv_upfront, 0);
 	if (sp->data == NULL) {
@@ -13344,7 +13344,7 @@ sctp_copy_it_in(struct sctp_tcb *stcb,
 	(void)SCTP_GETTIME_TIMEVAL(&sp->ts);
 
 	sp->sid = srcv->sinfo_stream;
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 	sp->length = (uint32_t)min(uio->uio_resid, max_send_len);
 #else
@@ -13353,7 +13353,7 @@ sctp_copy_it_in(struct sctp_tcb *stcb,
 #else
 	sp->length = (uint32_t)min(uio->uio_resid, max_send_len);
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 	if ((sp->length == (uint32_t)uio->uio_resid) &&
 #else
@@ -13386,11 +13386,11 @@ sctp_copy_it_in(struct sctp_tcb *stcb,
 		sctp_auth_key_acquire(stcb, sp->auth_keyid);
 		sp->holds_key_ref = 1;
 	}
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	SCTP_SOCKET_UNLOCK(SCTP_INP_SO(stcb->sctp_ep), 0);
 #endif
 	*error = sctp_copy_one(sp, uio, resv_in_first);
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	SCTP_SOCKET_LOCK(SCTP_INP_SO(stcb->sctp_ep), 0);
 #endif
  skip_copy:
@@ -13428,11 +13428,11 @@ sctp_sosend(struct socket *so,
             struct mbuf *top,
             struct mbuf *control,
 #endif
-#if defined(__APPLE__) || defined(__Panda__)
+#if defined(SCTP_KERNEL_APPLE) || defined(__Panda__)
             int flags
 #else
             int flags,
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
             struct thread *p
 #elif defined(__Windows__)
             PKTHREAD p
@@ -13451,7 +13451,7 @@ sctp_sosend(struct socket *so,
 #ifdef __Panda__
 	struct mbuf *control = NULL;
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	struct proc *p = current_proc();
 #endif
 	int error, use_sndinfo = 0;
@@ -13461,7 +13461,7 @@ sctp_sosend(struct socket *so,
 	struct sockaddr_in sin;
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	SCTP_SOCKET_LOCK(so, 1);
 #endif
 #ifdef __Panda__
@@ -13499,7 +13499,7 @@ sctp_sosend(struct socket *so,
 				  , p
 #endif
 		);
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 	return (error);
@@ -13521,7 +13521,7 @@ sctp_lower_sosend(struct socket *so,
                   struct sctp_sndrcvinfo *srcv
 #if !(defined( __Panda__) || defined(__Userspace__))
                   ,
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
                   struct thread *p
 #elif defined(__Windows__)
                   PKTHREAD p
@@ -13531,7 +13531,7 @@ sctp_lower_sosend(struct socket *so,
 #endif
 	)
 {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	struct epoch_tracker et;
 #endif
 	ssize_t sndlen = 0, max_len, local_add_more;
@@ -13569,7 +13569,7 @@ sctp_lower_sosend(struct socket *so,
 	stcb = NULL;
 	asoc = NULL;
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	sctp_lock_assert(so);
 #endif
 	t_inp = inp = (struct sctp_inpcb *)so->so_pcb;
@@ -13588,7 +13588,7 @@ sctp_lower_sosend(struct socket *so,
 	user_marks_eor = sctp_is_feature_on(inp, SCTP_PCB_FLAGS_EXPLICIT_EOR);
 	atomic_add_int(&inp->total_sends, 1);
 	if (uio) {
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 		if (uio->uio_resid < 0) {
 #else
@@ -13600,7 +13600,7 @@ sctp_lower_sosend(struct socket *so,
 			SCTP_LTRACE_ERR_RET(inp, stcb, net, SCTP_FROM_SCTP_OUTPUT, EINVAL);
 			return (EINVAL);
 		}
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 		sndlen = uio->uio_resid;
 #else
@@ -13717,7 +13717,7 @@ sctp_lower_sosend(struct socket *so,
 		sinfo_flags = inp->def_send.sinfo_flags;
 		sinfo_assoc_id = inp->def_send.sinfo_assoc_id;
 	}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	if (flags & MSG_EOR) {
 		sinfo_flags |= SCTP_EOR;
 	}
@@ -13893,7 +13893,7 @@ sctp_lower_sosend(struct socket *so,
 	if (srcv == NULL) {
 		srcv = (struct sctp_sndrcvinfo *)&asoc->def_send;
 		sinfo_flags = srcv->sinfo_flags;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		if (flags & MSG_EOR) {
 			sinfo_flags |= SCTP_EOR;
 		}
@@ -13938,7 +13938,7 @@ sctp_lower_sosend(struct socket *so,
 	}
 #endif
 	if (SCTP_SO_IS_NBIO(so)
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 	     || (flags & (MSG_NBIO | MSG_DONTWAIT)) != 0
 #endif
 	    ) {
@@ -14027,9 +14027,9 @@ sctp_lower_sosend(struct socket *so,
 	/* Ok, we will attempt a msgsnd :> */
 #if !(defined(__Panda__) || defined(__Windows__) || defined(__Userspace__))
 	if (p) {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 603000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 603000
 		p->td_ru.ru_msgsnd++;
-#elif defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#elif defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 		p->td_proc->p_stats->p_ru.ru_msgsnd++;
 #else
 		p->p_stats->p_ru.ru_msgsnd++;
@@ -14095,11 +14095,11 @@ sctp_lower_sosend(struct socket *so,
 			ph++;
 			SCTP_BUF_LEN(mm) = (int)(tot_out + sizeof(struct sctp_paramhdr));
 			if (top == NULL) {
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 				SCTP_SOCKET_UNLOCK(so, 0);
 #endif
 				error = uiomove((caddr_t)ph, (int)tot_out, uio);
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 				SCTP_SOCKET_LOCK(so, 0);
 #endif
 				if (error) {
@@ -14123,11 +14123,11 @@ sctp_lower_sosend(struct socket *so,
 		atomic_add_int(&stcb->asoc.refcnt, -1);
 		free_cnt_applied = 0;
 		/* release this lock, otherwise we hang on ourselves */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		NET_EPOCH_ENTER(et);
 #endif
 		sctp_abort_an_association(stcb->sctp_ep, stcb, mm, SCTP_SO_LOCKED);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		NET_EPOCH_EXIT(et);
 #endif
 		/* now relock the stcb so everything is sane */
@@ -14250,7 +14250,7 @@ skip_preblock:
 	if (stcb->asoc.state & SCTP_STATE_ABOUT_TO_BE_FREED) {
 		goto out_unlocked;
 	}
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	error = sblock(&so->so_snd, SBLOCKWAIT(flags));
 #endif
 	/* sndlen covers for mbuf case
@@ -14328,7 +14328,7 @@ skip_preblock:
 
 			}
 		}
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 		while (uio->uio_resid > 0) {
 #else
@@ -14348,7 +14348,7 @@ skip_preblock:
 
 			if ((max_len > (ssize_t)SCTP_BASE_SYSCTL(sctp_add_more_threshold)) ||
 			    (max_len && (SCTP_SB_LIMIT_SND(so) < SCTP_BASE_SYSCTL(sctp_add_more_threshold))) ||
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 			    (uio->uio_resid && (uio->uio_resid <= max_len))) {
 #else
@@ -14363,15 +14363,15 @@ skip_preblock:
 					SCTP_TCB_UNLOCK(stcb);
 					hold_tcblock = 0;
 				}
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 				SCTP_SOCKET_UNLOCK(so, 0);
 #endif
-#if (defined(__FreeBSD__) && __FreeBSD_version > 602000) || defined(__Userspace__)
+#if (defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 602000) || defined(__Userspace__)
 				mm = sctp_copy_resume(uio, (int)max_len, user_marks_eor, &error, &sndout, &new_tail);
 #else
 				mm = sctp_copy_resume(uio, (int)max_len, &error, &sndout, &new_tail);
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 				SCTP_SOCKET_LOCK(so, 0);
 #endif
 				if ((mm == NULL) || error) {
@@ -14411,7 +14411,7 @@ skip_preblock:
 				}
 
 				/* Did we reach EOR? */
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 				if ((uio->uio_resid == 0) &&
 #else
@@ -14429,7 +14429,7 @@ skip_preblock:
 				}
 				SCTP_TCB_SEND_UNLOCK(stcb);
 			}
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 			if (uio->uio_resid == 0) {
 #else
@@ -14475,11 +14475,11 @@ skip_preblock:
 					/* a collision took us forward? */
 					queue_only = 0;
 				} else {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 					NET_EPOCH_ENTER(et);
 #endif
 					sctp_send_initiate(inp, stcb, SCTP_SO_LOCKED);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 					NET_EPOCH_EXIT(et);
 #endif
 					SCTP_SET_STATE(stcb, SCTP_STATE_COOKIE_WAIT);
@@ -14539,7 +14539,7 @@ skip_preblock:
 				 * the input via the net is happening
 				 * and I don't need to start output :-D
 				 */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				NET_EPOCH_ENTER(et);
 #endif
 				if (hold_tcblock == 0) {
@@ -14554,7 +14554,7 @@ skip_preblock:
 							  stcb,
 							  SCTP_OUTPUT_FROM_USR_SEND, SCTP_SO_LOCKED);
 				}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				NET_EPOCH_EXIT(et);
 #endif
 			}
@@ -14581,7 +14581,7 @@ skip_preblock:
 			if (SCTP_SB_LIMIT_SND(so) <= (inqueue_bytes +
 						      min(SCTP_BASE_SYSCTL(sctp_add_more_threshold), SCTP_SB_LIMIT_SND(so)))) {
 				if (SCTP_BASE_SYSCTL(sctp_logging_level) & SCTP_BLK_LOGGING_ENABLE) {
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 					sctp_log_block(SCTP_BLOCK_LOG_INTO_BLK,
 						       asoc, uio->uio_resid);
@@ -14598,7 +14598,7 @@ skip_preblock:
 #if !defined(__Panda__) && !defined(__Windows__)
 				stcb->block_entry = &be;
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 				sbunlock(&so->so_snd, 1);
 #endif
 				error = sbwait(&so->so_snd);
@@ -14616,7 +14616,7 @@ skip_preblock:
 					goto out_unlocked;
 				}
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 				error = sblock(&so->so_snd, SBLOCKWAIT(flags));
 #endif
 				if (SCTP_BASE_SYSCTL(sctp_logging_level) & SCTP_BLK_LOGGING_ENABLE) {
@@ -14652,7 +14652,7 @@ skip_preblock:
 			asoc->stream_locked = 0;
 		}
 		SCTP_TCB_SEND_UNLOCK(stcb);
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD)
 		if (uio->uio_resid == 0) {
 #else
@@ -14756,12 +14756,12 @@ dataless_eof:
 					         "%s:%d at %s", __FILE__, __LINE__, __func__);
 					op_err = sctp_generate_cause(SCTP_BASE_SYSCTL(sctp_diag_info_code),
 					                             msg);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 					NET_EPOCH_ENTER(et);
 #endif
 					sctp_abort_an_association(stcb->sctp_ep, stcb,
 					                          op_err, SCTP_SO_LOCKED);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 					NET_EPOCH_EXIT(et);
 #endif
 					/* now relock the stcb so everything is sane */
@@ -14788,11 +14788,11 @@ skip_out_eof:
 			/* a collision took us forward? */
 			queue_only = 0;
 		} else {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			NET_EPOCH_ENTER(et);
 #endif
 			sctp_send_initiate(inp, stcb, SCTP_SO_LOCKED);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			NET_EPOCH_EXIT(et);
 #endif
 			SCTP_SET_STATE(stcb, SCTP_STATE_COOKIE_WAIT);
@@ -14840,7 +14840,7 @@ skip_out_eof:
 		               stcb->asoc.total_flight,
 		               stcb->asoc.chunks_on_out_queue, stcb->asoc.total_flight_count);
 	}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	NET_EPOCH_ENTER(et);
 #endif
 	if ((queue_only == 0) && (nagle_applies == 0) && (stcb->asoc.peers_rwnd && un_sent)) {
@@ -14875,7 +14875,7 @@ skip_out_eof:
 		(void)sctp_med_chunk_output(inp, stcb, &stcb->asoc, &num_out,
 		                            &reason, 1, 1, &now, &now_filled, frag_point, SCTP_SO_LOCKED);
 	}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	NET_EPOCH_EXIT(et);
 #endif
 	SCTPDBG(SCTP_DEBUG_OUTPUT1, "USR Send complete qo:%d prw:%d unsent:%d tf:%d cooq:%d toqs:%d err:%d\n",
@@ -14884,7 +14884,7 @@ skip_out_eof:
 	        stcb->asoc.total_output_queue_size, error);
 
 out:
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	sbunlock(&so->so_snd, 1);
 #endif
 out_unlocked:
@@ -14902,7 +14902,7 @@ out_unlocked:
 		atomic_add_int(&stcb->asoc.refcnt, -1);
 	}
 #ifdef INVARIANTS
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	if (stcb) {
 		if (mtx_owned(&stcb->tcb_mtx)) {
 			panic("Leaving with tcb mtx owned?");
@@ -15008,7 +15008,7 @@ sctp_add_auth_chunk(struct mbuf *m, struct mbuf **m_end,
 	return (m);
 }
 
-#if defined(__FreeBSD__)  || defined(__APPLE__)
+#if defined(SCTP_KERNEL_FreeBSD)  || defined(SCTP_KERNEL_APPLE)
 #ifdef INET6
 int
 sctp_v6src_match_nexthop(struct sockaddr_in6 *src6, sctp_route_t *ro)
@@ -15021,7 +15021,7 @@ sctp_v6src_match_nexthop(struct sockaddr_in6 *src6, sctp_route_t *ro)
 		return (0);
 
 	/* get prefix entry of address */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	ND6_RLOCK();
 #endif
 	LIST_FOREACH(pfx, &MODULE_GLOBAL(nd_prefix), ndpr_entry) {
@@ -15033,7 +15033,7 @@ sctp_v6src_match_nexthop(struct sockaddr_in6 *src6, sctp_route_t *ro)
 	}
 	/* no prefix entry in the prefix list */
 	if (pfx == NULL) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		ND6_RUNLOCK();
 #endif
 		SCTPDBG(SCTP_DEBUG_OUTPUT2, "No prefix entry for ");
@@ -15058,14 +15058,14 @@ sctp_v6src_match_nexthop(struct sockaddr_in6 *src6, sctp_route_t *ro)
 		SCTPDBG(SCTP_DEBUG_OUTPUT2, "installed router is ");
 		SCTPDBG_ADDR(SCTP_DEBUG_OUTPUT2, ro->ro_rt->rt_gateway);
 		if (sctp_cmpaddr((struct sockaddr *)&gw6, ro->ro_rt->rt_gateway)) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			ND6_RUNLOCK();
 #endif
 			SCTPDBG(SCTP_DEBUG_OUTPUT2, "pfxrouter is installed\n");
 			return (1);
 		}
 	}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	ND6_RUNLOCK();
 #endif
 	SCTPDBG(SCTP_DEBUG_OUTPUT2, "pfxrouter is not installed\n");

--- a/usrsctplib/netinet/sctp_output.h
+++ b/usrsctplib/netinet/sctp_output.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_output.h 351654 2019-09-01 10:09:53Z tuexen $");
 #endif
@@ -71,7 +71,7 @@ sctp_source_address_selection(struct sctp_inpcb *inp,
 			      sctp_route_t *ro, struct sctp_nets *net,
 			      int non_asoc_addr_ok, uint32_t vrf_id);
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Userspace__)
 int
 sctp_v6src_match_nexthop(struct sockaddr_in6 *src6, sctp_route_t *ro);
 int
@@ -79,7 +79,7 @@ sctp_v4src_match_nexthop(struct sctp_ifa *sifa, sctp_route_t *ro);
 #endif
 
 void sctp_send_initiate(struct sctp_inpcb *, struct sctp_tcb *, int
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
     );
@@ -90,7 +90,7 @@ sctp_send_initiate_ack(struct sctp_inpcb *, struct sctp_tcb *,
                        int, int,
                        struct sockaddr *, struct sockaddr *,
                        struct sctphdr *, struct sctp_init_chunk *,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                        uint8_t, uint32_t,
 #endif
                        uint32_t, uint16_t);
@@ -124,7 +124,7 @@ void sctp_send_shutdown_complete(struct sctp_tcb *, struct sctp_nets *, int);
 
 void sctp_send_shutdown_complete2(struct sockaddr *, struct sockaddr *,
                                   struct sctphdr *,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                                   uint8_t, uint32_t, uint16_t,
 #endif
                                   uint32_t, uint16_t);
@@ -148,7 +148,7 @@ void sctp_move_chunks_from_net(struct sctp_tcb *stcb, struct sctp_nets *net);
 					sizeof(struct sctp_idata_chunk) : \
 					sizeof(struct sctp_data_chunk))
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 int
 sctp_output(struct sctp_inpcb *, struct mbuf *, struct sockaddr *,
     struct mbuf *, struct thread *, int);
@@ -176,12 +176,12 @@ sctp_output(struct sctp_inpcb *,
 #endif
 
 void sctp_chunk_output(struct sctp_inpcb *, struct sctp_tcb *, int, int
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
     );
 void sctp_send_abort_tcb(struct sctp_tcb *, struct mbuf *, int
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
     );
@@ -225,14 +225,14 @@ sctp_send_str_reset_req(struct sctp_tcb *, uint16_t , uint16_t *,
 void
 sctp_send_abort(struct mbuf *, int, struct sockaddr *, struct sockaddr *,
                 struct sctphdr *, uint32_t, struct mbuf *,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                 uint8_t, uint32_t, uint16_t,
 #endif
                 uint32_t, uint16_t);
 
 void sctp_send_operr_to(struct sockaddr *, struct sockaddr *,
                         struct sctphdr *, uint32_t, struct mbuf *,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                         uint8_t, uint32_t, uint16_t,
 #endif
                         uint32_t, uint16_t);
@@ -251,11 +251,11 @@ sctp_sosend(struct socket *so,
     struct mbuf *top,
     struct mbuf *control,
 #endif
-#if defined(__APPLE__) || defined(__Panda__)
+#if defined(SCTP_KERNEL_APPLE) || defined(__Panda__)
     int flags
 #else
     int flags,
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
     struct thread *p
 #elif defined(__Windows__)
     PKTHREAD p

--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -32,13 +32,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_pcb.c 359405 2020-03-28 20:25:45Z tuexen $");
 #endif
 
 #include <netinet/sctp_os.h>
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/proc.h>
 #endif
 #include <netinet/sctp_var.h>
@@ -63,7 +63,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_pcb.c 359405 2020-03-28 20:25:45Z tuex
 #include <netinet6/ip6_var.h>
 #endif
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #include <sys/sched.h>
 #include <sys/smp.h>
 #include <sys/unistd.h>
@@ -76,11 +76,11 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_pcb.c 359405 2020-03-28 20:25:45Z tuex
 #endif
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #define APPLE_FILE_NO 4
 #endif
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 VNET_DEFINE(struct sctp_base_info, system_base_info);
 #else
 struct sctp_base_info system_base_info;
@@ -93,7 +93,7 @@ int
 SCTP6_ARE_ADDR_EQUAL(struct sockaddr_in6 *a, struct sockaddr_in6 *b)
 {
 #ifdef SCTP_EMBEDDED_V6_SCOPE
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	struct in6_addr tmp_a, tmp_b;
 
 	tmp_a = a->sin6_addr;
@@ -990,7 +990,7 @@ sctp_does_stcb_own_this_addr(struct sctp_tcb *stcb, struct sockaddr *to)
 						    IN4_ISPRIVATE_ADDRESS(&sin->sin_addr)) {
 							continue;
 						}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 						if (prison_check_ip4(stcb->sctp_ep->ip_inp.inp.inp_cred,
 						                     &sin->sin_addr) != 0) {
 							continue;
@@ -1012,7 +1012,7 @@ sctp_does_stcb_own_this_addr(struct sctp_tcb *stcb, struct sockaddr *to)
 #endif
 						sin6 = &sctp_ifa->address.sin6;
 						rsin6 = (struct sockaddr_in6 *)to;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 						if (prison_check_ip6(stcb->sctp_ep->ip_inp.inp.inp_cred,
 						                     &sin6->sin6_addr) != 0) {
 							continue;
@@ -1217,7 +1217,7 @@ sctp_tcb_special_locate(struct sctp_inpcb **inp_p, struct sockaddr *from,
 			SCTP_INP_RUNLOCK(inp);
 			continue;
 		}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		switch (to->sa_family) {
 #ifdef INET
 		case AF_INET:
@@ -1958,7 +1958,7 @@ sctp_endpoint_probe(struct sockaddr *nam, struct sctppcbhead *head,
 					SCTP_INP_RUNLOCK(inp);
 					continue;
 				}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				if (prison_check_ip4(inp->ip_inp.inp.inp_cred,
 				                     &sin->sin_addr) != 0) {
 					SCTP_INP_RUNLOCK(inp);
@@ -1974,7 +1974,7 @@ sctp_endpoint_probe(struct sockaddr *nam, struct sctppcbhead *head,
 					SCTP_INP_RUNLOCK(inp);
 					continue;
 				}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				if (prison_check_ip6(inp->ip_inp.inp.inp_cred,
 				                     &sin6->sin6_addr) != 0) {
 					SCTP_INP_RUNLOCK(inp);
@@ -2091,7 +2091,7 @@ sctp_endpoint_probe(struct sockaddr *nam, struct sctppcbhead *head,
 				switch (nam->sa_family) {
 #ifdef INET
 				case AF_INET:
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 					if (sin == NULL) {
 						/* TSNH */
 						break;
@@ -2797,13 +2797,13 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 	memset(inp, 0, sizeof(*inp));
 
 	/* bump generations */
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	inp->ip_inp.inp.inp_state = INPCB_STATE_INUSE;
 #endif
 	/* setup socket pointers */
 	inp->sctp_socket = so;
 	inp->ip_inp.inp.inp_socket = so;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	inp->ip_inp.inp.inp_cred = crhold(so->so_cred);
 #endif
 #ifdef INET6
@@ -2832,7 +2832,7 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 	inp->pktdrop_supported = (uint8_t)SCTP_BASE_SYSCTL(sctp_pktdrop_enable);
 	inp->idata_supported = 0;
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	inp->fibnum = so->so_fibnum;
 #else
 	inp->fibnum = 0;
@@ -2846,7 +2846,7 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 	/* init the small hash table we use to track asocid <-> tcb */
 	inp->sctp_asocidhash = SCTP_HASH_INIT(SCTP_STACK_VTAG_HASH_SIZE, &inp->hashasocidmark);
 	if (inp->sctp_asocidhash == NULL) {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		crfree(inp->ip_inp.inp.inp_cred);
 #endif
 		SCTP_ZONE_FREE(SCTP_BASE_INFO(ipi_zone_ep), inp);
@@ -2859,7 +2859,7 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 
 	so->so_pcb = (caddr_t)inp;
 
-#if defined(__FreeBSD__) && __FreeBSD_version < 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 803000
 	if ((SCTP_SO_TYPE(so) == SOCK_DGRAM) ||
 	    (SCTP_SO_TYPE(so) == SOCK_SEQPACKET)) {
 #else
@@ -2893,7 +2893,7 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 		 */
 		SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_PCB, EOPNOTSUPP);
 		so->so_pcb = NULL;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		crfree(inp->ip_inp.inp.inp_cred);
 #endif
 		SCTP_ZONE_FREE(SCTP_BASE_INFO(ipi_zone_ep), inp);
@@ -2915,7 +2915,7 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 		SCTP_PRINTF("Out of SCTP-INPCB->hashinit - no resources\n");
 		SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_PCB, ENOBUFS);
 		so->so_pcb = NULL;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		crfree(inp->ip_inp.inp.inp_cred);
 #endif
 		SCTP_ZONE_FREE(SCTP_BASE_INFO(ipi_zone_ep), inp);
@@ -2929,7 +2929,7 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 		SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_PCB, ENOBUFS);
 		so->so_pcb = NULL;
 		SCTP_HASH_FREE(inp->sctp_tcbhash, inp->sctp_hashmark);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		crfree(inp->ip_inp.inp.inp_cred);
 #endif
 		SCTP_ZONE_FREE(SCTP_BASE_INFO(ipi_zone_ep), inp);
@@ -2940,7 +2940,7 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 #endif
 	inp->def_vrf_id = vrf_id;
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD)
 	inp->ip_inp.inp.inpcb_mtx = lck_mtx_alloc_init(SCTP_BASE_INFO(sctbinfo).mtx_grp, SCTP_BASE_INFO(sctbinfo).mtx_attr);
 	if (inp->ip_inp.inp.inpcb_mtx == NULL) {
@@ -2963,7 +2963,7 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 #endif
 	SCTP_INP_INFO_WLOCK();
 	SCTP_INP_LOCK_INIT(inp);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	INP_LOCK_INIT(&inp->ip_inp.inp, "inp", "sctpinp");
 #endif
 	SCTP_INP_READ_INIT(inp);
@@ -2973,7 +2973,7 @@ sctp_inpcb_alloc(struct socket *so, uint32_t vrf_id)
 
 	/* add it to the info area */
 	LIST_INSERT_HEAD(&SCTP_BASE_INFO(listhead), inp, sctp_list);
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	inp->ip_inp.inp.inp_pcbinfo = &SCTP_BASE_INFO(sctbinfo);
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD) || defined(APPLE_LION) || defined(APPLE_MOUNTAINLION)
 	LIST_INSERT_HEAD(SCTP_BASE_INFO(sctbinfo).listhead, &inp->ip_inp.inp, inp_list);
@@ -3240,7 +3240,7 @@ sctp_remove_laddr(struct sctp_laddr *laddr)
 	SCTP_DECR_LADDR_COUNT();
 }
 
-#if !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__Userspace__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Userspace__))
 /*
  * Don't know why, but without this there is an unknown reference when
  * compiling NetBSD... hmm
@@ -3251,7 +3251,7 @@ extern void in6_sin6_2_sin(struct sockaddr_in *, struct sockaddr_in6 *sin6);
 
 /* sctp_ifap is used to bypass normal local address validation checks */
 int
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
                 struct sctp_ifa *sctp_ifap, struct thread *p)
 #elif defined(__Windows__)
@@ -3265,7 +3265,7 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 	/* bind a ep to a socket address */
 	struct sctppcbhead *head;
 	struct sctp_inpcb *inp, *inp_tmp;
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE)
 	struct inpcb *ip_inp;
 #endif
 	int port_reuse_active = 0;
@@ -3280,7 +3280,7 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 	lport = 0;
 	bindall = 1;
 	inp = (struct sctp_inpcb *)so->so_pcb;
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE)
 	ip_inp = (struct inpcb *)so->so_pcb;
 #endif
 #ifdef SCTP_DEBUG
@@ -3296,7 +3296,7 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 		SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_PCB, EINVAL);
 		return (EINVAL);
 	}
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 #ifdef INVARIANTS
 	if (p == NULL)
 		panic("null proc/thread");
@@ -3323,7 +3323,7 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 
 			sin = (struct sockaddr_in *)addr;
 			lport = sin->sin_port;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800000
 			/*
 			 * For LOOPBACK the prison_local_ip4() call will transmute the ip address
 			 * to the proper value.
@@ -3354,7 +3354,7 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 			}
 #endif
 			lport = sin6->sin6_port;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800000
 			/*
 			 * For LOOPBACK the prison_local_ip6() call will transmute the ipv6 address
 			 * to the proper value.
@@ -3374,7 +3374,7 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 					SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_PCB, EINVAL);
 					return (EINVAL);
 				}
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD)
 				if (in6_embedscope(&sin6->sin6_addr, sin6, ip_inp, NULL) != 0) {
 #else
@@ -3383,7 +3383,7 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 					SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_PCB, EINVAL);
 					return (EINVAL);
 				}
-#elif defined(__FreeBSD__)
+#elif defined(SCTP_KERNEL_FreeBSD)
 				error = scope6_check_id(sin6, MODULE_GLOBAL(ip6_use_defzone));
 				if (error != 0) {
 					SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP_PCB, error);
@@ -3444,7 +3444,7 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 #if !defined(__Windows__)
 		if (ntohs(lport) < IPPORT_RESERVED) {
 			if ((p != NULL) && ((error =
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #if __FreeBSD_version > 602000
 				  priv_check(p, PRIV_NETINET_RESERVEDPORT)
 #elif __FreeBSD_version >= 500000
@@ -3452,7 +3452,7 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 #else
 				  suser(p)
 #endif
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 				  suser(p->p_ucred, &p->p_acflag)
 #elif defined(__Userspace__) /* must be true to use raw socket */
 				  1
@@ -3564,13 +3564,13 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 #else
 #if defined(__Userspace__)
 		/* TODO ensure uid is 0, etc... */
-#elif defined(__FreeBSD__) || defined(__APPLE__)
+#elif defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE)
 		if (ip_inp->inp_flags & INP_HIGHPORT) {
 			first = MODULE_GLOBAL(ipport_hifirstauto);
 			last = MODULE_GLOBAL(ipport_hilastauto);
 		} else if (ip_inp->inp_flags & INP_LOWPORT) {
 			if (p && (error =
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #if __FreeBSD_version > 602000
 				  priv_check(p, PRIV_NETINET_RESERVEDPORT)
 #elif __FreeBSD_version >= 500000
@@ -3578,7 +3578,7 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 #else
 				  suser(p)
 #endif
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 				  suser(p->p_ucred, &p->p_acflag)
 #else
 				  suser(p, 0)
@@ -3596,7 +3596,7 @@ sctp_inpcb_bind(struct socket *so, struct sockaddr *addr,
 #endif
 			first = MODULE_GLOBAL(ipport_firstauto);
 			last = MODULE_GLOBAL(ipport_lastauto);
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE)
 		}
 #endif
 #endif /* __Windows__ */
@@ -3811,7 +3811,7 @@ sctp_iterator_inp_being_freed(struct sctp_inpcb *inp)
 	 * lock on the inp_info stuff.
 	 */
 	it = sctp_it_ctl.cur_it;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 	if (it && (it->vn != curvnet)) {
 		/* Its not looking at our VNET */
 		return;
@@ -3842,7 +3842,7 @@ sctp_iterator_inp_being_freed(struct sctp_inpcb *inp)
 	 */
 	SCTP_IPI_ITERATOR_WQ_LOCK();
 	TAILQ_FOREACH_SAFE(it, &sctp_it_ctl.iteratorhead, sctp_nxt_itr, nit) {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 		if (it->vn != curvnet) {
 			continue;
 		}
@@ -3889,7 +3889,7 @@ sctp_inpcb_free(struct sctp_inpcb *inp, int immediate, int from)
 	int being_refed = 0;
 	struct sctp_queued_to_read *sq, *nsq;
 #if !defined(__Panda__) && !defined(__Userspace__)
-#if !defined(__FreeBSD__) || __FreeBSD_version < 500000
+#if !defined(SCTP_KERNEL_FreeBSD) || __FreeBSD_version < 500000
 	sctp_rtentry_t *rt;
 #endif
 #endif
@@ -3897,7 +3897,7 @@ sctp_inpcb_free(struct sctp_inpcb *inp, int immediate, int from)
 	sctp_sharedkey_t *shared_key, *nshared_key;
 
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	sctp_lock_assert(SCTP_INP_SO(inp));
 #endif
 #ifdef SCTP_LOG_CLOSING
@@ -4187,7 +4187,7 @@ sctp_inpcb_free(struct sctp_inpcb *inp, int immediate, int from)
 #endif
 
 #if !(defined(__Panda__) || defined(__Windows__) || defined(__Userspace__))
-#if !defined(__FreeBSD__) || __FreeBSD_version < 500000
+#if !defined(SCTP_KERNEL_FreeBSD) || __FreeBSD_version < 500000
 	rt = ip_pcb->inp_route.ro_rt;
 #endif
 #endif
@@ -4230,13 +4230,13 @@ sctp_inpcb_free(struct sctp_inpcb *inp, int immediate, int from)
 #endif
 
 #if !(defined(__Panda__) || defined(__Windows__) || defined(__Userspace__))
-#if !defined(__FreeBSD__) || __FreeBSD_version < 500000
+#if !defined(SCTP_KERNEL_FreeBSD) || __FreeBSD_version < 500000
 	if (rt) {
 		RTFREE(rt);
 		ip_pcb->inp_route.ro_rt = 0;
 	}
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version < 803000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 803000
 #ifdef INET
 	if (ip_pcb->inp_moptions) {
 		inp_freemoptions(ip_pcb->inp_moptions);
@@ -4248,7 +4248,7 @@ sctp_inpcb_free(struct sctp_inpcb *inp, int immediate, int from)
 
 #ifdef INET6
 #if !(defined(__Panda__) || defined(__Windows__) || defined(__Userspace__))
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE)
 	if (ip_pcb->inp_vflag & INP_IPV6) {
 #else
 	if (inp->inp_vflag & INP_IPV6) {
@@ -4257,7 +4257,7 @@ sctp_inpcb_free(struct sctp_inpcb *inp, int immediate, int from)
 	}
 #endif
 #endif				/* INET6 */
-#if !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__))
 	inp->inp_vflag = 0;
 #else
 	ip_pcb->inp_vflag = 0;
@@ -4274,7 +4274,7 @@ sctp_inpcb_free(struct sctp_inpcb *inp, int immediate, int from)
 		/*sa_ignore FREED_MEMORY*/
 	}
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	inp->ip_inp.inp.inp_state = INPCB_STATE_DEAD;
 	if (in_pcb_checkstate(&inp->ip_inp.inp, WNT_STOPUSING, 1) != WNT_STOPUSING) {
 #ifdef INVARIANTS
@@ -4312,14 +4312,14 @@ sctp_inpcb_free(struct sctp_inpcb *inp, int immediate, int from)
 		inp->sctp_tcbhash = NULL;
 	}
 	/* Now we must put the ep memory back into the zone pool */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	crfree(inp->ip_inp.inp.inp_cred);
 	INP_LOCK_DESTROY(&inp->ip_inp.inp);
 #endif
 	SCTP_INP_LOCK_DESTROY(inp);
 	SCTP_INP_READ_DESTROY(inp);
 	SCTP_ASOC_CREATE_LOCK_DESTROY(inp);
-#if !defined(__APPLE__)
+#if !defined(SCTP_KERNEL_APPLE)
 	SCTP_ZONE_FREE(SCTP_BASE_INFO(ipi_zone_ep), inp);
 	SCTP_DECR_EP_COUNT();
 #else
@@ -4603,7 +4603,7 @@ sctp_add_remote_addr(struct sctp_tcb *stcb, struct sockaddr *newaddr,
 		struct sockaddr_in6 *sin6;
 
 		sin6 = (struct sockaddr_in6 *)&net->ro._l_addr;
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD)
 		(void)in6_embedscope(&sin6->sin6_addr, sin6, &stcb->sctp_ep->ip_inp.inp, NULL);
 #else
@@ -4671,7 +4671,7 @@ sctp_add_remote_addr(struct sctp_tcb *stcb, struct sockaddr *newaddr,
 				imtu = 0;
 			}
 			rmtu = SCTP_GATHER_MTU_FROM_ROUTE(net->ro._s_addr, &net->ro._l_addr.sa, net->ro.ro_rt);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			hcmtu = sctp_hc_get_mtu(&net->ro._l_addr, stcb->sctp_ep->fibnum);
 #else
 			hcmtu = 0;
@@ -4770,7 +4770,7 @@ sctp_add_remote_addr(struct sctp_tcb *stcb, struct sockaddr *newaddr,
 	 */
 	net->find_pseudo_cumack = 1;
 	net->find_rtx_pseudo_cumack = 1;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	/* Choose an initial flowid. */
 	net->flowid = stcb->asoc.my_vtag ^
 	              ntohs(stcb->rport) ^
@@ -4905,7 +4905,7 @@ struct sctp_tcb *
 sctp_aloc_assoc(struct sctp_inpcb *inp, struct sockaddr *firstaddr,
                 int *error, uint32_t override_tag, uint32_t vrf_id,
                 uint16_t o_streams, uint16_t port,
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
                 struct thread *p,
 #elif defined(__Windows__)
                 PKTHREAD p,
@@ -5474,7 +5474,7 @@ sctp_free_assoc(struct sctp_inpcb *inp, struct sctp_tcb *stcb, int from_inpcbfre
 	struct socket *so;
 
 	/* first, lets purge the entry from the hash table. */
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	sctp_lock_assert(SCTP_INP_SO(inp));
 #endif
 
@@ -5492,7 +5492,7 @@ sctp_free_assoc(struct sctp_inpcb *inp, struct sctp_tcb *stcb, int from_inpcbfre
 		sctp_free_remote_addr(stcb->asoc.alternate);
 		stcb->asoc.alternate = NULL;
 	}
-#if !defined(__APPLE__) /* TEMP: moved to below */
+#if !defined(SCTP_KERNEL_APPLE) /* TEMP: moved to below */
         /* TEMP CODE */
 	if (stcb->freed_from_where == 0) {
 		/* Only record the first place free happened from */
@@ -5650,7 +5650,7 @@ sctp_free_assoc(struct sctp_inpcb *inp, struct sctp_tcb *stcb, int from_inpcbfre
 				    SS_ISCONFIRMING |
 				    SS_ISCONNECTED);
 				so->so_state |= SS_ISDISCONNECTED;
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 				socantrcvmore(so);
 #else
 				socantrcvmore_locked(so);
@@ -5948,7 +5948,7 @@ sctp_free_assoc(struct sctp_inpcb *inp, struct sctp_tcb *stcb, int from_inpcbfre
 		SCTP_INP_INFO_WUNLOCK();
 		SCTP_INP_RLOCK(inp);
 	}
-#if defined(__APPLE__) /* TEMP CODE */
+#if defined(SCTP_KERNEL_APPLE) /* TEMP CODE */
 	stcb->freed_from_where = from_location;
 #endif
 #ifdef SCTP_TRACK_FREED_ASOCS
@@ -6039,7 +6039,7 @@ sctp_destination_is_reachable(struct sctp_tcb *stcb, struct sockaddr *destaddr)
 	switch (destaddr->sa_family) {
 #ifdef INET6
 	case AF_INET6:
-#if !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__))
 		answer = inp->inp_vflag & INP_IPV6;
 #else
 		answer = inp->ip_inp.inp.inp_vflag & INP_IPV6;
@@ -6048,7 +6048,7 @@ sctp_destination_is_reachable(struct sctp_tcb *stcb, struct sockaddr *destaddr)
 #endif
 #ifdef INET
 	case AF_INET:
-#if !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__))
 		answer = inp->inp_vflag & INP_IPV4;
 #else
 		answer = inp->ip_inp.inp.inp_vflag & INP_IPV4;
@@ -6077,7 +6077,7 @@ sctp_update_ep_vflag(struct sctp_inpcb *inp)
 	struct sctp_laddr *laddr;
 
 	/* first clear the flag */
-#if !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__))
 	inp->inp_vflag = 0;
 #else
 	inp->ip_inp.inp.inp_vflag = 0;
@@ -6096,7 +6096,7 @@ sctp_update_ep_vflag(struct sctp_inpcb *inp)
 		switch (laddr->ifa->address.sa.sa_family) {
 #ifdef INET6
 		case AF_INET6:
-#if !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__))
 			inp->inp_vflag |= INP_IPV6;
 #else
 			inp->ip_inp.inp.inp_vflag |= INP_IPV6;
@@ -6105,7 +6105,7 @@ sctp_update_ep_vflag(struct sctp_inpcb *inp)
 #endif
 #ifdef INET
 		case AF_INET:
-#if !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__))
 			inp->inp_vflag |= INP_IPV4;
 #else
 			inp->ip_inp.inp.inp_vflag |= INP_IPV4;
@@ -6166,7 +6166,7 @@ sctp_add_local_addr_ep(struct sctp_inpcb *inp, struct sctp_ifa *ifa, uint32_t ac
 		switch (ifa->address.sa.sa_family) {
 #ifdef INET6
 		case AF_INET6:
-#if !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__))
 			inp->inp_vflag |= INP_IPV6;
 #else
 			inp->ip_inp.inp.inp_vflag |= INP_IPV6;
@@ -6175,7 +6175,7 @@ sctp_add_local_addr_ep(struct sctp_inpcb *inp, struct sctp_ifa *ifa, uint32_t ac
 #endif
 #ifdef INET
 		case AF_INET:
-#if !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__))
 			inp->inp_vflag |= INP_IPV4;
 #else
 			inp->ip_inp.inp.inp_vflag |= INP_IPV4;
@@ -6376,9 +6376,9 @@ sctp_del_local_addr_restricted(struct sctp_tcb *stcb, struct sctp_ifa *ifa)
 	return;
 }
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 /*
- * Temporarily remove for __APPLE__ until we use the Tiger equivalents
+ * Temporarily remove for SCTP_KERNEL_APPLE until we use the Tiger equivalents
  */
 /* sysctl */
 static int sctp_max_number_of_assoc = SCTP_MAX_NUM_OF_ASOC;
@@ -6387,7 +6387,7 @@ static int sctp_scale_up_for_address = SCTP_SCALE_FOR_ADDR;
 
 
 
-#if defined(__FreeBSD__) && defined(SCTP_MCORE_INPUT) && defined(SMP)
+#if defined(SCTP_KERNEL_FreeBSD) && defined(SCTP_MCORE_INPUT) && defined(SMP)
 struct sctp_mcore_ctrl *sctp_mcore_workers = NULL;
 int *sctp_cpuarry = NULL;
 void
@@ -6410,7 +6410,7 @@ sctp_queue_to_mcore(struct mbuf *m, int off, int cpu_to_use)
 		sctp_input_with_port(m, off, 0);
 		return;
 	}
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 	qent->vn = curvnet;
 #endif
 	qent->m = m;
@@ -6464,7 +6464,7 @@ sctp_mcore_thread(void *arg)
 		if (qent) {
 			TAILQ_REMOVE(&wkq->que, qent, next);
 			SCTP_MCORE_QUNLOCK(wkq);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 			CURVNET_SET(qent->vn);
 #endif
 			m = qent->m;
@@ -6477,7 +6477,7 @@ sctp_mcore_thread(void *arg)
 				SCTP_PRINTF("V6 not yet supported\n");
 				sctp_m_freem(m);
 			}
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 			CURVNET_RESTORE();
 #endif
 			SCTP_MCORE_QLOCK(wkq);
@@ -6556,7 +6556,7 @@ sctp_startup_mcore_threads(void)
 	}
 }
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_cc_version >= 1400000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_cc_version >= 1400000
 static struct mbuf *
 sctp_netisr_hdlr(struct mbuf *m, uintptr_t source)
 {
@@ -6625,13 +6625,13 @@ sctp_pcb_init(void)
 	memset(&SCTP_BASE_SYSCTL(sctp_log), 0, sizeof(struct sctp_log));
 #endif
 #endif
-#if defined(__FreeBSD__) && defined(SMP) && defined(SCTP_USE_PERCPU_STAT)
+#if defined(SCTP_KERNEL_FreeBSD) && defined(SMP) && defined(SCTP_USE_PERCPU_STAT)
 	SCTP_MALLOC(SCTP_BASE_STATS, struct sctpstat *,
 		    ((mp_maxid+1) * sizeof(struct sctpstat)),
 		    SCTP_M_MCORE);
 #endif
 	(void)SCTP_GETTIME_TIMEVAL(&tv);
-#if defined(__FreeBSD__) && defined(SMP) && defined(SCTP_USE_PERCPU_STAT)
+#if defined(SCTP_KERNEL_FreeBSD) && defined(SMP) && defined(SCTP_USE_PERCPU_STAT)
 	memset(SCTP_BASE_STATS, 0, sizeof(struct sctpstat) * (mp_maxid+1));
 	SCTP_BASE_STATS[PCPU_GET(cpuid)].sctps_discontinuitytime.tv_sec = (uint32_t)tv.tv_sec;
 	SCTP_BASE_STATS[PCPU_GET(cpuid)].sctps_discontinuitytime.tv_usec = (uint32_t)tv.tv_usec;
@@ -6642,7 +6642,7 @@ sctp_pcb_init(void)
 #endif
 	/* init the empty list of (All) Endpoints */
 	LIST_INIT(&SCTP_BASE_INFO(listhead));
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	LIST_INIT(&SCTP_BASE_INFO(inplisthead));
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD) || defined(APPLE_LION) || defined(APPLE_MOUNTAINLION)
 	SCTP_BASE_INFO(sctbinfo).listhead = &SCTP_BASE_INFO(inplisthead);
@@ -6667,7 +6667,7 @@ sctp_pcb_init(void)
 
 
 	/* init the hash table of endpoints */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if defined(__FreeBSD_cc_version) && __FreeBSD_cc_version >= 440000
 	TUNABLE_INT_FETCH("net.inet.sctp.tcbhashsize", &SCTP_BASE_SYSCTL(sctp_hashtblsize));
 	TUNABLE_INT_FETCH("net.inet.sctp.pcbhashsize", &SCTP_BASE_SYSCTL(sctp_pcbtblsize));
@@ -6782,7 +6782,7 @@ sctp_pcb_init(void)
 #endif
 	sctp_startup_iterator();
 
-#if defined(__FreeBSD__) && defined(SCTP_MCORE_INPUT) && defined(SMP)
+#if defined(SCTP_KERNEL_FreeBSD) && defined(SCTP_MCORE_INPUT) && defined(SMP)
 	sctp_startup_mcore_threads();
 #endif
 
@@ -6794,7 +6794,7 @@ sctp_pcb_init(void)
 	 */
 	sctp_init_vrf_list(SCTP_DEFAULT_VRF);
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_cc_version >= 1400000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_cc_version >= 1400000
 	if (ip_register_flow_handler(sctp_netisr_hdlr, IPPROTO_SCTP)) {
 		SCTP_PRINTF("***SCTP- Error can't register netisr handler***\n");
 	}
@@ -6835,14 +6835,14 @@ sctp_pcb_finish(void)
 		return;
 	}
 	SCTP_BASE_VAR(sctp_pcb_initialized) = 0;
-#if !defined(__FreeBSD__)
+#if !defined(SCTP_KERNEL_FreeBSD)
 	/* Notify the iterator to exit. */
 	SCTP_IPI_ITERATOR_WQ_LOCK();
 	sctp_it_ctl.iterator_flags |= SCTP_ITERATOR_MUST_EXIT;
 	sctp_wakeup_iterator();
 	SCTP_IPI_ITERATOR_WQ_UNLOCK();
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if !defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION)
 	in_pcbinfo_detach(&SCTP_BASE_INFO(sctbinfo));
 #endif
@@ -6893,11 +6893,11 @@ sctp_pcb_finish(void)
 	 * The only way FreeBSD reaches here is if we have VRF's
 	 * but we still add the ifdef to make it compile on old versions.
 	 */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 retry:
 #endif
 	SCTP_IPI_ITERATOR_WQ_LOCK();
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	/*
 	 * sctp_iterator_worker() might be working on an it entry without
 	 * holding the lock.  We won't find it on the list either and
@@ -6914,7 +6914,7 @@ retry:
 	}
 #endif
 	TAILQ_FOREACH_SAFE(it, &sctp_it_ctl.iteratorhead, sctp_nxt_itr, nit) {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 		if (it->vn != curvnet) {
 			continue;
 		}
@@ -6926,7 +6926,7 @@ retry:
 		SCTP_FREE(it,SCTP_M_ITER);
 	}
 	SCTP_IPI_ITERATOR_WQ_UNLOCK();
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 	SCTP_ITERATOR_LOCK();
 	if ((sctp_it_ctl.cur_it) &&
 	    (sctp_it_ctl.cur_it->vn == curvnet)) {
@@ -6934,7 +6934,7 @@ retry:
 	}
 	SCTP_ITERATOR_UNLOCK();
 #endif
-#if !defined(__FreeBSD__)
+#if !defined(SCTP_KERNEL_FreeBSD)
 	SCTP_IPI_ITERATOR_WQ_DESTROY();
 	SCTP_ITERATOR_LOCK_DESTROY();
 #endif
@@ -6995,14 +6995,14 @@ retry:
 	}
 
 	/* free the locks and mutexes */
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	SCTP_TIMERQ_LOCK_DESTROY();
 #endif
 #ifdef SCTP_PACKET_LOGGING
 	SCTP_IP_PKTLOG_DESTROY();
 #endif
 	SCTP_IPI_ADDR_DESTROY();
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	SCTP_IPI_COUNT_DESTROY();
 #endif
 	SCTP_STATLOG_DESTROY();
@@ -7010,7 +7010,7 @@ retry:
 
 	SCTP_WQ_ADDR_DESTROY();
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD) || defined(APPLE_LION) || defined(APPLE_MOUNTAINLION)
 	lck_grp_attr_free(SCTP_BASE_INFO(sctbinfo).mtx_grp_attr);
 	lck_grp_free(SCTP_BASE_INFO(sctbinfo).mtx_grp);
@@ -7035,7 +7035,7 @@ retry:
 	if (SCTP_BASE_INFO(sctp_tcpephash) != NULL)
 		SCTP_HASH_FREE(SCTP_BASE_INFO(sctp_tcpephash), SCTP_BASE_INFO(hashtcpmark));
 
-#if defined(__Windows__) || defined(__FreeBSD__) || defined(__Userspace__)
+#if defined(__Windows__) || defined(SCTP_KERNEL_FreeBSD) || defined(__Userspace__)
 	SCTP_ZONE_DESTROY(SCTP_BASE_INFO(ipi_zone_ep));
 	SCTP_ZONE_DESTROY(SCTP_BASE_INFO(ipi_zone_asoc));
 	SCTP_ZONE_DESTROY(SCTP_BASE_INFO(ipi_zone_laddr));
@@ -7046,7 +7046,7 @@ retry:
 	SCTP_ZONE_DESTROY(SCTP_BASE_INFO(ipi_zone_asconf));
 	SCTP_ZONE_DESTROY(SCTP_BASE_INFO(ipi_zone_asconf_ack));
 #endif
-#if defined(__FreeBSD__) && defined(SMP) && defined(SCTP_USE_PERCPU_STAT)
+#if defined(SCTP_KERNEL_FreeBSD) && defined(SMP) && defined(SCTP_USE_PERCPU_STAT)
 	SCTP_FREE(SCTP_BASE_STATS, SCTP_M_MCORE);
 #endif
 }
@@ -8050,7 +8050,7 @@ sctp_drain()
 	 * is LOW on MBUF's and needs help. This is where reneging will
 	 * occur. We really hope this does NOT happen!
 	 */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 	VNET_ITERATOR_DECL(vnet_iter);
 #else
 	struct sctp_inpcb *inp;
@@ -8061,7 +8061,7 @@ sctp_drain()
 		return;
 	}
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 	VNET_LIST_RLOCK_NOSLEEP();
 	VNET_FOREACH(vnet_iter) {
 		CURVNET_SET(vnet_iter);
@@ -8069,7 +8069,7 @@ sctp_drain()
 		struct sctp_tcb *stcb;
 #endif
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 		SCTP_STAT_INCR(sctps_protocol_drain_calls);
 		if (SCTP_BASE_SYSCTL(sctp_do_drain) == 0) {
 #ifdef VIMAGE
@@ -8092,7 +8092,7 @@ sctp_drain()
 			SCTP_INP_RUNLOCK(inp);
 		}
 		SCTP_INP_INFO_RUNLOCK();
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 		CURVNET_RESTORE();
 	}
 	VNET_LIST_RUNLOCK_NOSLEEP();
@@ -8152,7 +8152,7 @@ sctp_initiate_iterator(inp_func inpf,
 	it->asoc_state = asoc_state;
 	it->function_inp_end = inpe;
 	it->no_chunk_output = chunk_output_off;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 	it->vn = curvnet;
 #endif
 	if (s_inp) {

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_pcb.h 359379 2020-03-27 21:48:52Z tuexen $");
 #endif
@@ -149,7 +149,7 @@ struct sctp_tagblock {
 
 
 struct sctp_epinfo {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #ifdef INET
 	struct socket *udp4_tun_socket;
 #endif
@@ -189,7 +189,7 @@ struct sctp_epinfo {
 	struct sctppcbhead listhead;
 	struct sctpladdr addr_wq;
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	struct inpcbhead inplisthead;
 	struct inpcbinfo sctbinfo;
 #endif
@@ -204,7 +204,7 @@ struct sctp_epinfo {
 	sctp_zone_t ipi_zone_asconf;
 	sctp_zone_t ipi_zone_asconf_ack;
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 503000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 503000
 #if __FreeBSD_version <= 602000
 	struct mtx ipi_ep_mtx;
 #else
@@ -224,7 +224,7 @@ struct sctp_epinfo {
 	userland_mutex_t ipi_count_mtx;
 	userland_mutex_t ipi_pktlog_mtx;
 	userland_mutex_t wq_addr_mtx;
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 #ifdef _KERN_LOCKS_H_
 	lck_mtx_t *ipi_addr_mtx;
 	lck_mtx_t *ipi_count_mtx;
@@ -292,7 +292,7 @@ struct sctp_base_info {
 	 * anchor the system must be here.
 	 */
 	struct sctp_epinfo sctppcbinfo;
-#if defined(__FreeBSD__) && defined(SMP) && defined(SCTP_USE_PERCPU_STAT)
+#if defined(SCTP_KERNEL_FreeBSD) && defined(SMP) && defined(SCTP_USE_PERCPU_STAT)
 	struct sctpstat    *sctpstat;
 #else
 	struct sctpstat    sctpstat;
@@ -305,10 +305,10 @@ struct sctp_base_info {
 	int packet_log_end;
 	uint8_t packet_log_buffer[SCTP_PACKET_LOG_SIZE];
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	eventhandler_tag eh_tag;
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	int sctp_main_timer_ticks;
 #endif
 #if defined(__Userspace__)
@@ -457,7 +457,7 @@ struct sctp_inpcb {
 		        ~SCTP_ALIGNM1];
 	}     ip_inp;
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	/* leave some space in case i386 inpcb is bigger than ppc */
 	uint8_t		padding[128];
 #endif
@@ -520,7 +520,7 @@ struct sctp_inpcb {
 #endif
 	struct mbuf *pkt, *pkt_last;
 	struct mbuf *control;
-#if !(defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__))
 #ifndef INP_IPV6
 #define INP_IPV6	0x1
 #endif
@@ -533,7 +533,7 @@ struct sctp_inpcb {
         uint8_t inp_ip_tos;    /* defined as macro in user_inpcb.h */
 	uint8_t inp_ip_resv;
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version >= 503000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 503000
 	struct mtx inp_mtx;
 	struct mtx inp_create_mtx;
 	struct mtx inp_rdata_mtx;
@@ -543,7 +543,7 @@ struct sctp_inpcb {
 	userland_mutex_t inp_create_mtx;
 	userland_mutex_t inp_rdata_mtx;
 	int32_t refcount;
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 #if defined(SCTP_APPLE_RWLOCK)
 	lck_rw_t *inp_mtx;
 #else
@@ -560,7 +560,7 @@ struct sctp_inpcb {
     /* TODO decide on __Userspace__ locks */
 	int32_t refcount;
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	int32_t refcount;
 
 	uint32_t lock_caller1;
@@ -641,13 +641,13 @@ struct sctp_tcb {
 	int freed_from_where;
 	uint16_t rport;		/* remote port in network format */
 	uint16_t resv;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 503000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 503000
 	struct mtx tcb_mtx;
 	struct mtx tcb_send_mtx;
 #elif defined(SCTP_PROCESS_LEVEL_LOCKS)
 	userland_mutex_t tcb_mtx;
 	userland_mutex_t tcb_send_mtx;
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 	lck_mtx_t* tcb_mtx;
 	lck_mtx_t* tcb_send_mtx;
 #elif defined(__Windows__)
@@ -656,7 +656,7 @@ struct sctp_tcb {
 #elif defined(__Userspace__)
     /* TODO decide on __Userspace__ locks */
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	uint32_t caller1;
 	uint32_t caller2;
 	uint32_t caller3;
@@ -664,11 +664,11 @@ struct sctp_tcb {
 };
 
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 503000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 503000
 
 #include <netinet/sctp_lock_bsd.h>
 
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 /*
  * Apple MacOS X 10.4 "Tiger"
  */
@@ -701,7 +701,7 @@ struct sctp_tcb {
  * goes with the base info. sctp_pcb.c has
  * the real definition.
  */
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 VNET_DECLARE(struct sctp_base_info, system_base_info) ;
 #else
 extern struct sctp_base_info system_base_info;
@@ -754,7 +754,7 @@ struct sctp_nets *sctp_findnet(struct sctp_tcb *, struct sockaddr *);
 
 struct sctp_inpcb *sctp_pcb_findep(struct sockaddr *, int, int, uint32_t);
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 int sctp_inpcb_bind(struct socket *, struct sockaddr *,
 		    struct sctp_ifa *,struct thread *);
 #elif defined(__Windows__)
@@ -811,7 +811,7 @@ void sctp_inpcb_free(struct sctp_inpcb *, int, int);
 #define SCTP_DONT_INITIALIZE_AUTH_PARAMS	0
 #define SCTP_INITIALIZE_AUTH_PARAMS		1
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 struct sctp_tcb *
 sctp_aloc_assoc(struct sctp_inpcb *, struct sockaddr *,
                 int *, uint32_t, uint32_t, uint16_t, uint16_t, struct thread *,
@@ -891,7 +891,7 @@ sctp_initiate_iterator(inp_func inpf,
 		       end_func ef,
 		       struct sctp_inpcb *,
 		       uint8_t co_off);
-#if defined(__FreeBSD__) && defined(SCTP_MCORE_INPUT) && defined(SMP)
+#if defined(SCTP_KERNEL_FreeBSD) && defined(SCTP_MCORE_INPUT) && defined(SMP)
 void
 sctp_queue_to_mcore(struct mbuf *m, int off, int cpu_to_use);
 

--- a/usrsctplib/netinet/sctp_peeloff.c
+++ b/usrsctplib/netinet/sctp_peeloff.c
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_peeloff.c 337708 2018-08-13 13:58:45Z tuexen $");
 #endif
@@ -49,7 +49,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_peeloff.c 337708 2018-08-13 13:58:45Z 
 #include <netinet/sctputil.h>
 #include <netinet/sctp_auth.h>
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #define APPLE_FILE_NO 5
 #endif
 
@@ -164,7 +164,7 @@ sctp_do_peeloff(struct socket *head, struct socket *so, sctp_assoc_t assoc_id)
 	atomic_add_int(&stcb->asoc.refcnt, 1);
 	SCTP_TCB_UNLOCK(stcb);
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	sctp_pull_off_control_to_new_inp(inp, n_inp, stcb, SBL_WAIT);
 #else
 	sctp_pull_off_control_to_new_inp(inp, n_inp, stcb, M_WAITOK);
@@ -205,18 +205,18 @@ sctp_get_peeloff(struct socket *head, sctp_assoc_t assoc_id, int *error)
 	}
 	atomic_add_int(&stcb->asoc.refcnt, 1);
 	SCTP_TCB_UNLOCK(stcb);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 	CURVNET_SET(head->so_vnet);
 #endif
 	newso = sonewconn(head, SS_ISCONNECTED
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	    , NULL
 #elif defined(__Panda__)
 	    /* place this socket in the assoc's vrf id */
 	    , NULL, stcb->asoc.vrf_id
 #endif
 		);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 	CURVNET_RESTORE();
 #endif
 	if (newso == NULL) {
@@ -227,7 +227,7 @@ sctp_get_peeloff(struct socket *head, sctp_assoc_t assoc_id, int *error)
 		return (NULL);
 
 	}
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	  else {
 		SCTP_SOCKET_LOCK(newso, 1);
 	}
@@ -288,7 +288,7 @@ sctp_get_peeloff(struct socket *head, sctp_assoc_t assoc_id, int *error)
 	SOCK_UNLOCK(newso);
 	/* We remove it right away */
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__)
 #ifdef SCTP_LOCK_LOGGING
 	if (SCTP_BASE_SYSCTL(sctp_logging_level) & SCTP_LOCK_LOGGING_ENABLE) {
 		sctp_log_lock(inp, (struct sctp_tcb *)NULL, SCTP_LOG_LOCK_SOCK);
@@ -318,7 +318,7 @@ sctp_get_peeloff(struct socket *head, sctp_assoc_t assoc_id, int *error)
 	 * And now the final hack. We move data in the pending side i.e.
 	 * head to the new socket buffer. Let the GRUBBING begin :-0
 	 */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	sctp_pull_off_control_to_new_inp(inp, n_inp, stcb, SBL_WAIT);
 #else
 	sctp_pull_off_control_to_new_inp(inp, n_inp, stcb, M_WAITOK);

--- a/usrsctplib/netinet/sctp_peeloff.h
+++ b/usrsctplib/netinet/sctp_peeloff.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_peeloff.h 309607 2016-12-06 10:21:25Z tuexen $");
 #endif

--- a/usrsctplib/netinet/sctp_sha1.h
+++ b/usrsctplib/netinet/sctp_sha1.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 #endif
@@ -44,14 +44,14 @@ __FBSDID("$FreeBSD$");
 #include <sys/types.h>
 #if defined(SCTP_USE_NSS_SHA1)
 #if defined(__Userspace_os_Darwin)
-/* The NSS sources require __APPLE__ to be defined.
+/* The NSS sources require SCTP_KERNEL_APPLE to be defined.
  * XXX: Remove this ugly hack once the platform defines have been cleaned up.
  */
-#define __APPLE__
+#define SCTP_KERNEL_APPLE
 #endif
 #include <pk11pub.h>
 #if defined(__Userspace_os_Darwin)
-#undef __APPLE__
+#undef SCTP_KERNEL_APPLE
 #endif
 #elif defined(SCTP_USE_OPENSSL_SHA1)
 #include <openssl/sha.h>
@@ -83,7 +83,7 @@ struct sctp_sha1_context {
 #endif
 };
 
-#if (defined(__APPLE__) && defined(KERNEL))
+#if (defined(SCTP_KERNEL_APPLE) && defined(KERNEL))
 #ifndef _KERNEL
 #define _KERNEL
 #endif

--- a/usrsctplib/netinet/sctp_ss_functions.c
+++ b/usrsctplib/netinet/sctp_ss_functions.c
@@ -28,7 +28,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_ss_functions.c 358028 2020-02-17 18:05:03Z tuexen $");
 #endif

--- a/usrsctplib/netinet/sctp_structs.h
+++ b/usrsctplib/netinet/sctp_structs.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_structs.h 359379 2020-03-27 21:48:52Z tuexen $");
 #endif
@@ -55,7 +55,7 @@ struct sctp_timer {
 	void *ep;
 	void *tcb;
 	void *net;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800000
 	void *vnet;
 #endif
 
@@ -113,11 +113,11 @@ typedef void (*asoc_func) (struct sctp_inpcb *, struct sctp_tcb *, void *ptr,
 typedef int (*inp_func) (struct sctp_inpcb *, void *ptr, uint32_t val);
 typedef void (*end_func) (void *ptr, uint32_t val);
 
-#if defined(__FreeBSD__) && defined(SCTP_MCORE_INPUT) && defined(SMP)
+#if defined(SCTP_KERNEL_FreeBSD) && defined(SCTP_MCORE_INPUT) && defined(SMP)
 /* whats on the mcore control struct */
 struct sctp_mcore_queue {
 	TAILQ_ENTRY(sctp_mcore_queue) next;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 	struct vnet *vn;
 #endif
 	struct mbuf *m;
@@ -142,7 +142,7 @@ struct sctp_mcore_ctrl {
 
 struct sctp_iterator {
 	TAILQ_ENTRY(sctp_iterator) sctp_nxt_itr;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 801000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 801000
 	struct vnet *vn;
 #endif
 	struct sctp_timer tmr;
@@ -184,10 +184,10 @@ struct sctp_asconf_iterator {
 };
 
 struct iterator_control {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	struct mtx ipi_iterator_wq_mtx;
 	struct mtx it_mtx;
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 	lck_mtx_t *ipi_iterator_wq_mtx;
 	lck_mtx_t *it_mtx;
 #elif defined(SCTP_PROCESS_LEVEL_LOCKS)
@@ -220,7 +220,7 @@ struct iterator_control {
 	uint32_t iterator_running;
 	uint32_t iterator_flags;
 };
-#if !defined(__FreeBSD__)
+#if !defined(SCTP_KERNEL_FreeBSD)
 #define SCTP_ITERATOR_MUST_EXIT		0x00000001
 #define SCTP_ITERATOR_EXITED		0x00000002
 #endif
@@ -229,7 +229,7 @@ struct iterator_control {
 
 struct sctp_net_route {
 	sctp_rtentry_t *ro_rt;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version < 1100093
 #if __FreeBSD_version >= 800000
 	void *ro_lle;
@@ -249,7 +249,7 @@ struct sctp_net_route {
 	uint16_t	spare;
 #endif
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if !defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION) && !defined(APPLE_ELCAPITAN)
 	struct llentry	*ro_lle;
 #endif
@@ -443,7 +443,7 @@ struct sctp_nets {
 	uint8_t last_hs_used;	/* index into the last HS table entry we used */
 	uint8_t lan_type;
 	uint8_t rto_needed;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	uint32_t flowid;
 	uint8_t flowtype;
 #endif

--- a/usrsctplib/netinet/sctp_sysctl.c
+++ b/usrsctplib/netinet/sctp_sysctl.c
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_sysctl.c 356357 2020-01-04 20:33:12Z tuexen $");
 #endif
@@ -44,15 +44,15 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_sysctl.c 356357 2020-01-04 20:33:12Z t
 #include <netinet/sctp_pcb.h>
 #include <netinet/sctputil.h>
 #include <netinet/sctp_output.h>
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/smp.h>
 #include <sys/sysctl.h>
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #include <netinet/sctp_bsd_addr.h>
 #endif
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 FEATURE(sctp, "Stream Control Transmission Protocol");
 #endif
 
@@ -74,7 +74,7 @@ sctp_init_sysctls()
 	SCTP_BASE_SYSCTL(sctp_reconfig_enable) = SCTPCTL_RECONFIG_ENABLE_DEFAULT;
 	SCTP_BASE_SYSCTL(sctp_nrsack_enable) = SCTPCTL_NRSACK_ENABLE_DEFAULT;
 	SCTP_BASE_SYSCTL(sctp_pktdrop_enable) = SCTPCTL_PKTDROP_ENABLE_DEFAULT;
-#if !(defined(__FreeBSD__) && __FreeBSD_version >= 800000)
+#if !(defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800000)
 	SCTP_BASE_SYSCTL(sctp_no_csum_on_loopback) = SCTPCTL_LOOPBACK_NOCSUM_DEFAULT;
 #endif
 	SCTP_BASE_SYSCTL(sctp_peer_chunk_oh) = SCTPCTL_PEER_CHKOH_DEFAULT;
@@ -165,13 +165,13 @@ sctp_init_sysctls()
 #if defined(SCTP_DEBUG)
 	SCTP_BASE_SYSCTL(sctp_debug_on) = SCTPCTL_DEBUG_DEFAULT;
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	SCTP_BASE_SYSCTL(sctp_ignore_vmware_interfaces) = SCTPCTL_IGNORE_VMWARE_INTERFACES_DEFAULT;
 	SCTP_BASE_SYSCTL(sctp_main_timer) = SCTPCTL_MAIN_TIMER_DEFAULT;
 	SCTP_BASE_SYSCTL(sctp_addr_watchdog_limit) = SCTPCTL_ADDR_WATCHDOG_LIMIT_DEFAULT;
 	SCTP_BASE_SYSCTL(sctp_vtag_watchdog_limit) = SCTPCTL_VTAG_WATCHDOG_LIMIT_DEFAULT;
 #endif
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	SCTP_BASE_SYSCTL(sctp_output_unlocked) = SCTPCTL_OUTPUT_UNLOCKED_DEFAULT;
 #endif
 }
@@ -189,7 +189,7 @@ sctp_finish_sysctls()
 }
 #endif
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_KERNEL_FreeBSD) || defined(__Windows__)
 /* It returns an upper limit. No filtering is done here */
 static unsigned int
 sctp_sysctl_number_of_addresses(struct sctp_inpcb *inp)
@@ -329,7 +329,7 @@ sctp_sysctl_copy_out_local_addresses(struct sctp_inpcb *inp, struct sctp_tcb *st
 						sin = &sctp_ifa->address.sin;
 						if (sin->sin_addr.s_addr == 0)
 							continue;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 						if (prison_check_ip4(inp->ip_inp.inp.inp_cred,
 						                     &sin->sin_addr) != 0) {
 							continue;
@@ -350,7 +350,7 @@ sctp_sysctl_copy_out_local_addresses(struct sctp_inpcb *inp, struct sctp_tcb *st
 						sin6 = &sctp_ifa->address.sin6;
 						if (IN6_IS_ADDR_UNSPECIFIED(&sin6->sin6_addr))
 							continue;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 						if (prison_check_ip6(inp->ip_inp.inp.inp_cred,
 						                     &sin6->sin6_addr) != 0) {
 							continue;
@@ -428,7 +428,7 @@ sctp_sysctl_copy_out_local_addresses(struct sctp_inpcb *inp, struct sctp_tcb *st
 /*
  * sysctl functions
  */
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 static int
 sctp_sysctl_handle_assoclist SYSCTL_HANDLER_ARGS
 {
@@ -458,7 +458,7 @@ sctp_sysctl_handle_assoclist(SYSCTL_HANDLER_ARGS)
 	number_of_remote_addresses = 0;
 
 	SCTP_INP_INFO_RLOCK();
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	if (req->oldptr == USER_ADDR_NULL) {
 #else
 	if (req->oldptr == NULL) {
@@ -490,7 +490,7 @@ sctp_sysctl_handle_assoclist(SYSCTL_HANDLER_ARGS)
 #endif
 		return (0);
 	}
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	if (req->newptr != USER_ADDR_NULL) {
 #else
 	if (req->newptr != NULL) {
@@ -511,7 +511,7 @@ sctp_sysctl_handle_assoclist(SYSCTL_HANDLER_ARGS)
 		xinpcb.last = 0;
 		xinpcb.local_port = ntohs(inp->sctp_lport);
 		xinpcb.flags = inp->sctp_flags;
-#if defined(__FreeBSD__) && __FreeBSD_version < 1000048
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 1000048
 		xinpcb.features = (uint32_t)inp->sctp_features;
 #else
 		xinpcb.features = inp->sctp_features;
@@ -520,7 +520,7 @@ sctp_sysctl_handle_assoclist(SYSCTL_HANDLER_ARGS)
 		xinpcb.total_recvs = inp->total_recvs;
 		xinpcb.total_nospaces = inp->total_nospaces;
 		xinpcb.fragmentation_point = inp->sctp_frag_point;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		xinpcb.socket = (uintptr_t)inp->sctp_socket;
 #else
 		xinpcb.socket = inp->sctp_socket;
@@ -532,12 +532,12 @@ sctp_sysctl_handle_assoclist(SYSCTL_HANDLER_ARGS)
 			xinpcb.qlen = 0;
 			xinpcb.maxqlen = 0;
 		} else {
-#if defined(__FreeBSD__) && __FreeBSD_version >= 1200034
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 1200034
 			xinpcb.qlen = so->sol_qlen;
 #else
 			xinpcb.qlen = so->so_qlen;
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version > 1100096
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 1100096
 #if __FreeBSD_version >= 1200034
 			xinpcb.qlen_old = so->sol_qlen > USHRT_MAX ?
 			    USHRT_MAX : (uint16_t) so->sol_qlen;
@@ -546,12 +546,12 @@ sctp_sysctl_handle_assoclist(SYSCTL_HANDLER_ARGS)
 			    USHRT_MAX : (uint16_t) so->so_qlen;
 #endif
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version >= 1200034
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 1200034
 			xinpcb.maxqlen = so->sol_qlimit;
 #else
 			xinpcb.maxqlen = so->so_qlimit;
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version > 1100096
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 1100096
 #if __FreeBSD_version >= 1200034
 			xinpcb.maxqlen_old = so->sol_qlimit > USHRT_MAX ?
 			    USHRT_MAX : (uint16_t) so->sol_qlimit;
@@ -587,7 +587,7 @@ sctp_sysctl_handle_assoclist(SYSCTL_HANDLER_ARGS)
 				xstcb.primary_addr = stcb->asoc.primary_destination->ro._l_addr;
 			xstcb.heartbeat_interval = stcb->asoc.heart_beat_delay;
 			xstcb.state = (uint32_t)sctp_map_assoc_state(stcb->asoc.state);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version >= 800000
 			/* 7.0 does not support these */
 			xstcb.assoc_id = sctp_get_associd(stcb);
@@ -648,7 +648,7 @@ sctp_sysctl_handle_assoclist(SYSCTL_HANDLER_ARGS)
 				xraddr.cwnd = net->cwnd;
 				xraddr.flight_size = net->flight_size;
 				xraddr.mtu = net->mtu;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version >= 800000
 				xraddr.rtt = net->rtt / 1000;
 				xraddr.heartbeat_interval = net->heart_beat_delay;
@@ -721,7 +721,7 @@ skip:
 	return (error);
 }
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 static int
 sctp_sysctl_handle_udp_tunneling SYSCTL_HANDLER_ARGS
 {
@@ -738,7 +738,7 @@ sctp_sysctl_handle_udp_tunneling(SYSCTL_HANDLER_ARGS)
 	old = SCTP_BASE_SYSCTL(sctp_udp_tunneling_port);
 	SCTP_INP_INFO_RUNLOCK();
 	new = old;
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800056 && __FreeBSD_version < 1000100
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800056 && __FreeBSD_version < 1000100
 #ifdef VIMAGE
 	error = vnet_sysctl_handle_int(oidp, &new, 0, req);
 #else
@@ -748,7 +748,7 @@ sctp_sysctl_handle_udp_tunneling(SYSCTL_HANDLER_ARGS)
 	error = sysctl_handle_int(oidp, &new, 0, req);
 #endif
 	if ((error == 0) &&
-#if defined (__APPLE__)
+#if defined (SCTP_KERNEL_APPLE)
 	    (req->newptr != USER_ADDR_NULL)) {
 #else
 	    (req->newptr != NULL)) {
@@ -781,7 +781,7 @@ sctp_sysctl_handle_udp_tunneling(SYSCTL_HANDLER_ARGS)
 	return (error);
 }
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 int sctp_is_vmware_interface(struct ifnet *);
 
 static int
@@ -814,7 +814,7 @@ sctp_sysctl_handle_vmware_interfaces SYSCTL_HANDLER_ARGS
 }
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 static int
 sctp_sysctl_handle_auth SYSCTL_HANDLER_ARGS
 {
@@ -828,7 +828,7 @@ sctp_sysctl_handle_auth(SYSCTL_HANDLER_ARGS)
 	uint32_t new;
 
 	new = SCTP_BASE_SYSCTL(sctp_auth_enable);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800056 && __FreeBSD_version < 1000100
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800056 && __FreeBSD_version < 1000100
 #ifdef VIMAGE
 	error = vnet_sysctl_handle_int(oidp, &new, 0, req);
 #else
@@ -838,7 +838,7 @@ sctp_sysctl_handle_auth(SYSCTL_HANDLER_ARGS)
 	error = sysctl_handle_int(oidp, &new, 0, req);
 #endif
 	if ((error == 0) &&
-#if defined (__APPLE__)
+#if defined (SCTP_KERNEL_APPLE)
 	    (req->newptr != USER_ADDR_NULL)) {
 #else
 	    (req->newptr != NULL)) {
@@ -859,7 +859,7 @@ sctp_sysctl_handle_auth(SYSCTL_HANDLER_ARGS)
 	return (error);
 }
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 static int
 sctp_sysctl_handle_asconf SYSCTL_HANDLER_ARGS
 {
@@ -873,7 +873,7 @@ sctp_sysctl_handle_asconf(SYSCTL_HANDLER_ARGS)
 	uint32_t new;
 
 	new = SCTP_BASE_SYSCTL(sctp_asconf_enable);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800056 && __FreeBSD_version < 1000100
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800056 && __FreeBSD_version < 1000100
 #ifdef VIMAGE
 	error = vnet_sysctl_handle_int(oidp, &new, 0, req);
 #else
@@ -883,7 +883,7 @@ sctp_sysctl_handle_asconf(SYSCTL_HANDLER_ARGS)
 	error = sysctl_handle_int(oidp, &new, 0, req);
 #endif
 	if ((error == 0) &&
-#if defined (__APPLE__)
+#if defined (SCTP_KERNEL_APPLE)
 	    (req->newptr != USER_ADDR_NULL)) {
 #else
 	    (req->newptr != NULL)) {
@@ -904,7 +904,7 @@ sctp_sysctl_handle_asconf(SYSCTL_HANDLER_ARGS)
 	return (error);
 }
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 static int
 sctp_sysctl_handle_stats SYSCTL_HANDLER_ARGS
 {
@@ -915,7 +915,7 @@ sctp_sysctl_handle_stats(SYSCTL_HANDLER_ARGS)
 {
 #endif
 	int error;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if defined(SMP) && defined(SCTP_USE_PERCPU_STAT)
 	struct sctpstat *sarry;
 	struct sctpstat sb;
@@ -924,7 +924,7 @@ sctp_sysctl_handle_stats(SYSCTL_HANDLER_ARGS)
 	struct sctpstat sb_temp;
 #endif
 
-#if defined (__APPLE__)
+#if defined (SCTP_KERNEL_APPLE)
 	if ((req->newptr != USER_ADDR_NULL) &&
 #else
 	if ((req->newptr != NULL) &&
@@ -932,7 +932,7 @@ sctp_sysctl_handle_stats(SYSCTL_HANDLER_ARGS)
 	    (req->newlen != sizeof(struct sctpstat))) {
 		return (EINVAL);
 	}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	memset(&sb_temp, 0, sizeof(struct sctpstat));
 
 	if (req->newptr != NULL) {
@@ -1089,7 +1089,7 @@ sctp_sysctl_handle_stats(SYSCTL_HANDLER_ARGS)
 }
 
 #if defined(SCTP_LOCAL_TRACE_BUF)
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 static int
 sctp_sysctl_handle_trace_log SYSCTL_HANDLER_ARGS
 {
@@ -1109,7 +1109,7 @@ sctp_sysctl_handle_trace_log(SYSCTL_HANDLER_ARGS)
 	return (error);
 }
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 static int
 sctp_sysctl_handle_trace_log_clear SYSCTL_HANDLER_ARGS
 {
@@ -1138,8 +1138,8 @@ sctp_sysctl_handle_trace_log_clear(SYSCTL_HANDLER_ARGS)
 }
 #endif
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_KERNEL_FreeBSD)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version >= 800056 && __FreeBSD_version < 1000100
 #ifdef VIMAGE
 #define SCTP_UINT_SYSCTL(name, var_name, prefix)			\
@@ -1258,7 +1258,7 @@ SYSCTL_PROC(_net_inet_sctp, OID_AUTO, asconf_enable, CTLFLAG_VNET|CTLTYPE_UINT|C
 SCTP_UINT_SYSCTL(reconfig_enable, sctp_reconfig_enable, SCTPCTL_RECONFIG_ENABLE)
 SCTP_UINT_SYSCTL(nrsack_enable, sctp_nrsack_enable, SCTPCTL_NRSACK_ENABLE)
 SCTP_UINT_SYSCTL(pktdrop_enable, sctp_pktdrop_enable, SCTPCTL_PKTDROP_ENABLE)
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 SCTP_UINT_SYSCTL(loopback_nocsum, sctp_no_csum_on_loopback, SCTPCTL_LOOPBACK_NOCSUM)
 #endif
 SCTP_UINT_SYSCTL(peer_chkoh, sctp_peer_chunk_oh, SCTPCTL_PEER_CHKOH)
@@ -1330,14 +1330,14 @@ SCTP_UINT_SYSCTL(diag_info_code, sctp_diag_info_code, SCTPCTL_DIAG_INFO_CODE)
 #ifdef SCTP_DEBUG
 SCTP_UINT_SYSCTL(debug, sctp_debug_on, SCTPCTL_DEBUG)
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 SCTP_UINT_SYSCTL(main_timer, sctp_main_timer, SCTPCTL_MAIN_TIMER)
 SYSCTL_PROC(_net_inet_sctp, OID_AUTO, ignore_vmware_interfaces, CTLTYPE_UINT|CTLFLAG_RW,
             NULL, 0, sctp_sysctl_handle_vmware_interfaces, "IU", SCTPCTL_IGNORE_VMWARE_INTERFACES_DESC);
 SCTP_UINT_SYSCTL(addr_watchdog_limit, sctp_addr_watchdog_limit, SCTPCTL_ADDR_WATCHDOG_LIMIT)
 SCTP_UINT_SYSCTL(vtag_watchdog_limit, sctp_vtag_watchdog_limit, SCTPCTL_VTAG_WATCHDOG_LIMIT)
 #endif
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 SCTP_UINT_SYSCTL(output_unlocked, sctp_output_unlocked, SCTPCTL_OUTPUT_UNLOCKED)
 #endif
 SYSCTL_PROC(_net_inet_sctp, OID_AUTO, stats, CTLFLAG_VNET|CTLTYPE_STRUCT|CTLFLAG_RW,

--- a/usrsctplib/netinet/sctp_sysctl.h
+++ b/usrsctplib/netinet/sctp_sysctl.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_sysctl.h 356357 2020-01-04 20:33:12Z tuexen $");
 #endif
@@ -56,7 +56,7 @@ struct sctp_sysctl {
 	uint32_t sctp_nrsack_enable;
 	uint32_t sctp_pktdrop_enable;
 	uint32_t sctp_fr_max_burst_default;
-#if !(defined(__FreeBSD__) && __FreeBSD_version >= 800000)
+#if !(defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800000)
 	uint32_t sctp_no_csum_on_loopback;
 #endif
 	uint32_t sctp_peer_chunk_oh;
@@ -129,13 +129,13 @@ struct sctp_sysctl {
 #if defined(SCTP_DEBUG)
 	uint32_t sctp_debug_on;
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	uint32_t sctp_ignore_vmware_interfaces;
 	uint32_t sctp_main_timer;
 	uint32_t sctp_addr_watchdog_limit;
 	uint32_t sctp_vtag_watchdog_limit;
 #endif
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	uint32_t sctp_output_unlocked;
 #endif
 };
@@ -498,7 +498,7 @@ struct sctp_sysctl {
 #define SCTPCTL_UDP_TUNNELING_PORT_DESC		"Set the SCTP/UDP tunneling port"
 #define SCTPCTL_UDP_TUNNELING_PORT_MIN		0
 #define SCTPCTL_UDP_TUNNELING_PORT_MAX		65535
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #define SCTPCTL_UDP_TUNNELING_PORT_DEFAULT	0
 #else
 #define SCTPCTL_UDP_TUNNELING_PORT_DEFAULT	SCTP_OVER_UDP_TUNNELING_PORT
@@ -585,7 +585,7 @@ struct sctp_sysctl {
 #define SCTPCTL_DEBUG_DEFAULT	0
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #define SCTPCTL_MAIN_TIMER_DESC		"Main timer interval in ms"
 #define SCTPCTL_MAIN_TIMER_MIN		1
 #define SCTPCTL_MAIN_TIMER_MAX		0xFFFFFFFF
@@ -597,14 +597,14 @@ struct sctp_sysctl {
 #define SCTPCTL_IGNORE_VMWARE_INTERFACES_DEFAULT	SCTPCTL_IGNORE_VMWARE_INTERFACES_MAX
 #endif
 
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 #define SCTPCTL_OUTPUT_UNLOCKED_DESC	"Unlock socket when sending packets down to IP"
 #define SCTPCTL_OUTPUT_UNLOCKED_MIN	0
 #define SCTPCTL_OUTPUT_UNLOCKED_MAX	1
 #define SCTPCTL_OUTPUT_UNLOCKED_DEFAULT	SCTPCTL_OUTPUT_UNLOCKED_MIN
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #define	SCTPCTL_ADDR_WATCHDOG_LIMIT_DESC	"Address watchdog limit"
 #define	SCTPCTL_ADDR_WATCHDOG_LIMIT_MIN		0
 #define	SCTPCTL_ADDR_WATCHDOG_LIMIT_MAX		0xFFFFFFFF
@@ -617,7 +617,7 @@ struct sctp_sysctl {
 #endif
 
 #if defined(_KERNEL) || defined(__Userspace__)
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Userspace__)
 #if defined(SYSCTL_DECL)
 SYSCTL_DECL(_net_inet_sctp);
 #endif

--- a/usrsctplib/netinet/sctp_timer.c
+++ b/usrsctplib/netinet/sctp_timer.c
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_timer.c 359405 2020-03-28 20:25:45Z tuexen $");
 #endif
@@ -62,7 +62,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_timer.c 359405 2020-03-28 20:25:45Z tu
 #endif
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #define APPLE_FILE_NO 6
 #endif
 
@@ -517,7 +517,7 @@ sctp_mark_all_for_resend(struct sctp_tcb *stcb,
 	}
 	tv.tv_sec = cur_rto / 1000000;
 	tv.tv_usec = cur_rto % 1000000;
-#ifndef __FreeBSD__
+#ifndef SCTP_KERNEL_FreeBSD
 	timersub(&now, &tv, &min_wait);
 #else
 	min_wait = now;
@@ -614,7 +614,7 @@ sctp_mark_all_for_resend(struct sctp_tcb *stcb,
 			}
 			if (stcb->asoc.prsctp_supported && PR_SCTP_TTL_ENABLED(chk->flags)) {
 				/* Is it expired? */
-#ifndef __FreeBSD__
+#ifndef SCTP_KERNEL_FreeBSD
 				if (timercmp(&now, &chk->rec.data.timetodrop, >)) {
 #else
 				if (timevalcmp(&now, &chk->rec.data.timetodrop, >)) {
@@ -1442,7 +1442,7 @@ sctp_heartbeat_timer(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
 
 		if ((net->last_sent_time.tv_sec > 0) ||
 		    (net->last_sent_time.tv_usec > 0)) {
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 			struct timeval diff;
 
 			SCTP_GETTIME_TIMEVAL(&diff);
@@ -1488,7 +1488,7 @@ sctp_pathmtu_timer(struct sctp_inpcb *inp,
 				if (net->ro._l_addr.sa.sa_family == AF_INET6) {
 					struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&net->ro._l_addr;
 					/* KAME hack: embed scopeid */
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD)
 					(void)in6_embedscope(&sin6->sin6_addr, sin6, NULL, NULL);
 #else

--- a/usrsctplib/netinet/sctp_timer.h
+++ b/usrsctplib/netinet/sctp_timer.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_timer.h 359195 2020-03-21 16:12:19Z tuexen $");
 #endif
@@ -92,7 +92,7 @@ void sctp_audit_retranmission_queue(struct sctp_association *);
 
 void sctp_iterator_timer(struct sctp_iterator *it);
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(APPLE_LEOPARD) || defined(APPLE_SNOWLEOPARD) || defined(APPLE_LION) || defined(APPLE_MOUNTAINLION)
 void sctp_slowtimo(void);
 #else

--- a/usrsctplib/netinet/sctp_uio.h
+++ b/usrsctplib/netinet/sctp_uio.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_uio.h 336511 2018-07-19 20:16:33Z tuexen $");
 #endif
@@ -40,7 +40,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_uio.h 336511 2018-07-19 20:16:33Z tuex
 #ifndef _NETINET_SCTP_UIO_H_
 #define _NETINET_SCTP_UIO_H_
 
-#if (defined(__APPLE__) && defined(KERNEL))
+#if (defined(SCTP_KERNEL_APPLE) && defined(KERNEL))
 #ifndef _KERNEL
 #define _KERNEL
 #endif
@@ -110,7 +110,7 @@ struct sctp_event_subscribe {
  * ancillary data structures
  */
 struct sctp_initmsg {
-#if defined(__FreeBSD__) && __FreeBSD_version < 800000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 800000
 	/* This is a bug. Not fixed for ABI compatibility */
 	uint32_t sinit_num_ostreams;
 	uint32_t sinit_max_instreams;
@@ -143,7 +143,7 @@ struct sctp_sndrcvinfo {
 	uint16_t sinfo_stream;
 	uint16_t sinfo_ssn;
 	uint16_t sinfo_flags;
-#if defined(__FreeBSD__) && __FreeBSD_version < 800000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 800000
 	uint16_t sinfo_pr_policy;
 #endif
 	uint32_t sinfo_ppid;
@@ -161,7 +161,7 @@ struct sctp_extrcvinfo {
 	uint16_t sinfo_stream;
 	uint16_t sinfo_ssn;
 	uint16_t sinfo_flags;
-#if defined(__FreeBSD__) && __FreeBSD_version < 800000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 800000
 	uint16_t sinfo_pr_policy;
 #endif
 	uint32_t sinfo_ppid;
@@ -1121,7 +1121,7 @@ struct sctpstat {
 
 #define SCTP_STAT_INCR(_x) SCTP_STAT_INCR_BY(_x,1)
 #define SCTP_STAT_DECR(_x) SCTP_STAT_DECR_BY(_x,1)
-#if defined(__FreeBSD__) && defined(SMP) && defined(SCTP_USE_PERCPU_STAT)
+#if defined(SCTP_KERNEL_FreeBSD) && defined(SMP) && defined(SCTP_USE_PERCPU_STAT)
 #define SCTP_STAT_INCR_BY(_x,_d) (SCTP_BASE_STATS[PCPU_GET(cpuid)]._x += _d)
 #define SCTP_STAT_DECR_BY(_x,_d) (SCTP_BASE_STATS[PCPU_GET(cpuid)]._x -= _d)
 #else
@@ -1150,7 +1150,7 @@ union sctp_sockstore {
 /* And something for us old timers */
 /***********************************/
 
-#ifndef __APPLE__
+#ifndef SCTP_KERNEL_APPLE
 #ifndef __Userspace__
 #ifndef ntohll
 #if defined(__Userspace_os_Linux)
@@ -1183,7 +1183,7 @@ union sctp_sockstore {
 struct xsctp_inpcb {
 	uint32_t last;
 	uint32_t flags;
-#if defined(__FreeBSD__) && __FreeBSD_version < 1000048
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 1000048
 	uint32_t features;
 #else
 	uint64_t features;
@@ -1193,7 +1193,7 @@ struct xsctp_inpcb {
 	uint32_t total_nospaces;
 	uint32_t fragmentation_point;
 	uint16_t local_port;
-#if defined(__FreeBSD__) && __FreeBSD_version > 1100096
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 1100096
 	uint16_t qlen_old;
 	uint16_t maxqlen_old;
 #else
@@ -1201,18 +1201,18 @@ struct xsctp_inpcb {
 	uint16_t maxqlen;
 #endif
 	uint16_t __spare16;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	kvaddr_t socket;
 #else
 	void *socket;
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version > 1100096
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 1100096
 	uint32_t qlen;
 	uint32_t maxqlen;
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version < 1000048
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 1000048
 	uint32_t extra_padding[32]; /* future */
-#elif defined(__FreeBSD__) && (__FreeBSD_version < 1001517)
+#elif defined(SCTP_KERNEL_FreeBSD) && (__FreeBSD_version < 1001517)
 	uint32_t extra_padding[31]; /* future */
 #else
 	uint32_t extra_padding[26]; /* future */
@@ -1245,7 +1245,7 @@ struct xsctp_tcb {
 	uint16_t remote_port;                   /* sctpAssocEntry 4   */
 	struct sctp_timeval start_time;         /* sctpAssocEntry 16  */
 	struct sctp_timeval discontinuity_time; /* sctpAssocEntry 17  */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version >= 800000
 	uint32_t peers_rwnd;
 	sctp_assoc_t assoc_id;                  /* sctpAssocEntry 1   */
@@ -1281,7 +1281,7 @@ struct xsctp_raddr {
 	uint8_t heartbeat_enabled;         /* sctpAssocLocalRemEntry 4   */
 	uint8_t potentially_failed;
 	struct sctp_timeval start_time;    /* sctpAssocLocalRemEntry 8   */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version >= 800000
 	uint32_t rtt;
 	uint32_t heartbeat_interval;
@@ -1334,7 +1334,7 @@ sctp_lower_sosend(struct socket *so,
     int flags,
     struct sctp_sndrcvinfo *srcv
 #if !(defined(__Panda__) || defined(__Userspace__))
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
     ,struct thread *p
 #elif defined(__Windows__)
     , PKTHREAD p
@@ -1365,7 +1365,7 @@ sctp_sorecvmsg(struct socket *so,
 #if !(defined(_KERNEL)) && !(defined(__Userspace__))
 
 __BEGIN_DECLS
-#if defined(__FreeBSD__) && __FreeBSD_version < 902000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 902000
 int	sctp_peeloff __P((int, sctp_assoc_t));
 int	sctp_bindx __P((int, struct sockaddr *, int, int));
 int	sctp_connectx __P((int, const struct sockaddr *, int, sctp_assoc_t *));

--- a/usrsctplib/netinet/sctp_var.h
+++ b/usrsctplib/netinet/sctp_var.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctp_var.h 357708 2020-02-09 22:40:05Z tuexen $");
 #endif
@@ -44,7 +44,7 @@ __FBSDID("$FreeBSD: head/sys/netinet/sctp_var.h 357708 2020-02-09 22:40:05Z tuex
 
 #if defined(_KERNEL) || defined(__Userspace__)
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 extern struct pr_usrreqs sctp_usrreqs;
 #endif
 
@@ -186,7 +186,7 @@ extern struct pr_usrreqs sctp_usrreqs;
 	} \
 }
 
-#if defined(__FreeBSD__) && __FreeBSD_version > 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 500000
 
 #define sctp_free_remote_addr(__net) { \
 	if ((__net)) {  \
@@ -399,14 +399,14 @@ struct sctp_tcb;
 struct sctphdr;
 
 
-#if (defined(__FreeBSD__) && __FreeBSD_version > 690000) || defined(__Windows__) || defined(__Userspace__)
+#if (defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 690000) || defined(__Windows__) || defined(__Userspace__)
 void sctp_close(struct socket *so);
 #else
 int sctp_detach(struct socket *so);
 #endif
 int sctp_disconnect(struct socket *so);
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
-#if defined(__FreeBSD__) && __FreeBSD_version < 902000
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 902000
 void sctp_ctlinput __P((int, struct sockaddr *, void *));
 int sctp_ctloutput __P((struct socket *, struct sockopt *));
 #ifdef INET
@@ -415,7 +415,7 @@ void sctp_input __P((struct mbuf *, int));
 #endif
 void sctp_pathmtu_adjustment __P((struct sctp_tcb *, uint16_t));
 #else
-#if defined(__APPLE__) && !defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION) && !defined(APPLE_ELCAPITAN)
+#if defined(SCTP_KERNEL_APPLE) && !defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION) && !defined(APPLE_ELCAPITAN)
 void sctp_ctlinput(int, struct sockaddr *, void *, struct ifnet * SCTP_UNUSED);
 #else
 void sctp_ctlinput(int, struct sockaddr *, void *);
@@ -423,7 +423,7 @@ void sctp_ctlinput(int, struct sockaddr *, void *);
 int sctp_ctloutput(struct socket *, struct sockopt *);
 #ifdef INET
 void sctp_input_with_port(struct mbuf *, int, uint16_t);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 1100020
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 1100020
 int sctp_input(struct mbuf **, int *, int);
 #else
 void sctp_input(struct mbuf *, int);
@@ -442,7 +442,7 @@ void sctp_input(struct mbuf *,...);
 void *sctp_ctlinput(int, struct sockaddr *, void *);
 int sctp_ctloutput(int, struct socket *, int, int, struct mbuf **);
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version < 902000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 902000
 void sctp_drain __P((void));
 #else
 void sctp_drain(void);
@@ -451,22 +451,22 @@ void sctp_drain(void);
 void sctp_init(uint16_t,
                int (*)(void *addr, void *buffer, size_t length, uint8_t tos, uint8_t set_df),
                void (*)(const char *, ...), int start_threads);
-#elif defined(__FreeBSD__) && __FreeBSD_version < 902000
+#elif defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 902000
 void sctp_init __P((void));
-#elif defined(__APPLE__) && (!defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) &&!defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION))
+#elif defined(SCTP_KERNEL_APPLE) && (!defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) &&!defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION))
 void sctp_init(struct protosw *pp, struct domain *dp);
 #else
 void sctp_init(void);
 void sctp_notify(struct sctp_inpcb *, struct sctp_tcb *, struct sctp_nets *,
     uint8_t, uint8_t, uint16_t, uint32_t);
 #endif
-#if !defined(__FreeBSD__)
+#if !defined(SCTP_KERNEL_FreeBSD)
 void sctp_finish(void);
 #endif
-#if defined(__FreeBSD__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(__Windows__) || defined(__Userspace__)
 int sctp_flush(struct socket *, int);
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version < 902000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 902000
 int sctp_shutdown __P((struct socket *));
 #else
 int sctp_shutdown(struct socket *);
@@ -475,21 +475,21 @@ int sctp_bindx(struct socket *, int, struct sockaddr_storage *,
 	int, int, struct proc *);
 /* can't use sctp_assoc_t here */
 int sctp_peeloff(struct socket *, struct socket *, int, caddr_t, int *);
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 int sctp_ingetaddr(struct socket *, struct sockaddr **);
 #elif defined(__Panda__)
 int sctp_ingetaddr(struct socket *, struct sockaddr *);
 #else
 int sctp_ingetaddr(struct socket *, struct mbuf *);
 #endif
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 int sctp_peeraddr(struct socket *, struct sockaddr **);
 #elif defined(__Panda__)
 int sctp_peeraddr(struct socket *, struct sockaddr *);
 #else
 int sctp_peeraddr(struct socket *, struct mbuf *);
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 #if __FreeBSD_version >= 700000
 int sctp_listen(struct socket *, int, struct thread *);
 #else
@@ -502,7 +502,7 @@ int sctp_listen(struct socket *, int, struct proc *);
 #else
 int sctp_listen(struct socket *, struct proc *);
 #endif
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__)
 int sctp_accept(struct socket *, struct sockaddr **);
 #elif defined(__Panda__)
 int sctp_accept(struct socket *, struct sockaddr *, int *, void *, int *);

--- a/usrsctplib/netinet/sctputil.h
+++ b/usrsctplib/netinet/sctputil.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet/sctputil.h 359405 2020-03-28 20:25:45Z tuexen $");
 #endif
@@ -57,7 +57,7 @@ void sctp_m_freem(struct mbuf *m);
 #define sctp_m_freem m_freem
 #endif
 
-#if defined(SCTP_LOCAL_TRACE_BUF) || defined(__APPLE__)
+#if defined(SCTP_LOCAL_TRACE_BUF) || defined(SCTP_KERNEL_APPLE)
 void
 sctp_log_trace(uint32_t fr, const char *str SCTP_UNUSED, uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e, uint32_t f);
 #endif
@@ -111,7 +111,7 @@ sctp_mtu_size_reset(struct sctp_inpcb *, struct sctp_association *, uint32_t);
 void
 sctp_wakeup_the_read_socket(struct sctp_inpcb *inp, struct sctp_tcb *stcb,
     int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
 );
@@ -131,7 +131,7 @@ sctp_add_to_readq(struct sctp_inpcb *inp,
     int end,
     int inpread_locked,
     int so_locked
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
     );
@@ -163,7 +163,7 @@ struct mbuf *
 sctp_pad_lastmbuf(struct mbuf *, int, struct mbuf *);
 
 void sctp_ulp_notify(uint32_t, struct sctp_tcb *, uint32_t, void *, int
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
     );
@@ -180,7 +180,7 @@ void sctp_stop_timers_for_shutdown(struct sctp_tcb *);
 void sctp_stop_association_timers(struct sctp_tcb *, bool);
 
 void sctp_report_all_outbound(struct sctp_tcb *, uint16_t, int, int
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
     );
@@ -189,7 +189,7 @@ int sctp_expand_mapping_array(struct sctp_association *, uint32_t);
 
 void sctp_abort_notification(struct sctp_tcb *, uint8_t, uint16_t,
 			     struct sctp_abort_chunk *, int
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
     );
@@ -199,7 +199,7 @@ void
 sctp_abort_association(struct sctp_inpcb *, struct sctp_tcb *, struct mbuf *,
                        int, struct sockaddr *, struct sockaddr *,
                        struct sctphdr *, struct mbuf *,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                        uint8_t, uint32_t,
 #endif
                        uint32_t, uint16_t);
@@ -209,7 +209,7 @@ sctp_abort_association(struct sctp_inpcb *, struct sctp_tcb *, struct mbuf *,
 void
 sctp_abort_an_association(struct sctp_inpcb *, struct sctp_tcb *,
     struct mbuf *, int
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
 );
@@ -218,7 +218,7 @@ void sctp_handle_ootb(struct mbuf *, int, int,
                       struct sockaddr *, struct sockaddr *,
                       struct sctphdr *, struct sctp_inpcb *,
                       struct mbuf *,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
                       uint8_t, uint32_t, uint16_t,
 #endif
                       uint32_t, uint16_t);
@@ -280,7 +280,7 @@ void sctp_print_address(struct sockaddr *);
 int
 sctp_release_pr_sctp_chunk(struct sctp_tcb *, struct sctp_tmit_chunk *,
     uint8_t, int
-#if !defined(__APPLE__) && !defined(SCTP_SO_LOCK_TESTING)
+#if !defined(SCTP_KERNEL_APPLE) && !defined(SCTP_SO_LOCK_TESTING)
     SCTP_UNUSED
 #endif
 );
@@ -355,7 +355,7 @@ do { \
 } while (0)
 
 /* functions to start/stop udp tunneling */
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_KERNEL_FreeBSD)
 void sctp_over_udp_stop(void);
 int sctp_over_udp_start(void);
 #endif
@@ -424,7 +424,7 @@ void sctp_audit_log(uint8_t, uint8_t);
 
 #endif
 uint32_t sctp_min_mtu(uint32_t, uint32_t, uint32_t);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 void sctp_hc_set_mtu(union sctp_sockstore *, uint16_t, uint32_t);
 uint32_t sctp_hc_get_mtu(union sctp_sockstore *, uint16_t);
 #endif

--- a/usrsctplib/netinet6/sctp6_usrreq.c
+++ b/usrsctplib/netinet6/sctp6_usrreq.c
@@ -32,14 +32,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet6/sctp6_usrreq.c 358083 2020-02-18 21:25:17Z tuexen $");
 #endif
 
 #include <netinet/sctp_os.h>
 #ifdef INET6
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/proc.h>
 #endif
 #include <netinet/sctp_pcb.h>
@@ -62,7 +62,7 @@ __FBSDID("$FreeBSD: head/sys/netinet6/sctp6_usrreq.c 358083 2020-02-18 21:25:17Z
 #include <netinet/icmp6.h>
 #include <netinet/udp.h>
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #define APPLE_FILE_NO 9
 #endif
 #if defined(__Panda__) || defined(__Userspace__)
@@ -130,7 +130,7 @@ in6_sin_2_v4mapsin6(const struct sockaddr_in *sin, struct sockaddr_in6 *sin6)
 
 #if !defined(__Userspace__)
 int
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_KERNEL_FreeBSD)
 sctp6_input_with_port(struct mbuf **i_pak, int *offp, uint16_t port)
 #elif defined( __Panda__)
 sctp6_input(pakhandle_type *i_pak)
@@ -148,12 +148,12 @@ sctp6_input(struct mbuf **i_pak, int *offp, int proto)
 	struct sctp_chunkhdr *ch;
 	int length, offset;
 	uint8_t compute_crc;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	uint32_t mflowid;
 	uint8_t mflowtype;
 	uint16_t fibnum;
 #endif
-#if !(defined(__APPLE__) || defined (__FreeBSD__))
+#if !(defined(SCTP_KERNEL_APPLE) || defined (SCTP_KERNEL_FreeBSD))
 	uint16_t port = 0;
 #endif
 
@@ -183,7 +183,7 @@ sctp6_input(struct mbuf **i_pak, int *offp, int proto)
 		sctp_packet_log(m);
 	}
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 #if __FreeBSD_version > 1000049
 	SCTPDBG(SCTP_DEBUG_CRCOFFLOAD,
 	        "sctp6_input(): Packet of length %d received on %s with csum_flags 0x%b.\n",
@@ -204,7 +204,7 @@ sctp6_input(struct mbuf **i_pak, int *offp, int proto)
 	        m->m_pkthdr.csum_flags);
 #endif
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 	SCTPDBG(SCTP_DEBUG_CRCOFFLOAD,
 	        "sctp6_input(): Packet of length %d received on %s%d with csum_flags 0x%x.\n",
 	        m->m_pkthdr.len,
@@ -219,7 +219,7 @@ sctp6_input(struct mbuf **i_pak, int *offp, int proto)
 	        m->m_pkthdr.rcvif->if_xname,
 	        m->m_pkthdr.csum_flags);
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	mflowid = m->m_pkthdr.flowid;
 	mflowtype = M_HASHTYPE_GET(m);
 	fibnum = M_GETFIB(m);
@@ -246,8 +246,8 @@ sctp6_input(struct mbuf **i_pak, int *offp, int proto)
 #endif
 	src.sin6_port = sh->src_port;
 	src.sin6_addr = ip6->ip6_src;
-#if defined(__FreeBSD__)
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_FreeBSD)
+#if defined(SCTP_KERNEL_APPLE)
 	/* XXX: This code should also be used on Apple */
 #endif
 	if (in6_setscope(&src.sin6_addr, m->m_pkthdr.rcvif, NULL) != 0) {
@@ -261,15 +261,15 @@ sctp6_input(struct mbuf **i_pak, int *offp, int proto)
 #endif
 	dst.sin6_port = sh->dest_port;
 	dst.sin6_addr = ip6->ip6_dst;
-#if defined(__FreeBSD__)
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_FreeBSD)
+#if defined(SCTP_KERNEL_APPLE)
 	/* XXX: This code should also be used on Apple */
 #endif
 	if (in6_setscope(&dst.sin6_addr, m->m_pkthdr.rcvif, NULL) != 0) {
 		goto out;
 	}
 #endif
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 #if defined(NFAITH) && 0 < NFAITH
 	if (faithprefix(&dst.sin6_addr)) {
 		goto out;
@@ -288,7 +288,7 @@ sctp6_input(struct mbuf **i_pak, int *offp, int proto)
 		goto out;
 	}
 	ecn_bits = ((ntohl(ip6->ip6_flow) >> 20) & 0x000000ff);
-#if defined(__FreeBSD__) && __FreeBSD_version >= 800000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 800000
 	if (m->m_pkthdr.csum_flags & CSUM_SCTP_VALID) {
 		SCTP_STAT_INCR(sctps_recvhwcrc);
 		compute_crc = 0;
@@ -309,7 +309,7 @@ sctp6_input(struct mbuf **i_pak, int *offp, int proto)
 	                             sh, ch,
 	                             compute_crc,
 	                             ecn_bits,
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	                             mflowtype, mflowid, fibnum,
 #endif
 	                             vrf_id, port);
@@ -320,7 +320,7 @@ sctp6_input(struct mbuf **i_pak, int *offp, int proto)
 	return (IPPROTO_DONE);
 }
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 int
 sctp6_input(struct mbuf **i_pak, int *offp)
 {
@@ -328,7 +328,7 @@ sctp6_input(struct mbuf **i_pak, int *offp)
 }
 #endif
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 int
 sctp6_input(struct mbuf **i_pak, int *offp, int proto SCTP_UNUSED)
 {
@@ -344,7 +344,7 @@ sctp6_notify(struct sctp_inpcb *inp,
              uint8_t icmp6_code,
              uint32_t next_mtu)
 {
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 	struct socket *so;
 #endif
 	int timer_stopped;
@@ -370,7 +370,7 @@ sctp6_notify(struct sctp_inpcb *inp,
 		/* Treat it like an ABORT. */
 		if (icmp6_code == ICMP6_PARAMPROB_NEXTHEADER) {
 			sctp_abort_notification(stcb, 1, 0, NULL, SCTP_SO_NOT_LOCKED);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 			so = SCTP_INP_SO(inp);
 			atomic_add_int(&stcb->asoc.refcnt, 1);
 			SCTP_TCB_UNLOCK(stcb);
@@ -380,7 +380,7 @@ sctp6_notify(struct sctp_inpcb *inp,
 #endif
 			(void)sctp_free_assoc(inp, stcb, SCTP_NORMAL_PROC,
 					      SCTP_FROM_SCTP_USRREQ + SCTP_LOC_2);
-#if defined(__APPLE__) || defined(SCTP_SO_LOCK_TESTING)
+#if defined(SCTP_KERNEL_APPLE) || defined(SCTP_SO_LOCK_TESTING)
 			SCTP_SOCKET_UNLOCK(so, 1);
 #endif
 		} else {
@@ -405,7 +405,7 @@ sctp6_notify(struct sctp_inpcb *inp,
 		}
 		if (net->mtu > next_mtu) {
 			net->mtu = next_mtu;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 			if (net->port) {
 				sctp_hc_set_mtu(&net->ro._l_addr, inp->fibnum, next_mtu + sizeof(struct udphdr));
 			} else {
@@ -430,7 +430,7 @@ sctp6_notify(struct sctp_inpcb *inp,
 }
 
 void
-#if defined(__APPLE__) && !defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION) && !defined(APPLE_ELCAPITAN)
+#if defined(SCTP_KERNEL_APPLE) && !defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION) && !defined(APPLE_ELCAPITAN)
 sctp6_ctlinput(int cmd, struct sockaddr *pktdst, void *d, struct ifnet *ifp SCTP_UNUSED)
 #else
 sctp6_ctlinput(int cmd, struct sockaddr *pktdst, void *d)
@@ -497,7 +497,7 @@ sctp6_ctlinput(int cmd, struct sockaddr *pktdst, void *d)
 #endif
 		src.sin6_port = sh.src_port;
 		src.sin6_addr = ip6cp->ip6c_ip6->ip6_src;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		if (in6_setscope(&src.sin6_addr, ip6cp->ip6c_m->m_pkthdr.rcvif, NULL) != 0) {
 			return;
 		}
@@ -509,7 +509,7 @@ sctp6_ctlinput(int cmd, struct sockaddr *pktdst, void *d)
 #endif
 		dst.sin6_port = sh.dest_port;
 		dst.sin6_addr = ip6cp->ip6c_ip6->ip6_dst;
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		if (in6_setscope(&dst.sin6_addr, ip6cp->ip6c_m->m_pkthdr.rcvif, NULL) != 0) {
 			return;
 		}
@@ -534,7 +534,7 @@ sctp6_ctlinput(int cmd, struct sockaddr *pktdst, void *d)
 					return;
 				}
 			} else {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 				if (ip6cp->ip6c_m->m_pkthdr.len >=
 				    ip6cp->ip6c_off + sizeof(struct sctphdr) +
 				                      sizeof(struct sctp_chunkhdr) +
@@ -595,7 +595,7 @@ sctp6_ctlinput(int cmd, struct sockaddr *pktdst, void *d)
 			}
 #endif
 		} else {
-#if defined(__FreeBSD__) && __FreeBSD_version < 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 500000
 			if (PRC_IS_REDIRECT(cmd) && (inp != NULL)) {
 				in6_rtchange(inp, inet6ctlerrmap[cmd]);
 			}
@@ -618,7 +618,7 @@ sctp6_ctlinput(int cmd, struct sockaddr *pktdst, void *d)
  * this routine can probably be collasped into the one in sctp_userreq.c
  * since they do the same thing and now we lookup with a sockaddr
  */
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 static int
 sctp6_getcred(SYSCTL_HANDLER_ARGS)
 {
@@ -630,15 +630,15 @@ sctp6_getcred(SYSCTL_HANDLER_ARGS)
 	int error;
 	uint32_t vrf_id;
 
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE)
 	vrf_id = SCTP_DEFAULT_VRFID;
 #else
 	vrf_id = panda_get_vrf_from_call(); /* from connectx call? */
 #endif
 
-#if defined(__FreeBSD__) && __FreeBSD_version > 602000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 602000
 	error = priv_check(req->td, PRIV_NETINET_GETCRED);
-#elif defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#elif defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 	error = suser(req->td);
 #else
 	error = suser(req->p);
@@ -701,7 +701,7 @@ SYSCTL_PROC(_net_inet6_sctp6, OID_AUTO, getcred, CTLTYPE_OPAQUE | CTLFLAG_RW,
 #endif
 
 /* This is the same as the sctp_abort() could be made common */
-#if (defined(__FreeBSD__) && __FreeBSD_version > 690000) || defined(__Windows__)
+#if (defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 690000) || defined(__Windows__)
 static void
 #elif defined(__Panda__) || defined(__Userspace__)
 int
@@ -710,7 +710,7 @@ static int
 #endif
 sctp6_abort(struct socket *so)
 {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	struct epoch_tracker et;
 #endif
 	struct sctp_inpcb *inp;
@@ -719,13 +719,13 @@ sctp6_abort(struct socket *so)
 	inp = (struct sctp_inpcb *)so->so_pcb;
 	if (inp == NULL) {
 		SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP6_USRREQ, EINVAL);
-#if (defined(__FreeBSD__) && __FreeBSD_version > 690000) || defined(__Windows__)
+#if (defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 690000) || defined(__Windows__)
 		return;
 #else
 		return (EINVAL);
 #endif
 	}
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	NET_EPOCH_ENTER(et);
 #endif
  sctp_must_try_again:
@@ -746,7 +746,7 @@ sctp6_abort(struct socket *so)
 		 * here for the accounting/select.
 		 */
 		SCTP_SB_CLEAR(so->so_rcv);
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 		so->so_usecount--;
 #else
 		/* Now null out the reference, we are completely detached. */
@@ -759,7 +759,7 @@ sctp6_abort(struct socket *so)
 			goto sctp_must_try_again;
 		}
 	}
-#if (defined(__FreeBSD__) && __FreeBSD_version > 690000) || defined(__Windows__)
+#if (defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 690000) || defined(__Windows__)
 	NET_EPOCH_EXIT(et);
 	return;
 #else
@@ -767,7 +767,7 @@ sctp6_abort(struct socket *so)
 #endif
 }
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 static int
 sctp6_attach(struct socket *so, int proto SCTP_UNUSED, struct thread *p SCTP_UNUSED)
 #elif defined(__Panda__) || defined(__Userspace__)
@@ -805,7 +805,7 @@ sctp6_attach(struct socket *so, int proto SCTP_UNUSED, struct proc *p SCTP_UNUSE
 	SCTP_INP_WLOCK(inp);
 	inp->sctp_flags |= SCTP_PCB_FLAGS_BOUND_V6;	/* I'm v6! */
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__)
 	inp->ip_inp.inp.inp_vflag |= INP_IPV6;
 #else
 	inp->inp_vflag |= INP_IPV6;
@@ -826,11 +826,11 @@ sctp6_attach(struct socket *so, int proto SCTP_UNUSED, struct proc *p SCTP_UNUSE
 	return (0);
 }
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 static int
 sctp6_bind(struct socket *so, struct sockaddr *addr, struct thread *p)
 {
-#elif defined(__FreeBSD__) || defined(__APPLE__)
+#elif defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE)
 static int
 sctp6_bind(struct socket *so, struct sockaddr *addr, struct proc *p)
 {
@@ -888,7 +888,7 @@ sctp6_bind(struct socket *so, struct mbuf *nam, struct proc *p)
 		}
 	}
 #endif
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__)
 	vflagsav = inp->ip_inp.inp.inp_vflag;
 	inp->ip_inp.inp.inp_vflag &= ~INP_IPV4;
 	inp->ip_inp.inp.inp_vflag |= INP_IPV6;
@@ -902,7 +902,7 @@ sctp6_bind(struct socket *so, struct mbuf *nam, struct proc *p)
 #ifdef INET
 		case AF_INET:
 			/* binding v4 addr to v6 socket, so reset flags */
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__)
 			inp->ip_inp.inp.inp_vflag |= INP_IPV4;
 			inp->ip_inp.inp.inp_vflag &= ~INP_IPV6;
 #else
@@ -919,7 +919,7 @@ sctp6_bind(struct socket *so, struct mbuf *nam, struct proc *p)
 			sin6_p = (struct sockaddr_in6 *)addr;
 
 			if (IN6_IS_ADDR_UNSPECIFIED(&sin6_p->sin6_addr)) {
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__)
 				inp->ip_inp.inp.inp_vflag |= INP_IPV4;
 #else
 				inp->inp_vflag |= INP_IPV4;
@@ -930,7 +930,7 @@ sctp6_bind(struct socket *so, struct mbuf *nam, struct proc *p)
 				struct sockaddr_in sin;
 
 				in6_sin6_2_sin(&sin, sin6_p);
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__)
 				inp->ip_inp.inp.inp_vflag |= INP_IPV4;
 				inp->ip_inp.inp.inp_vflag &= ~INP_IPV6;
 #else
@@ -972,7 +972,7 @@ sctp6_bind(struct socket *so, struct mbuf *nam, struct proc *p)
 	error = sctp_inpcb_bind(so, addr, NULL, p);
 out:
 	if (error != 0)
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__) || defined(__Userspace__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__) || defined(__Userspace__)
 		inp->ip_inp.inp.inp_vflag = vflagsav;
 #else
 		inp->inp_vflag = vflagsav;
@@ -981,7 +981,7 @@ out:
 }
 
 
-#if (defined(__FreeBSD__) && __FreeBSD_version > 690000) || defined(__Windows__) || defined(__Userspace__)
+#if (defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version > 690000) || defined(__Windows__) || defined(__Userspace__)
 #if !defined(__Userspace__)
 static void
 #else
@@ -1022,7 +1022,7 @@ sctp6_disconnect(struct socket *so)
 
 
 int
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 sctp_sendm(struct socket *so, int flags, struct mbuf *m, struct sockaddr *addr,
     struct mbuf *control, struct thread *p);
 
@@ -1033,12 +1033,12 @@ sctp_sendm(struct socket *so, int flags, struct mbuf *m, struct sockaddr *addr,
 #endif
 
 #if !defined(__Panda__) && !defined(__Windows__) && !defined(__Userspace__)
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 static int
 sctp6_send(struct socket *so, int flags, struct mbuf *m, struct sockaddr *addr,
     struct mbuf *control, struct thread *p)
 {
-#elif defined(__FreeBSD__) || defined(__APPLE__)
+#elif defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE)
 static int
 sctp6_send(struct socket *so, int flags, struct mbuf *m, struct sockaddr *addr,
     struct mbuf *control, struct proc *p)
@@ -1126,7 +1126,7 @@ connected_type:
 		inp->pkt_last = inp->pkt = m;
 	}
 	if (
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE)
 	/* FreeBSD and MacOSX uses a flag passed */
 	    ((flags & PRUS_MORETOCOME) == 0)
 #else
@@ -1141,16 +1141,16 @@ connected_type:
 		 * optionaly switch back to this code (by changing back the
 		 * defininitions but this is not advisable.
 		 */
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 		struct epoch_tracker et;
 #endif
 		int ret;
 
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	NET_EPOCH_ENTER(et);
 #endif
 		ret = sctp_output(inp, inp->pkt, addr, inp->control, p, flags);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	NET_EPOCH_EXIT(et);
 #endif
 		inp->pkt = NULL;
@@ -1162,11 +1162,11 @@ connected_type:
 }
 #endif
 
-#if defined(__FreeBSD__) && __FreeBSD_version >= 500000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version >= 500000
 static int
 sctp6_connect(struct socket *so, struct sockaddr *addr, struct thread *p)
 {
-#elif defined(__FreeBSD__) || defined(__APPLE__)
+#elif defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE)
 static int
 sctp6_connect(struct socket *so, struct sockaddr *addr, struct proc *p)
 {
@@ -1189,7 +1189,7 @@ sctp6_connect(struct socket *so, struct mbuf *nam, struct proc *p)
 {
 	struct sockaddr *addr = mtod(nam, struct sockaddr *);
 #endif
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	struct epoch_tracker et;
 #endif
 	uint32_t vrf_id;
@@ -1332,19 +1332,19 @@ sctp6_connect(struct socket *so, struct mbuf *nam, struct proc *p)
 	}
 	SCTP_SET_STATE(stcb, SCTP_STATE_COOKIE_WAIT);
 	(void)SCTP_GETTIME_TIMEVAL(&stcb->asoc.time_entered);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	NET_EPOCH_ENTER(et);
 #endif
 	sctp_send_initiate(inp, stcb, SCTP_SO_LOCKED);
 	SCTP_TCB_UNLOCK(stcb);
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	NET_EPOCH_EXIT(et);
 #endif
 	return (error);
 }
 
 static int
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 sctp6_getaddr(struct socket *so, struct sockaddr **addr)
 {
 	struct sockaddr_in6 *sin6;
@@ -1368,7 +1368,7 @@ sctp6_getaddr(struct socket *so, struct mbuf *nam)
 	/*
 	 * Do the malloc first in case it blocks.
 	 */
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 	SCTP_MALLOC_SONAME(sin6, struct sockaddr_in6 *, sizeof(*sin6));
 	if (sin6 == NULL)
 		return (ENOMEM);
@@ -1385,7 +1385,7 @@ sctp6_getaddr(struct socket *so, struct mbuf *nam)
 
 	inp = (struct sctp_inpcb *)so->so_pcb;
 	if (inp == NULL) {
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 		SCTP_FREE_SONAME(sin6);
 #endif
 		SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP6_USRREQ, ECONNRESET);
@@ -1403,7 +1403,7 @@ sctp6_getaddr(struct socket *so, struct mbuf *nam)
 			stcb = LIST_FIRST(&inp->sctp_asoc_list);
 			if (stcb == NULL) {
 				SCTP_INP_RUNLOCK(inp);
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 				SCTP_FREE_SONAME(sin6);
 #endif
 				SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP6_USRREQ, ENOENT);
@@ -1425,7 +1425,7 @@ sctp6_getaddr(struct socket *so, struct mbuf *nam)
 			if ((!fnd) || (sin_a6 == NULL)) {
 				/* punt */
 				SCTP_INP_RUNLOCK(inp);
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 				SCTP_FREE_SONAME(sin6);
 #endif
 				SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP6_USRREQ, ENOENT);
@@ -1456,7 +1456,7 @@ sctp6_getaddr(struct socket *so, struct mbuf *nam)
 			}
 		}
 		if (!fnd) {
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 			SCTP_FREE_SONAME(sin6);
 #endif
 			SCTP_INP_RUNLOCK(inp);
@@ -1480,14 +1480,14 @@ sctp6_getaddr(struct socket *so, struct mbuf *nam)
 		sin6->sin6_scope_id = 0;	/* XXX */
 #endif /* SCTP_KAME */
 #endif /* SCTP_EMBEDDED_V6_SCOPE */
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 	(*addr) = (struct sockaddr *)sin6;
 #endif
 	return (0);
 }
 
 static int
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 sctp6_peeraddr(struct socket *so, struct sockaddr **addr)
 {
 	struct sockaddr_in6 *sin6;
@@ -1510,7 +1510,7 @@ sctp6_peeraddr(struct socket *so, struct mbuf *nam)
 #endif
 
 	/* Do the malloc first in case it blocks. */
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 	SCTP_MALLOC_SONAME(sin6, struct sockaddr_in6 *, sizeof *sin6);
 	if (sin6 == NULL)
 		return (ENOMEM);
@@ -1529,7 +1529,7 @@ sctp6_peeraddr(struct socket *so, struct mbuf *nam)
 	if ((inp == NULL) ||
 	    ((inp->sctp_flags & SCTP_PCB_FLAGS_CONNECTED) == 0)) {
 		/* UDP type and listeners will drop out here */
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 		SCTP_FREE_SONAME(sin6);
 #endif
 		SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP6_USRREQ, ENOTCONN);
@@ -1542,7 +1542,7 @@ sctp6_peeraddr(struct socket *so, struct mbuf *nam)
 	}
 	SCTP_INP_RUNLOCK(inp);
 	if (stcb == NULL) {
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 		SCTP_FREE_SONAME(sin6);
 #endif
 		SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP6_USRREQ, ECONNRESET);
@@ -1561,7 +1561,7 @@ sctp6_peeraddr(struct socket *so, struct mbuf *nam)
 	SCTP_TCB_UNLOCK(stcb);
 	if (!fnd) {
 		/* No IPv4 address */
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 		SCTP_FREE_SONAME(sin6);
 #endif
 		SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP6_USRREQ, ENOENT);
@@ -1570,7 +1570,7 @@ sctp6_peeraddr(struct socket *so, struct mbuf *nam)
 #ifdef SCTP_EMBEDDED_V6_SCOPE
 #ifdef SCTP_KAME
 	if ((error = sa6_recoverscope(sin6)) != 0) {
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 		SCTP_FREE_SONAME(sin6);
 #endif
 		SCTP_LTRACE_ERR_RET(inp, NULL, NULL, SCTP_FROM_SCTP6_USRREQ, error);
@@ -1580,13 +1580,13 @@ sctp6_peeraddr(struct socket *so, struct mbuf *nam)
 	in6_recoverscope(sin6, &sin6->sin6_addr, NULL);
 #endif /* SCTP_KAME */
 #endif /* SCTP_EMBEDDED_V6_SCOPE */
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 	*addr = (struct sockaddr *)sin6;
 #endif
 	return (0);
 }
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 static int
 sctp6_in6getaddr(struct socket *so, struct sockaddr **nam)
 {
@@ -1622,7 +1622,7 @@ sctp6_in6getaddr(struct socket *so, struct mbuf *nam)
 	error = sctp6_getaddr(so, nam);
 #ifdef INET
 	if (error) {
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 		struct sockaddr_in6 *sin6;
 #else
 		struct sockaddr_in6 sin6;
@@ -1633,7 +1633,7 @@ sctp6_in6getaddr(struct socket *so, struct mbuf *nam)
 		if (error) {
 			return (error);
 		}
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 		SCTP_MALLOC_SONAME(sin6, struct sockaddr_in6 *, sizeof *sin6);
 		if (sin6 == NULL) {
 			SCTP_FREE_SONAME(*nam);
@@ -1656,7 +1656,7 @@ sctp6_in6getaddr(struct socket *so, struct mbuf *nam)
 }
 
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 static int
 sctp6_getpeeraddr(struct socket *so, struct sockaddr **nam)
 {
@@ -1694,7 +1694,7 @@ sctp6_getpeeraddr(struct socket *so, struct mbuf *nam)
 	error = sctp6_peeraddr(so, nam);
 #ifdef INET
 	if (error) {
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 		struct sockaddr_in6 *sin6;
 #else
 		struct sockaddr_in6 sin6;
@@ -1705,7 +1705,7 @@ sctp6_getpeeraddr(struct socket *so, struct mbuf *nam)
 		if (error) {
 			return (error);
 		}
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 		SCTP_MALLOC_SONAME(sin6, struct sockaddr_in6 *, sizeof *sin6);
 		if (sin6 == NULL) {
 			SCTP_FREE_SONAME(*nam);
@@ -1727,9 +1727,9 @@ sctp6_getpeeraddr(struct socket *so, struct mbuf *nam)
 	return (error);
 }
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE) || defined(__Windows__)
 struct pr_usrreqs sctp6_usrreqs = {
-#if defined(__FreeBSD__)
+#if defined(SCTP_KERNEL_FreeBSD)
 	.pru_abort = sctp6_abort,
 	.pru_accept = sctp_accept,
 	.pru_attach = sctp6_attach,
@@ -1753,7 +1753,7 @@ struct pr_usrreqs sctp6_usrreqs = {
 	.pru_sockaddr = sctp6_in6getaddr,
 	.pru_sosend = sctp_sosend,
 	.pru_soreceive = sctp_soreceive
-#elif defined(__APPLE__)
+#elif defined(SCTP_KERNEL_APPLE)
 	.pru_abort = sctp6_abort,
 	.pru_accept = sctp_accept,
 	.pru_attach = sctp6_attach,

--- a/usrsctplib/netinet6/sctp6_var.h
+++ b/usrsctplib/netinet6/sctp6_var.h
@@ -32,7 +32,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef __FreeBSD__
+#ifdef SCTP_KERNEL_FreeBSD
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD: head/sys/netinet6/sctp6_var.h 317457 2017-04-26 19:26:40Z tuexen $");
 #endif
@@ -49,26 +49,26 @@ extern void in6_sin_2_v4mapsin6(const struct sockaddr_in *, struct sockaddr_in6 
 #endif
 #if defined(_KERNEL)
 
-#if defined(__FreeBSD__) || (__APPLE__) || defined(__Windows__)
+#if defined(SCTP_KERNEL_FreeBSD) || (SCTP_KERNEL_APPLE) || defined(__Windows__)
 SYSCTL_DECL(_net_inet6_sctp6);
 extern struct pr_usrreqs sctp6_usrreqs;
 #else
 int sctp6_usrreq(struct socket *, int, struct mbuf *, struct mbuf *, struct mbuf *);
 #endif
 
-#if defined(__APPLE__)
+#if defined(SCTP_KERNEL_APPLE)
 int sctp6_input(struct mbuf **, int *);
 int sctp6_input_with_port(struct mbuf **, int *, uint16_t);
 #elif defined(__Panda__)
 int sctp6_input (pakhandle_type *);
-#elif defined(__FreeBSD__) && __FreeBSD_version < 902000
+#elif defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 902000
 int sctp6_input __P((struct mbuf **, int *, int));
 int sctp6_input_with_port __P((struct mbuf **, int *, uint16_t));
 #else
 int sctp6_input(struct mbuf **, int *, int);
 int sctp6_input_with_port(struct mbuf **, int *, uint16_t);
 #endif
-#if defined(__FreeBSD__) && __FreeBSD_version < 902000
+#if defined(SCTP_KERNEL_FreeBSD) && __FreeBSD_version < 902000
 int sctp6_output
 __P((struct sctp_inpcb *, struct mbuf *, struct sockaddr *,
      struct mbuf *, struct proc *));
@@ -76,13 +76,13 @@ void sctp6_ctlinput __P((int, struct sockaddr *, void *));
 #else
 int sctp6_output(struct sctp_inpcb *, struct mbuf *, struct sockaddr *,
                  struct mbuf *, struct proc *);
-#if defined(__APPLE__) && !defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION) && !defined(APPLE_ELCAPITAN)
+#if defined(SCTP_KERNEL_APPLE) && !defined(APPLE_LEOPARD) && !defined(APPLE_SNOWLEOPARD) && !defined(APPLE_LION) && !defined(APPLE_MOUNTAINLION) && !defined(APPLE_ELCAPITAN)
 void sctp6_ctlinput(int, struct sockaddr *, void *, struct ifnet * SCTP_UNUSED);
 #else
 void sctp6_ctlinput(int, struct sockaddr *, void *);
 #endif
 #endif
-#if !(defined(__FreeBSD__) || defined(__APPLE__))
+#if !(defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_APPLE))
 extern void in6_sin_2_v4mapsin6(struct sockaddr_in *, struct sockaddr_in6 *);
 extern void in6_sin6_2_sin(struct sockaddr_in *, struct sockaddr_in6 *);
 extern void in6_sin6_2_sin_in_sock(struct sockaddr *);

--- a/usrsctplib/user_mbuf.c
+++ b/usrsctplib/user_mbuf.c
@@ -46,7 +46,7 @@
 #include "user_atomic.h"
 #include "netinet/sctp_pcb.h"
 
-struct mbstat mbstat;
+struct usr_mbstat usr_mbstat;
 #define KIPC_MAX_LINKHDR        4       /* int: max length of link header (see sys/sysclt.h) */
 #define KIPC_MAX_PROTOHDR	5	/* int: max length of network header (see sys/sysclt.h)*/
 int max_linkhdr = KIPC_MAX_LINKHDR;
@@ -542,19 +542,19 @@ mbuf_initialize(void *dummy)
 	 *
 	 */
 
-	mbstat.m_mbufs = 0;
-	mbstat.m_mclusts = 0;
-	mbstat.m_drain = 0;
-	mbstat.m_msize = MSIZE;
-	mbstat.m_mclbytes = MCLBYTES;
-	mbstat.m_minclsize = MINCLSIZE;
-	mbstat.m_mlen = MLEN;
-	mbstat.m_mhlen = MHLEN;
-	mbstat.m_numtypes = MT_NTYPES;
+	usr_mbstat.m_mbufs = 0;
+	usr_mbstat.m_mclusts = 0;
+	usr_mbstat.m_drain = 0;
+	usr_mbstat.m_msize = MSIZE;
+	usr_mbstat.m_mclbytes = MCLBYTES;
+	usr_mbstat.m_minclsize = MINCLSIZE;
+	usr_mbstat.m_mlen = MLEN;
+	usr_mbstat.m_mhlen = MHLEN;
+	usr_mbstat.m_numtypes = MT_NTYPES;
 
-	mbstat.m_mcfail = mbstat.m_mpfail = 0;
-	mbstat.sf_iocnt = 0;
-	mbstat.sf_allocwait = mbstat.sf_allocfail = 0;
+	usr_mbstat.m_mcfail = usr_mbstat.m_mpfail = 0;
+	usr_mbstat.sf_iocnt = 0;
+	usr_mbstat.sf_allocwait = usr_mbstat.sf_allocfail = 0;
 
 }
 
@@ -909,7 +909,7 @@ m_pullup(struct mbuf *n, int len)
 	return (m);
 bad:
 	m_freem(n);
-	mbstat.m_mpfail++;	/* XXX: No consistency. */
+	usr_mbstat.m_mpfail++;	/* XXX: No consistency. */
 	return (NULL);
 }
 
@@ -1199,12 +1199,12 @@ m_copym(struct mbuf *m, int off0, int len, int wait)
 		np = &n->m_next;
 	}
 	if (top == NULL)
-		mbstat.m_mcfail++;	/* XXX: No consistency. */
+		usr_mbstat.m_mcfail++;	/* XXX: No consistency. */
 
 	return (top);
 nospace:
 	m_freem(top);
-	mbstat.m_mcfail++;	/* XXX: No consistency. */
+	usr_mbstat.m_mcfail++;	/* XXX: No consistency. */
 	return (NULL);
 }
 

--- a/usrsctplib/user_mbuf.h
+++ b/usrsctplib/user_mbuf.h
@@ -130,11 +130,11 @@ void		 m_copydata(const struct mbuf *, int, int, caddr_t);
 
 /*
  * General mbuf allocator statistics structure.
- * __Userspace__ mbstat may be useful for gathering statistics.
+ * __Userspace__ usr_mbstat may be useful for gathering statistics.
  * In the kernel many of these statistics are no longer used as
  * they track allocator statistics through kernel UMA's built in statistics mechanism.
  */
-struct mbstat {
+struct usr_mbstat {
 	u_long	m_mbufs;	/* XXX */
 	u_long	m_mclusts;	/* XXX */
 
@@ -352,7 +352,7 @@ void		 m_tag_free_default(struct m_tag *);
 extern int max_linkhdr;    /* Largest link-level header */
 extern int max_protohdr; /* Size of largest protocol layer header. See user_mbuf.c */
 
-extern struct mbstat	mbstat;		/* General mbuf stats/infos */
+extern struct usr_mbstat	usr_mbstat;		/* General mbuf stats/infos */
 
 
 /*

--- a/usrsctplib/user_socketvar.h
+++ b/usrsctplib/user_socketvar.h
@@ -376,7 +376,7 @@ extern userland_cond_t accept_cond;
 /*
  * Externalized form of struct socket used by the sysctl(3) interface.
  */
-struct xsocket {
+struct usr_xsocket {
 	size_t	xso_len;	/* length of this structure */
 	struct	socket *xso_so;	/* makes a convenient handle sometimes */
 	short	so_type;
@@ -678,7 +678,7 @@ int	sosend_generic(struct socket *so, struct sockaddr *addr,
 	    int flags, struct thread *td);
 int	sosetopt(struct socket *so, struct sockopt *sopt);
 int	soshutdown(struct socket *so, int how);
-void	sotoxsocket(struct socket *so, struct xsocket *xso);
+void	sotoxsocket(struct socket *so, struct usr_xsocket *xso);
 void	sowakeup(struct socket *so, struct sockbuf *sb);
 
 #ifdef SOCKBUF_DEBUG

--- a/usrsctplib/user_socketvar.h
+++ b/usrsctplib/user_socketvar.h
@@ -393,7 +393,7 @@ struct usr_xsocket {
 	u_short	so_error;
 	pid_t	so_pgid;
 	u_long	so_oobmark;
-	struct xsockbuf {
+	struct usr_xsockbuf {
 		u_int	sb_cc;
 		u_int	sb_hiwat;
 		u_int	sb_mbcnt;
@@ -616,7 +616,7 @@ int	sbreserve_locked(struct sockbuf *sb, u_long cc, struct socket *so,
 	    struct thread *td);
 struct mbuf *
 	sbsndptr(struct sockbuf *sb, u_int off, u_int len, u_int *moff);
-void	sbtoxsockbuf(struct sockbuf *sb, struct xsockbuf *xsb);
+void	sbtoxsockbuf(struct sockbuf *sb, struct usr_xsockbuf *xsb);
 int	sbwait(struct sockbuf *sb);
 int	sblock(struct sockbuf *sb, int flags);
 void	sbunlock(struct sockbuf *sb);

--- a/usrsctplib/user_socketvar.h
+++ b/usrsctplib/user_socketvar.h
@@ -651,7 +651,7 @@ struct socket *
 int	sooptcopyin(struct sockopt *sopt, void *buf, size_t len, size_t minlen);
 int	sooptcopyout(struct sockopt *sopt, const void *buf, size_t len);
 
-/* XXX; prepare mbuf for (__FreeBSD__ < 3) routines. */
+/* XXX; prepare mbuf for (SCTP_KERNEL_FreeBSD < 3) routines. */
 int	soopt_getm(struct sockopt *sopt, struct mbuf **mp);
 int	soopt_mcopyin(struct sockopt *sopt, struct mbuf *m);
 int	soopt_mcopyout(struct sockopt *sopt, struct mbuf *m);

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -119,8 +119,8 @@ struct sctp_common_header {
 /* The definition of struct sockaddr_conn MUST be in
  * tune with other sockaddr_* structures.
  */
-#if defined(__APPLE__) || defined(__Bitrig__) || defined(__DragonFly__) || \
-    defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(SCTP_KERNEL_APPLE) || defined(__Bitrig__) || defined(SCTP_KERNEL_DragonFly) || \
+    defined(SCTP_KERNEL_FreeBSD) || defined(SCTP_KERNEL_OpenBSD) || defined(SCTP_KERNEL_NetBSD)
 struct sockaddr_conn {
 	uint8_t sconn_len;
 	uint8_t sconn_family;


### PR DESCRIPTION
I've been working on using usrsctp with a swift package and found some incompatibilities with the swift package manager and clang modules:

1. Undeffing `__APPLE__` is not a workable solution because it requires using unsafe compiler flags and therefore breaks the swift package (unsafe swift packages cannot be used as dependencies).  So I've renamed the OS checks which get undeffed to `SCTP_KERNEL_xxx` which now need to be activated if those features are desired, rather than fighting the compiler toolchain by undeffing default definitions. So this addresses #299 

2. Renamed `mbstat`, `xsocket` and `xsockbuf` to `usr_mbstat`, `usr_xsocket` and `usr_xsockbuf` so that they don't conflict with the system definitions of those structs.  This isn't a problem when you aren't using modules, but once you enable modules the build breaks because of this conflict.
