### PR TITLE
Adjust `usrsctp_handle_timers` signature and implementation

### DIFF
--- a/programs/st_client.c
+++ b/programs/st_client.c
@@ -68,9 +68,10 @@ static int connecting = 0;
 static int finish = 0;
 
 static unsigned int
-get_tick_count(void)
+get_milliseconds_count(void)
 {
 #ifdef _WIN32
+	// obtain number of milliseconds since system started
 	return GetTickCount();
 #else
 	struct timeval tv;
@@ -92,9 +93,9 @@ handle_events(int sock, struct socket* s, void* sconn_addr)
 	fd_set rfds;
 	struct timeval tv;
 
-	unsigned next_fire_time = get_tick_count();
+	unsigned next_fire_time = get_milliseconds_count();
 	unsigned last_fire_time = next_fire_time;
-	unsigned now = get_tick_count();
+	unsigned now = get_milliseconds_count();
 	int wait_time;
 
 	while (!finish) {

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -3528,9 +3528,9 @@ usrsctp_conninput(void *addr, const void *buffer, size_t length, uint8_t ecn_bit
 	return;
 }
 
-void usrsctp_handle_timers(uint32_t elapsed_msecs)
+void usrsctp_handle_timers(uint32_t elapsed_milliseconds)
 {
-	sctp_handle_tick(MSEC_TO_TICKS(elapsed_msecs));
+	sctp_handle_tick(MSEC_TO_TICKS(elapsed_milliseconds));
 }
 
 int

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -3528,9 +3528,9 @@ usrsctp_conninput(void *addr, const void *buffer, size_t length, uint8_t ecn_bit
 	return;
 }
 
-void usrsctp_handle_timers(uint32_t delta)
+void usrsctp_handle_timers(uint32_t elapsed_msecs)
 {
-	sctp_handle_tick(delta);
+	sctp_handle_tick(MSEC_TO_TICKS(elapsed_msecs));
 }
 
 int

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -1042,7 +1042,7 @@ usrsctp_get_events(struct socket *so);
 
 
 void
-usrsctp_handle_timers(uint32_t elapsed_msecs);
+usrsctp_handle_timers(uint32_t elapsed_milliseconds);
 
 #define SCTP_DUMP_OUTBOUND 1
 #define SCTP_DUMP_INBOUND  0

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -1042,7 +1042,7 @@ usrsctp_get_events(struct socket *so);
 
 
 void
-usrsctp_handle_timers(uint32_t delta);
+usrsctp_handle_timers(uint32_t elapsed_msecs);
 
 #define SCTP_DUMP_OUTBOUND 1
 #define SCTP_DUMP_INBOUND  0


### PR DESCRIPTION
Currently `usrsctp_handle_timers` passes delta value came from user application as is into `sctp_handle_tick`.
This only work correctly when delta value is measured in ticks.
As long as there is no way (or I can't find one) to figure out how ticks translated to wall clock time there is no way to use of this method pass correct ticks value.
I believe it is correct to allow user to pass elapsed milliseconds, which is converted by library to internal notion of time - ticks.