### PR TITLE
Call __msan_unpoison after syscall(__NR_getrandom, ...).

### DIFF
--- a/usrsctplib/user_environment.c
+++ b/usrsctplib/user_environment.c
@@ -209,6 +209,12 @@ finish_random(void)
 #include <unistd.h>
 #include <sys/syscall.h>
 
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+void __msan_unpoison(void *, size_t);
+#endif
+#endif
+
 void
 init_random(void)
 {
@@ -229,6 +235,14 @@ read_random(void *buf, size_t size)
 			position += n;
 		}
 	}
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+	/* Need to do this because MSan doesn't realize that syscall has
+	 * initialized the output buffer.
+	 */
+	__msan_unpoison(buf, size);
+#endif
+#endif
 	return;
 }
 


### PR DESCRIPTION
MSan doesn't realize that the syscall initialized the output buffer, so
this is necessary to avoid MSan errors when generating random numbers on
Linux.