### PR TITLE
Avoid duplicate definition of _CRT_RAND_S.

### DIFF
--- a/usrsctplib/user_environment.c
+++ b/usrsctplib/user_environment.c
@@ -30,7 +30,7 @@
 
 /* __Userspace__ */
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(_CRT_RAND_S)
 #define _CRT_RAND_S
 #endif
 #include <stdlib.h>


### PR DESCRIPTION
Our build system already defines _CRT_RAND_S, so this was resulting in -Wbuiltin-macro-redefined.

If you prefer, I can define _CRT_RAND_S through the usrsctp build files; this was just a lot easier.