### PR TITLE
Add new method to init the stack with threads but no UDP encapsulation

### DIFF
--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -138,7 +138,7 @@ sctp_init(void)
 	SCTP_BASE_VAR(timer_thread_started) = 0;
 #endif
 #if defined(__Userspace__)
-	sctp_pcb_init(start_threads);
+	sctp_pcb_init(start_threads == 1);
 	if (start_threads) {
 		sctp_start_timer_thread();
 	}

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -114,6 +114,16 @@ usrsctp_init(uint16_t port,
 
 
 void
+usrsctp_init_noudpthread(uint16_t port,
+		       int (*conn_output)(void *addr, void *buffer, size_t length, uint8_t tos, uint8_t set_df),
+		       void (*debug_printf)(const char *format, ...))
+{
+	init_sync();
+	sctp_init(port, conn_output, debug_printf, 2);
+}
+
+
+void
 usrsctp_init_nothreads(uint16_t port,
 		       int (*conn_output)(void *addr, void *buffer, size_t length, uint8_t tos, uint8_t set_df),
 		       void (*debug_printf)(const char *format, ...))

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -896,6 +896,11 @@ usrsctp_init(uint16_t,
              void (*)(const char *format, ...));
 
 void
+usrsctp_init_noudpthread(uint16_t,
+		       int (*)(void *addr, void *buffer, size_t length, uint8_t tos, uint8_t set_df),
+		       void (*)(const char *format, ...));
+
+void
 usrsctp_init_nothreads(uint16_t,
 		       int (*)(void *addr, void *buffer, size_t length, uint8_t tos, uint8_t set_df),
 		       void (*)(const char *format, ...));


### PR DESCRIPTION
Hi all,

I recently found out that when the stack is initialized with `usrsctp_init`, a dedicated thread for SCTP over UDP encapsulation is started too, which binds to ports on both IPv4 and IPv6. In my case ports are random because I'm passing `0` to the init method. Since I'm using usrsctp as a stack in a WebRTC server, I don't need that encapsulation: I'm actually wondering if it might be "dangerous" to have in the first place, as I'm not sure what happens in my code if someone starts sending SCTP messages to those ports via UDP (possibly a risk of highjacking existing associations?).

Looking at the code, apparently the only way to prevent those sockets from being created is calling `usrsctp_init_nothreads`, that stops `recv_thread_init` from being called (which is where those sockets are created and managed). This also forces us to handle the usrsctp stack in our own event loop, which increases the complexity on our end. As such, I prepared this simple PR that adds a new init method, called `usrsctp_init_noudpthread`, that still allows the stack to create threads, but prevents `recv_thread_init` from being called.

This seems to do the trick, even though I'm not sure this is the right way to integrate it in the existing codebase. In fact, I'm "abusing" the `start_threads` argument passed to the internal `sctp_init` for my purposes. In the existing code:

* `usrsctp_init` passes `start_threads=1`
* `usrsctp_init_nothreads` passes `start_threads=0`

My PR adds code so that all the above still is true, and

* `usrsctp_init_noudpthread` passes `start_threads=2`

This means that all checks that do something like `if(start_threads)` still resolve to `TRUE` as they should. To make sure the UDP encapsulation code is not started, I modified one of those checks to an explicit `start_threads == 1` instead, so that it doesn't kick in if I pass `2`. More precisely:

    sctp_pcb_init(start_threads == 1);

As `sctp_pcb_init` is what invokes `recv_thread_init` if the `start_threads` it is aware of is not `0`.

Please let me know if that makes sense and is acceptable as it is, or if it can have implications on other areas of the code. I still think we need a way to allow stacks not to create that UDP encapsulation stuff, as I believe it might be a vector of attacks in unsuspecting applications.

Thanks!