### PR TITLE
Fixed installation on other than Ubuntu GNU/Linux distributions

### DIFF
--- a/usrsctplib/CMakeLists.txt
+++ b/usrsctplib/CMakeLists.txt
@@ -36,10 +36,12 @@
 
 set(VERSION "1.0.0")
 
+include(GNUInstallDirs)
 set(prefix 					${CMAKE_INSTALL_PREFIX})
 set(exec_prefix 			${prefix})
-set(libdir 					${exec_prefix}/lib)
-set(includedir 				${prefix}/include/usrsctp)
+set(libdir 					${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
+set(includedir 				${prefix}/${CMAKE_INSTALL_INCLUDEDIR}/usrsctp)
+
 set(CMAKE_REQUIRED_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_MACOSX_RPATH 		1)
 
@@ -79,7 +81,6 @@ endif ()
 if (sctp_build_shared_lib)
 	set(BUILD_SHARED_LIBS 1)
 endif ()
-
 
 #################################################
 # LIBRARY FILES
@@ -178,14 +179,16 @@ endif ()
 set_target_properties(usrsctp PROPERTIES IMPORT_SUFFIX "_import.lib")
 set_target_properties(usrsctp PROPERTIES SOVERSION 1 VERSION 1.0.0)
 
-if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
-	SET(CMAKE_INSTALL_LIBDIR lib)
-endif ()
-
-
 #################################################
 # INSTALL LIBRARY AND HEADER
 #################################################
 
 install(TARGETS usrsctp DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES usrsctp.h DESTINATION include)
+install(FILES usrsctp.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+#################################################
+# GENERATE AND INSTALL PKG-CONFIG FILE
+#################################################
+
+configure_file("${PROJECT_SOURCE_DIR}/usrsctp.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/usrsctp.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/usrsctp.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")


### PR DESCRIPTION
Fixed installation on other than Ubuntu GNU/Linux distributions.

Fedora and other GNU/Linux distributions use different $libdir prefixes. Now it can be installed on any GNU/Linux distributions.