### PR TITLE
Use CMAKE's BUILD_SHARED_LIBS flag to build shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ endif ()
 
 option(sctp_werror "Treat warning as error" 1)
 
-option(sctp_link_programs_static "Link example programs static" 0)
+option(sctp_build_shared_lib "Build USRSCTP as shared library" 0)
 
 option(sctp_build_programs "Build example programs" 1)
 
@@ -81,12 +81,6 @@ option(sctp_build_fuzzer "Compile in clang fuzzing mode" 0)
 
 if (sctp_sanitizer_address AND sctp_sanitizer_memory)
 	message(FATAL_ERROR "Can not compile with both sanitizer options")
-endif ()
-
-if (sctp_link_programs_static OR WIN32)
-	set(programs_link_library "usrsctp-static")
-else ()
-	set(programs_link_library "usrsctp")
 endif ()
 
 

--- a/fuzzer/CMakeLists.txt
+++ b/fuzzer/CMakeLists.txt
@@ -77,35 +77,35 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=fuzzer")
 # 5 - DATA RECEIVED
 
 add_executable(fuzzer_listen fuzzer_listen.c ../programs/programs_helper.c)
-target_link_libraries(fuzzer_listen usrsctp-static)
+target_link_libraries(fuzzer_listen usrsctp)
 
 add_executable(fuzzer_fragment fuzzer_fragment.c ../programs/programs_helper.c)
-target_link_libraries(fuzzer_fragment usrsctp-static)
+target_link_libraries(fuzzer_fragment usrsctp)
 
 add_executable(fuzzer_connect_multi fuzzer_connect.c ../programs/programs_helper.c)
 target_compile_definitions(fuzzer_connect_multi PRIVATE FUZZING_STAGE=0)
-target_link_libraries(fuzzer_connect_multi usrsctp-static)
+target_link_libraries(fuzzer_connect_multi usrsctp)
 
 add_executable(fuzzer_connect_multi_verbose fuzzer_connect.c ../programs/programs_helper.c)
 target_compile_definitions(fuzzer_connect_multi_verbose PRIVATE FUZZING_STAGE=0 FUZZ_VERBOSE)
-target_link_libraries(fuzzer_connect_multi_verbose usrsctp-static)
+target_link_libraries(fuzzer_connect_multi_verbose usrsctp)
 
 # add_executable(fuzzer_connect_cookie_wait fuzzer_connect.c)
 # target_compile_definitions(fuzzer_connect_cookie_wait PRIVATE FUZZING_STAGE=1)
-# target_link_libraries(fuzzer_connect_cookie_wait usrsctp-static)
+# target_link_libraries(fuzzer_connect_cookie_wait usrsctp)
 
 # add_executable(fuzzer_connect_cookie_echoed fuzzer_connect.c)
 # target_compile_definitions(fuzzer_connect_cookie_echoed PRIVATE FUZZING_STAGE=2)
-# target_link_libraries(fuzzer_connect_cookie_echoed usrsctp-static)
+# target_link_libraries(fuzzer_connect_cookie_echoed usrsctp)
 
 # add_executable(fuzzer_connect_established fuzzer_connect.c)
 # target_compile_definitions(fuzzer_connect_established PRIVATE FUZZING_STAGE=3)
-# target_link_libraries(fuzzer_connect_established usrsctp-static)
+# target_link_libraries(fuzzer_connect_established usrsctp)
 
 # add_executable(fuzzer_connect_data_sent fuzzer_connect.c)
 # target_compile_definitions(fuzzer_connect_data_sent PRIVATE FUZZING_STAGE=4)
-# target_link_libraries(fuzzer_connect_data_sent usrsctp-static)
+# target_link_libraries(fuzzer_connect_data_sent usrsctp)
 
 # add_executable(fuzzer_connect_data_received fuzzer_connect.c)
 # target_compile_definitions(fuzzer_connect_data_received PRIVATE FUZZING_STAGE=5)
-# target_link_libraries(fuzzer_connect_data_received usrsctp-static)
+# target_link_libraries(fuzzer_connect_data_received usrsctp)

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2015-2015 Oleg Alexeenkov
-# Copyright (C) 2015-2019 Felix Weinrank
+# Copyright (C) 2015-2020 Felix Weinrank
 #
 # All rights reserved.
 #
@@ -116,7 +116,7 @@ foreach (source_file ${check_programs})
 
 	target_link_libraries(
 		${source_file_we}
-		${programs_link_library}
+		"usrsctp"
 		${CMAKE_THREAD_LIBS_INIT}
 	)
 endforeach ()

--- a/programs/tsctp.c
+++ b/programs/tsctp.c
@@ -183,7 +183,7 @@ handle_connection(void *arg)
 	unsigned long messages = 0;
 	unsigned long long first_length = 0;
 	unsigned long long sum = 0;
-	unsigned long long round_bytes;
+	unsigned long long round_bytes = 0;
 	struct timeval round_start;
 	time_t round_timeout = 0;
 
@@ -204,10 +204,10 @@ handle_connection(void *arg)
 
 	gettimeofday(&time_start, NULL);
 	if (round_duration > 0) {
-		round_bytes = 0;
 		gettimeofday(&round_start, NULL);
 		round_timeout = calc_round_timeout(round_start);
 	}
+
 	while (n > 0) {
 		recv_calls++;
 		if (flags & MSG_NOTIFICATION) {

--- a/usrsctplib/CMakeLists.txt
+++ b/usrsctplib/CMakeLists.txt
@@ -76,6 +76,9 @@ endif ()
 # MISC
 #################################################
 
+if (sctp_build_shared_lib)
+	set(BUILD_SHARED_LIBS 1)
+endif ()
 
 
 #################################################
@@ -163,19 +166,15 @@ list(APPEND usrsctp_sources
 	user_socket.c
 )
 
-add_library(usrsctp SHARED ${usrsctp_sources} ${usrsctp_headers})
-add_library(usrsctp-static STATIC ${usrsctp_sources} ${usrsctp_headers})
+add_library(usrsctp ${usrsctp_sources} ${usrsctp_headers})
 
 target_include_directories(usrsctp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(usrsctp-static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 if (WIN32)
 	message(STATUS "link library: ws2_32")
 	target_link_libraries(usrsctp ws2_32 iphlpapi.lib)
-	target_link_libraries(usrsctp-static ws2_32 iphlpapi.lib)
 endif ()
 
-set_target_properties(usrsctp-static PROPERTIES OUTPUT_NAME "usrsctp")
 set_target_properties(usrsctp PROPERTIES IMPORT_SUFFIX "_import.lib")
 set_target_properties(usrsctp PROPERTIES SOVERSION 1 VERSION 1.0.0)
 
@@ -188,5 +187,5 @@ endif ()
 # INSTALL LIBRARY AND HEADER
 #################################################
 
-install(TARGETS usrsctp usrsctp-static DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS usrsctp DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES usrsctp.h DESTINATION include)


### PR DESCRIPTION
... and an linter fix for an uninitialized variable.

Fixes #542 