### PR TITLE
Fix compiler warning

### DIFF
--- a/programs/tsctp.c
+++ b/programs/tsctp.c
@@ -654,7 +654,7 @@ int main(int argc, char **argv)
 				}
 #else
 				if (!pthread_create(&tid, NULL, &handle_connection, (void *)conn_sock)) {
-					perror("CreateThread");
+					perror("pthread_create");
 					usrsctp_close(*conn_sock);
 					continue;
 				}

--- a/programs/tsctp.c
+++ b/programs/tsctp.c
@@ -647,9 +647,17 @@ int main(int argc, char **argv)
 					continue;
 				}
 #ifdef _WIN32
-				tid = CreateThread(NULL, 0, &handle_connection, (void *)conn_sock, 0, NULL);
+				if ((tid = CreateThread(NULL, 0, &handle_connection, (void *)conn_sock, 0, NULL)) == NULL) {
+					perror("CreateThread");
+					usrsctp_close(*conn_sock);
+					continue;
+				}
 #else
-				pthread_create(&tid, NULL, &handle_connection, (void *)conn_sock);
+				if (!pthread_create(&tid, NULL, &handle_connection, (void *)conn_sock)) {
+					perror("CreateThread");
+					usrsctp_close(*conn_sock);
+					continue;
+				}
 #endif
 			}
 			if (verbose) {


### PR DESCRIPTION
```
C:\Users\buildbot\bbw-weinrank\windows-7-cmake-MinGW-32\build\programs\tsctp.c: In function 'main':
C:\Users\buildbot\bbw-weinrank\windows-7-cmake-MinGW-32\build\programs\tsctp.c:350:9: error: variable 'tid' set but not used [-Werror=unused-but-set-variable]
  HANDLE tid;
         ^~~
cc1.exe: all warnings being treated as errors
mingw32-make.exe[2]: *** [programs\CMakeFiles\tsctp.dir\build.make:63: programs/CMakeFiles/tsctp.dir/tsctp.c.obj] Error 1
mingw32-make.exe[1]: *** [CMakeFiles\Makefile2:1005: programs/CMakeFiles/tsctp.dir/all] Error 2

```