### PR TITLE
Add #error if HAVE_SCONN_LEN is not defined.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,10 +126,13 @@ endif ()
 
 set(CMAKE_REQUIRED_INCLUDES "${CMAKE_CURRENT_SOURCE_DIR}/usrsctplib")
 
+# Needed to avoid #error when including usrsctp.h.
+set(CMAKE_REQUIRED_DEFINITIONS -DHAVE_SCONN_LEN)
 check_include_file(usrsctp.h have_usrsctp_h)
 if (NOT have_usrsctp_h)
 	message(FATAL_ERROR "usrsctp.h not found")
 endif ()
+unset(CMAKE_REQUIRED_DEFINITIONS)
 
 check_struct_has_member("struct sockaddr" "sa_len" "sys/types.h;sys/socket.h" have_sa_len)
 if (have_sa_len)
@@ -149,12 +152,14 @@ if (have_sin6_len)
 	add_definitions(-DHAVE_SIN6_LEN)
 endif ()
 
+# Needed to avoid #error when including usrsctp.h.
+set(CMAKE_REQUIRED_DEFINITIONS -DHAVE_SCONN_LEN)
 check_struct_has_member("struct sockaddr_conn" "sconn_len" "usrsctp.h" have_sconn_len)
 if (have_sconn_len)
 	message(STATUS "HAVE_SCONN_LEN")
 	add_definitions(-DHAVE_SCONN_LEN)
 endif ()
-
+unset(CMAKE_REQUIRED_DEFINITIONS)
 
 #################################################
 # COMPILER SETTINGS

--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,8 @@ AC_CHECK_MEMBER(struct sockaddr_in6.sin6_len,
 
 AC_CHECK_MEMBER(struct sockaddr_conn.sconn_len,
                 AC_DEFINE(HAVE_SCONN_LEN, 1, [Define this if your userland stack has sconn_len in sockaddr_conn struct.]),,
-                [#include "usrsctplib/usrsctp.h"])
+                [#define HAVE_SCONN_LEN // Needed to #avoid error when including usrsctp.h.
+                 #include "usrsctplib/usrsctp.h"])
 
 AC_MSG_CHECKING(for socklen_t)
 AC_TRY_COMPILE([#ifdef HAVE_SYS_TYPES_H

--- a/meson.build
+++ b/meson.build
@@ -137,7 +137,11 @@ have_sin6_len = compiler.has_member('struct sockaddr_in6', 'sin6_len', prefix: p
 if have_sin6_len
     add_project_arguments('-DHAVE_SIN6_LEN', language: 'c')
 endif
-have_sconn_len = compiler.has_member('struct sockaddr_conn', 'sconn_len', prefix: '#include "usrsctp.h"', include_directories: include_directories('usrsctplib'))
+prefix = '''
+#define HAVE_SCONN_LEN // Needed to avoid #error when including usrsctp.h.
+#include "usrsctp.h"
+'''
+have_sconn_len = compiler.has_member('struct sockaddr_conn', 'sconn_len', prefix: prefix, include_directories: include_directories('usrsctplib'))
 if have_sconn_len
     add_project_arguments('-DHAVE_SCONN_LEN', language: 'c')
 endif

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -121,6 +121,9 @@ struct sctp_common_header {
  */
 #if defined(__APPLE__) || defined(__Bitrig__) || defined(__DragonFly__) || \
     defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#ifndef HAVE_SCONN_LEN
+#error "HAVE_SCONN_LEN not defined!"
+#endif
 struct sockaddr_conn {
 	uint8_t sconn_len;
 	uint8_t sconn_family;


### PR DESCRIPTION
Recently we realized that WebRTC was using HAVE_SCONN_LEN to detect whether it needed to set the length field, as all the example programs do, but it wasn't actually being defined by our build configuration: https://bugs.chromium.org/p/webrtc/issues/detail?id=10322

This PR adds an error if "usrsctp.h" is included without HAVE_SCONN_LEN being defined in order to catch the problem easier.

I also needed to update the build files since this creates a chicken and egg problem where the error prevents the dynamic detection from working.

Is it expected that all programs including "usrsctp.h" define HAVE_SCONN_LEN, or is that just a convention? Would it make more sense to have usrsctp.h define HAVE_SCONN_LEN itself?