### PR TITLE
Call getrandom via syscall directly on Linux.

### DIFF
--- a/usrsctplib/user_environment.c
+++ b/usrsctplib/user_environment.c
@@ -206,7 +206,8 @@ finish_random(void)
 }
 #endif
 #elif defined(__linux__)
-#include <sys/random.h>
+#include <unistd.h>
+#include <sys/syscall.h>
 
 void
 init_random(void)
@@ -222,7 +223,8 @@ read_random(void *buf, size_t size)
 
 	position = 0;
 	while (position < size) {
-		n = getrandom((char *)buf + position, size - position, 0);
+    // Using syscall directly because getrandom isn't present in glibc < 2.25.
+		n = syscall(__NR_getrandom, (char *)buf + position, size - position, 0);
 		if (n > 0) {
 			position += n;
 		}


### PR DESCRIPTION
Doing this because getrandom wasn't added to glibc until 2.25.