### PR TITLE
Fixed compilation due usage of non existing macro

### DIFF
--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -3545,7 +3545,7 @@ usrsctp_conninput(void *addr, const void *buffer, size_t length, uint8_t ecn_bit
 
 void usrsctp_handle_timers(uint32_t elapsed_milliseconds)
 {
-	sctp_handle_tick(MSEC_TO_TICKS(elapsed_milliseconds));
+	sctp_handle_tick(sctp_msecs_to_ticks(elapsed_milliseconds));
 }
 
 int


### PR DESCRIPTION
Not sure how that happen, but in #470 I've used macro which no longer exists and it went unnoticed by me.
So, this PR is fixing the issue.