### PR TITLE
GitHub actions: CMake is preinstalled. CPU count is fixed.

### DIFF
--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -25,10 +25,6 @@ jobs:
       with:
         path: 'usrsctp_source'
 
-    - uses: seanmiddleditch/gha-setup-ninja@v1
-      with:
-        version: '1.10.0'
-
     - name: Prepare dirs
       shell: bash
       run: |
@@ -47,7 +43,6 @@ jobs:
               -Dsctp_inet=${{ matrix.sctp_inet }} \
               -Dsctp_build_programs=ON \
               -Dsctp_build_fuzzer=OFF \
-              -DCMAKE_GENERATOR=Ninja \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/cmake_install \
               ${GITHUB_WORKSPACE}/usrsctp_source
         
@@ -55,6 +50,7 @@ jobs:
       shell: bash
       run: |
         cmake --build cmake_build \
+              --parallel 2 \
               --config ${{ matrix.cmake_build_type }} \
               --target install \
               --clean-first

--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -29,11 +29,6 @@ jobs:
       with:
         version: '1.10.0'
 
-    - name: Setup CMake
-      uses: jwlawson/actions-setup-cmake@v1.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Prepare dirs
       shell: bash
       run: |


### PR DESCRIPTION
I've observed problems with existing `GitHub Actions` configuration I've proposed.
1. Sometimes `CMake` installation failed with `API limit error`. It is occurred that `GitHub Actions` runners has pre-installed `CMake` which could be used.
2. Sometimes (in my fork) I've observed `Ninja` installation failure. As long as I've added ninja to get automatic parallelization I believe that can be traded off by using default generator with `CMake` switch `--parallel` with hard coded number of `CPU`s, which is `2` for `GH Actions` runners. 

These changes should improve stability of the build. An maybe duration of builds will be reduced, because now additional SW is installed on runners.