### PR TITLE
GitHub Actions: switch to Ninja from "Unix Makefiles"

### DIFF
--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -29,6 +29,12 @@ jobs:
       uses: jwlawson/actions-setup-cmake@v1.2
       with:
         github-api-token: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Setup Ninja
+      uses: ashutoshvarma/setup-ninja@master
+      with:
+        # ninja version to download. Default: 1.10.0
+        version: 1.10.0
         
     - name: Prepare dirs
       shell: bash
@@ -48,13 +54,13 @@ jobs:
               -Dsctp_inet=${{ matrix.sctp_inet }} \
               -Dsctp_build_programs=ON \
               -Dsctp_build_fuzzer=OFF \
+              -DCMAKE_GENERATOR=Ninja \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/cmake_install \
               ${GITHUB_WORKSPACE}/usrsctp_source
         
     - name: Build and install project
       shell: bash
       run: |
-        echo "CPU cores: $(nproc)"
         cmake --build cmake_build \
               --parallel $(nproc) \
               --config ${{ matrix.cmake_build_type }} \

--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -54,4 +54,9 @@ jobs:
     - name: Build and install project
       shell: bash
       run: |
-        cmake --build cmake_build --config ${{ matrix.cmake_build_type }} --target install --clean-first
+        echo "CPU cores: $(nproc)"
+        cmake --build cmake_build \
+              --parallel $(nproc) \
+              --config ${{ matrix.cmake_build_type }} \
+              --target install \
+              --clean-first

--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -25,12 +25,6 @@ jobs:
       with:
         path: 'usrsctp_source'
 
-    - name: Setup Ninja
-      uses: ashutoshvarma/setup-ninja@master
-      with:
-        # ninja version to download. Default: 1.10.0
-        version: 1.10.0
- 
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v1.2
       with:
@@ -54,7 +48,6 @@ jobs:
               -Dsctp_inet=${{ matrix.sctp_inet }} \
               -Dsctp_build_programs=ON \
               -Dsctp_build_fuzzer=OFF \
-              -DCMAKE_GENERATOR=Ninja \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/cmake_install \
               ${GITHUB_WORKSPACE}/usrsctp_source
         
@@ -62,7 +55,7 @@ jobs:
       shell: bash
       run: |
         cmake --build cmake_build \
-              --parallel $(nproc) \
+              --parallel $(([ -x "$(command -v nproc)" ] && nproc) || ([ -x "$(command -v sysctl)" ] && sysctl -n hw.ncpu) || $NUMBER_OF_PROCESSORS) \
               --config ${{ matrix.cmake_build_type }} \
               --target install \
               --clean-first

--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -25,6 +25,10 @@ jobs:
       with:
         path: 'usrsctp_source'
 
+    - uses: seanmiddleditch/gha-setup-ninja@v1
+      with:
+        version: '1.10.0'
+
     - name: Setup CMake
       uses: jwlawson/actions-setup-cmake@v1.2
       with:
@@ -48,6 +52,7 @@ jobs:
               -Dsctp_inet=${{ matrix.sctp_inet }} \
               -Dsctp_build_programs=ON \
               -Dsctp_build_fuzzer=OFF \
+              -DCMAKE_GENERATOR=Ninja \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/cmake_install \
               ${GITHUB_WORKSPACE}/usrsctp_source
         
@@ -55,7 +60,6 @@ jobs:
       shell: bash
       run: |
         cmake --build cmake_build \
-              --parallel $(([ -x "$(command -v nproc)" ] && nproc) || ([ -x "$(command -v sysctl)" ] && sysctl -n hw.ncpu) || $NUMBER_OF_PROCESSORS) \
               --config ${{ matrix.cmake_build_type }} \
               --target install \
               --clean-first

--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -24,18 +24,18 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: 'usrsctp_source'
-      
-    - name: Setup CMake
-      uses: jwlawson/actions-setup-cmake@v1.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
-    
+
     - name: Setup Ninja
       uses: ashutoshvarma/setup-ninja@master
       with:
         # ninja version to download. Default: 1.10.0
         version: 1.10.0
-        
+ 
+    - name: Setup CMake
+      uses: jwlawson/actions-setup-cmake@v1.2
+      with:
+        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Prepare dirs
       shell: bash
       run: |


### PR DESCRIPTION
This PR switches from "Unix Makefiles" to "Ninja" to when perform build.
Ninja has an advantage of automatic build parallelization, so builds done by `GitHub Actions` must be faster.