### PR TITLE
Fix gcc/clang type mismatch warnings on Windows

### DIFF
--- a/programs/client_upcall.c
+++ b/programs/client_upcall.c
@@ -72,7 +72,7 @@ int inputAvailable(void)
 	tv.tv_usec = 0;
 	FD_ZERO(&fds);
 #if defined(_WIN32) && !defined(__MINGW32__)
-	FD_SET(_fileno(stdin), &fds);
+	FD_SET((SOCKET)_fileno(stdin), &fds);
   	select(_fileno(stdin) + 1, &fds, NULL, NULL, &tv);
 #else
 	FD_SET(STDIN_FILENO, &fds);

--- a/programs/discard_server.c
+++ b/programs/discard_server.c
@@ -107,7 +107,7 @@ receive_cb(struct socket *sock, union sctp_sockstore addr, void *data,
 			       rcv.rcv_sid,
 			       rcv.rcv_ssn,
 			       rcv.rcv_tsn,
-			       ntohl(rcv.rcv_ppid),
+			       (uint32_t)ntohl(rcv.rcv_ppid),
 			       rcv.rcv_context);
 		}
 		free(data);
@@ -221,7 +221,7 @@ main(int argc, char *argv[])
 						        rcv_info.rcv_sid,
 						        rcv_info.rcv_ssn,
 						        rcv_info.rcv_tsn,
-						        ntohl(rcv_info.rcv_ppid),
+						        (uint32_t)ntohl(rcv_info.rcv_ppid),
 						        rcv_info.rcv_context,
 						        (flags & MSG_EOR) ? 1 : 0);
 					} else {

--- a/programs/discard_server_upcall.c
+++ b/programs/discard_server_upcall.c
@@ -128,7 +128,7 @@ handle_upcall(struct socket *sock, void *data, int flgs)
 				       rn.recvv_rcvinfo.rcv_sid,
 				       rn.recvv_rcvinfo.rcv_ssn,
 				       rn.recvv_rcvinfo.rcv_tsn,
-				       ntohl(rn.recvv_rcvinfo.rcv_ppid),
+				       (uint32_t)ntohl(rn.recvv_rcvinfo.rcv_ppid),
 				       rn.recvv_rcvinfo.rcv_context);
 			}
 		}

--- a/programs/echo_server.c
+++ b/programs/echo_server.c
@@ -107,7 +107,7 @@ receive_cb(struct socket *sock, union sctp_sockstore addr, void *data,
 			       rcv.rcv_sid,
 			       rcv.rcv_ssn,
 			       rcv.rcv_tsn,
-			       ntohl(rcv.rcv_ppid),
+			       (uint32_t)ntohl(rcv.rcv_ppid),
 			       rcv.rcv_context);
 			if (flags & MSG_EOR) {
 				struct sctp_sndinfo snd_info;
@@ -236,7 +236,7 @@ main(int argc, char *argv[])
 						        rcv_info.rcv_sid,
 						        rcv_info.rcv_ssn,
 						        rcv_info.rcv_tsn,
-						        ntohl(rcv_info.rcv_ppid),
+						        (uint32_t)ntohl(rcv_info.rcv_ppid),
 						        rcv_info.rcv_context,
 						        (flags & MSG_EOR) ? 1 : 0);
 						if (flags & MSG_EOR) {

--- a/programs/echo_server_upcall.c
+++ b/programs/echo_server_upcall.c
@@ -130,7 +130,7 @@ handle_upcall(struct socket *sock, void *data, int flgs)
 				       rn.recvv_rcvinfo.rcv_sid,
 				       rn.recvv_rcvinfo.rcv_ssn,
 				       rn.recvv_rcvinfo.rcv_tsn,
-				       ntohl(rn.recvv_rcvinfo.rcv_ppid),
+				       (uint32_t)ntohl(rn.recvv_rcvinfo.rcv_ppid),
 				       rn.recvv_rcvinfo.rcv_context);
 				if (flags & MSG_EOR) {
 					struct sctp_sndinfo snd_info;

--- a/programs/ekr_client.c
+++ b/programs/ekr_client.c
@@ -142,7 +142,7 @@ receive_cb(struct socket *sock, union sctp_sockstore addr, void *data,
 			       rcv.rcv_sid,
 			       rcv.rcv_ssn,
 			       rcv.rcv_tsn,
-			       ntohl(rcv.rcv_ppid),
+			       (uint32_t)ntohl(rcv.rcv_ppid),
 			       rcv.rcv_context);
 		}
 		free(data);
@@ -248,7 +248,7 @@ main(int argc, char *argv[])
 	usrsctp_register_address((void *)&fd);
 #ifdef _WIN32
 	if ((tid = CreateThread(NULL, 0, &handle_packets, (void *)&fd, 0, NULL)) == NULL) {
-		fprintf(stderr, "CreateThread() failed with error: %d\n", GetLastError());
+		fprintf(stderr, "CreateThread() failed with error: %lu\n", GetLastError());
 		exit(EXIT_FAILURE);
 	}
 #else

