### PR TITLE
tsctp: add parameter to get the current throughput periodically

### DIFF
--- a/programs/tsctp.c
+++ b/programs/tsctp.c
@@ -184,7 +184,7 @@ handle_connection(void *arg)
 	unsigned long long sum = 0;
 	unsigned long round_bytes;
 	struct timeval round_start;
-	time_t round_timeout;
+	time_t round_timeout = 0;
 
 	conn_sock = *(struct socket **)arg;
 

--- a/programs/tsctp.c
+++ b/programs/tsctp.c
@@ -234,9 +234,9 @@ handle_connection(void *arg)
 			}
 		}
 		if (round_duration > 0 && round_timeout <= time(NULL)) {
-			gettimeofday(&now, NULL);
-			timersub(&now, &round_start, &diff_time);
-			seconds = diff_time.tv_sec + (double)diff_time.tv_usec/1000000.0;
+			gettimeofday(&time_now, NULL);
+			timersub(&time_now, &round_start, &time_diff);
+			seconds = time_diff.tv_sec + (double)time_diff.tv_usec/1000000.0;
 			fprintf(stdout, "throughput for the last %f seconds: %f B/s\n", seconds, (double)round_bytes / seconds);
 
 			round_bytes = 0;

--- a/programs/tsctp.c
+++ b/programs/tsctp.c
@@ -117,7 +117,6 @@ char Usage[] =
 "        -l             message length\n"
 "        -L             bind to local IP (default INADDR_ANY)\n"
 "        -n             number of messages sent (0 means infinite)/received\n"
-"        -D             turns Nagle off\n"
 "        -p             port number\n"
 "        -P             partial reliability policy to use (0=none (default), 1=ttl, 2=rtx, 3=buf)\n"
 "        -R             socket recv buffer\n"


### PR DESCRIPTION
Adds the parameter -d to be able to specify an update time x. If specified, the receiver prints every x seconds the throughput of the last x seconds.