### PR TITLE
Provide a destroy function for registered addresses

### DIFF
--- a/usrsctplib/netinet/sctp_pcb.c
+++ b/usrsctplib/netinet/sctp_pcb.c
@@ -334,6 +334,13 @@ sctp_free_ifa(struct sctp_ifa *sctp_ifap)
 		if (sctp_ifap->ifn_p) {
 			sctp_free_ifn(sctp_ifap->ifn_p);
 		}
+		if (sctp_ifap->destroy_address) {
+			/* sctp_ifap->address is struct sockaddr_conn */
+			if (sctp_ifap->address.sconn.sconn_addr) {
+				sctp_ifap->destroy_address (sctp_ifap->address.sconn.sconn_addr);
+			}
+			sctp_ifap->address.sconn.sconn_addr = NULL;
+		}
 		SCTP_FREE(sctp_ifap, SCTP_M_IFA);
 		atomic_subtract_int(&SCTP_BASE_INFO(ipi_count_ifas), 1);
 	}
@@ -536,6 +543,15 @@ sctp_add_addr_to_vrf(uint32_t vrf_id, void *ifn, uint32_t ifn_index,
 		     struct sockaddr *addr, uint32_t ifa_flags,
 		     int dynamic_add)
 {
+    return sctp_add_addr_to_vrf_full (vrf_id, ifn, ifn_index, ifn_type, if_name, ifa, addr, ifa_flags, dynamic_add, NULL);
+}
+
+struct sctp_ifa *
+sctp_add_addr_to_vrf_full(uint32_t vrf_id, void *ifn, uint32_t ifn_index,
+		     uint32_t ifn_type, const char *if_name, void *ifa,
+		     struct sockaddr *addr, uint32_t ifa_flags,
+		     int dynamic_add, void (*destroy)(void *))
+{
 	struct sctp_vrf *vrf;
 	struct sctp_ifn *sctp_ifnp, *new_sctp_ifnp;
 	struct sctp_ifa *sctp_ifap, *new_sctp_ifap;
@@ -690,6 +706,7 @@ sctp_add_addr_to_vrf(uint32_t vrf_id, void *ifn, uint32_t ifn_index,
 #endif
 	sctp_ifap->localifa_flags = SCTP_ADDR_VALID | SCTP_ADDR_DEFER_USE;
 	sctp_ifap->flags = ifa_flags;
+	sctp_ifap->destroy_address = destroy;
 	/* Set scope */
 	switch (sctp_ifap->address.sa.sa_family) {
 #ifdef INET

--- a/usrsctplib/netinet/sctp_pcb.h
+++ b/usrsctplib/netinet/sctp_pcb.h
@@ -111,6 +111,7 @@ struct sctp_ifa {
 				 * appropriate locks. This is for V6.
 				 */
 	union sctp_sockstore address;
+	void (*destroy_address)(void *);
 	uint32_t refcount;	/* number of folks referring to this */
 	uint32_t flags;
 	uint32_t localifa_flags;
@@ -707,6 +708,13 @@ sctp_add_addr_to_vrf(uint32_t vrfid,
 		     const char *if_name,
 		     void *ifa, struct sockaddr *addr, uint32_t ifa_flags,
 		     int dynamic_add);
+
+struct sctp_ifa *
+sctp_add_addr_to_vrf_full(uint32_t vrfid,
+		     void *ifn, uint32_t ifn_index, uint32_t ifn_type,
+		     const char *if_name,
+		     void *ifa, struct sockaddr *addr, uint32_t ifa_flags,
+		     int dynamic_add, void (*destroy)(void *));
 
 void sctp_update_ifn_mtu(uint32_t ifn_index, uint32_t mtu);
 

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -3139,7 +3139,7 @@ free_mbuf:
 #endif
 
 void
-usrsctp_register_address(void *addr)
+usrsctp_register_address_full(void *addr, void (*destroy)(void *))
 {
 	struct sockaddr_conn sconn;
 
@@ -3150,7 +3150,7 @@ usrsctp_register_address(void *addr)
 #endif
 	sconn.sconn_port = 0;
 	sconn.sconn_addr = addr;
-	sctp_add_addr_to_vrf(SCTP_DEFAULT_VRFID,
+	sctp_add_addr_to_vrf_full(SCTP_DEFAULT_VRFID,
 	                     NULL,
 	                     0xffffffff,
 	                     0,
@@ -3158,7 +3158,14 @@ usrsctp_register_address(void *addr)
 	                     NULL,
 	                     (struct sockaddr *)&sconn,
 	                     0,
-	                     0);
+	                     0,
+	                     destroy);
+}
+
+void
+usrsctp_register_address(void *addr)
+{
+	usrsctp_register_address_full (addr, NULL);
 }
 
 void

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -1028,6 +1028,9 @@ void
 usrsctp_register_address(void *);
 
 void
+usrsctp_register_address_full(void *, void (*)(void *));
+
+void
 usrsctp_deregister_address(void *);
 
 int


### PR DESCRIPTION
This patch tries to fix the problem of usrsctp calling callbacks even
after the usrsctp_close function is invoked.
Usrsctp seems to keep the asociation around until the teardown procedure
is completed. The problem is that sometimes it is not possible to
complete the shutdown procedure if the lower transport is gone like SCTP
running on top of DTLS. In such case, callbacks triggered from usrsctp
are providing an pointer address to an applications which could have
been deallocated.
To let applications know when they can safely deallocate memory
registered with an association, we are storing a destroy function which
will be used for usrsctp to notify applications when the association is
gone.
Related issues:
https://github.com/sctplab/usrsctp/issues/405
https://github.com/sctplab/usrsctp/issues/147