--- a/programs/ekr_peer.c
+++ b/programs/ekr_peer.c
@@ -132,7 +132,7 @@ receive_cb(struct socket *sock, union sctp_sockstore addr, void *data,
 			       rcv.rcv_sid,
 			       rcv.rcv_ssn,
 			       rcv.rcv_tsn,
-			       ntohl(rcv.rcv_ppid),
+			       (uint32_t)ntohl(rcv.rcv_ppid),
 			       rcv.rcv_context);
 		}
 		free(data);
@@ -238,7 +238,7 @@ main(int argc, char *argv[])
 #endif
 #ifdef _WIN32
 	if ((tid = CreateThread(NULL, 0, &handle_packets, (void *)&fd, 0, NULL)) == NULL) {
-		fprintf(stderr, "CreateThread() failed with error: %d\n", GetLastError());
+		fprintf(stderr, "CreateThread() failed with error: %lu\n", GetLastError());
 		exit(EXIT_FAILURE);
 	}
 #else

--- a/programs/ekr_server.c
+++ b/programs/ekr_server.c
@@ -143,7 +143,7 @@ receive_cb(struct socket *s, union sctp_sockstore addr, void *data,
 			       rcv.rcv_sid,
 			       rcv.rcv_ssn,
 			       rcv.rcv_tsn,
-			       ntohl(rcv.rcv_ppid),
+			       (uint32_t)ntohl(rcv.rcv_ppid),
 			       rcv.rcv_context);
 		}
 		free(data);
@@ -246,7 +246,7 @@ main(int argc, char *argv[])
 	usrsctp_register_address((void *)&fd);
 #ifdef _WIN32
 	if ((tid = CreateThread(NULL, 0, &handle_packets, (void *)&fd, 0, NULL)) == NULL) {
-		fprintf(stderr, "CreateThread() failed with error: %d\n", GetLastError());
+		fprintf(stderr, "CreateThread() failed with error: %lu\n", GetLastError());
 		exit(EXIT_FAILURE);
 	}
 #else

--- a/programs/programs_helper.c
+++ b/programs/programs_helper.c
@@ -325,7 +325,7 @@ handle_send_failed_event(struct sctp_send_failed_event *ssfe)
 		fprintf(debug_target, "(flags = %x) ", ssfe->ssfe_flags);
 	}
 	fprintf(debug_target, "message with PPID = %u, SID = %u, flags: 0x%04x due to error = 0x%08x",
-	       ntohl(ssfe->ssfe_info.snd_ppid), ssfe->ssfe_info.snd_sid,
+	       (uint32_t)ntohl(ssfe->ssfe_info.snd_ppid), ssfe->ssfe_info.snd_sid,
 	       ssfe->ssfe_info.snd_flags, ssfe->ssfe_error);
 	n = ssfe->ssfe_length - sizeof(struct sctp_send_failed_event);
 	for (i = 0; i < n; i++) {

--- a/programs/rtcweb.c
+++ b/programs/rtcweb.c
@@ -1125,7 +1125,7 @@ handle_send_failed_event(struct sctp_send_failed_event *ssfe)
 		printf("(flags = %x) ", ssfe->ssfe_flags);
 	}
 	printf("message with PPID = %u, SID = %u, flags: 0x%04x due to error = 0x%08x",
-	       ntohl(ssfe->ssfe_info.snd_ppid), ssfe->ssfe_info.snd_sid,
+	       (uint32_t)ntohl(ssfe->ssfe_info.snd_ppid), ssfe->ssfe_info.snd_sid,
 	       ssfe->ssfe_info.snd_flags, ssfe->ssfe_error);
 	n = ssfe->ssfe_length - sizeof(struct sctp_send_failed_event);
 	for (i = 0; i < n; i++) {

--- a/programs/st_client.c
+++ b/programs/st_client.c
@@ -84,7 +84,11 @@ get_milliseconds_count(void)
 }
 
 static void
+#ifdef _WIN32
+handle_events(SOCKET sock, struct socket* s, void* sconn_addr)
+#else
 handle_events(int sock, struct socket* s, void* sconn_addr)
+#endif
 {
 	char *dump_buf;
 	ssize_t length;
@@ -190,7 +194,7 @@ on_socket_readable(struct socket* s) {
 			       rcv_info.rcv_sid,
 			       rcv_info.rcv_ssn,
 			       rcv_info.rcv_tsn,
-			       ntohl(rcv_info.rcv_ppid),
+			       (uint32_t)ntohl(rcv_info.rcv_ppid),
 			       rcv_info.rcv_context);
 		}
 	}

--- a/programs/tsctp.c
+++ b/programs/tsctp.c
@@ -760,7 +760,7 @@ int main(int argc, char **argv)
 				}
 #ifdef _WIN32
 				if ((tid = CreateThread(NULL, 0, &handle_connection, (void *)conn_sock, 0, NULL)) == NULL) {
-					fprintf(stderr, "CreateThread() failed with error: %d\n", GetLastError());
+					fprintf(stderr, "CreateThread() failed with error: %lu\n", GetLastError());
 #else
 				if ((rc = pthread_create(&tid, NULL, &handle_connection, (void *)conn_sock)) != 0) {
 					fprintf(stderr, "pthread_create: %s\n", strerror(rc));


### PR DESCRIPTION
On Windows, `ntohl` returns an `unsigned long` instead of `uint32_t`, so it expects a "%lu" print format specifier instead of "%u". Fixed by casting to `uint32_t`.