### PR TITLE
MinGW release build - initialize variables

### DIFF
--- a/programs/tsctp.c
+++ b/programs/tsctp.c
@@ -184,7 +184,7 @@ handle_connection(void *arg)
 	unsigned long long first_length = 0;
 	unsigned long long sum = 0;
 	unsigned long long round_bytes = 0;
-	struct timeval round_start;
+	struct timeval round_start = (struct timeval){0};
 	time_t round_timeout = 0;
 
 	conn_sock = *(struct socket **)arg;

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -1328,7 +1328,7 @@ usrsctp_socket(int domain, int type, int protocol,
 	       uint32_t sb_threshold,
 	       void *ulp_info)
 {
-	struct socket *so;
+	struct socket *so = NULL;
 
 	if ((protocol == IPPROTO_SCTP) && (SCTP_BASE_VAR(sctp_pcb_initialized) == 0)) {
 		errno = EPROTONOSUPPORT;


### PR DESCRIPTION
Fix compile problem with uninitilized variables when MinGW is used for the release build.