### PR TITLE
Add usrsctp_get_ulpinfo getter.

### DIFF
--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -614,6 +614,7 @@ int register_recv_cb (struct socket *,
                               struct sctp_rcvinfo, int, void *));
 int register_send_cb (struct socket *, uint32_t, int (*)(struct socket *, uint32_t));
 int register_ulp_info (struct socket *, void *);
+int retrieve_ulp_info (struct socket *, void **);
 
 #endif
 struct sctp_tcb {

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -9205,4 +9205,23 @@ register_ulp_info (struct socket *so, void *ulp_info)
 	SCTP_INP_WUNLOCK(inp);
 	return (1);
 }
+
+int
+retrieve_ulp_info (struct socket *so, void **pulp_info)
+{
+	struct sctp_inpcb *inp;
+
+	if (pulp_info == NULL) {
+		return (0);
+	}
+
+	inp = (struct sctp_inpcb *) so->so_pcb;
+	if (inp == NULL) {
+		return (0);
+	}
+	SCTP_INP_RLOCK(inp);
+	*pulp_info = inp->ulp_info;
+	SCTP_INP_RUNLOCK(inp);
+	return (1);
+}
 #endif

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -2583,6 +2583,13 @@ usrsctp_set_ulpinfo(struct socket *so, void *ulp_info)
 	return (register_ulp_info(so, ulp_info));
 }
 
+
+int
+usrsctp_get_ulpinfo(struct socket *so, void **pulp_info)
+{
+	return (retrieve_ulp_info(so, pulp_info));
+}
+
 int
 usrsctp_bindx(struct socket *so, struct sockaddr *addrs, int addrcnt, int flags)
 {

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -1033,6 +1033,9 @@ int
 usrsctp_set_ulpinfo(struct socket *, void *);
 
 int
+usrsctp_get_ulpinfo(struct socket *, void **);
+
+int
 usrsctp_set_upcall(struct socket *so,
                    void (*upcall)(struct socket *, void *, int),
                    void *arg);


### PR DESCRIPTION
Can be used to access `ulp_info` from within `send_cb`.

Fixes #465.