### PR TITLE
fix of incorrect type conversion.

### DIFF
--- a/usrsctplib/netinet/sctp_cc_functions.c
+++ b/usrsctplib/netinet/sctp_cc_functions.c
@@ -793,7 +793,7 @@ sctp_cwnd_update_after_sack_common(struct sctp_tcb *stcb,
 				t_path_mptcp += (((uint64_t)net->cwnd) << SHIFT_MPTCP_MULTI_Z) /
 				                (((uint64_t)net->mtu) * (uint64_t)srtt);
 				tmp = (((uint64_t)net->cwnd) << SHIFT_MPTCP_MULTI_N) /
-				      ((uint64_t)net->mtu * (uint64_t)(srtt * srtt));
+				      ((uint64_t)net->mtu * srtt * srtt);
 				if (tmp > max_path) {
 					max_path = tmp;
 				}


### PR DESCRIPTION
used transform (uint64_t) (srtt * srtt) is incorrect. first, the product will be counted in uint32_t, and only then the conversion to uint64_t will be performed.

I couldn't find the importance of preemptive execution (srtt * srtt), so I suggest a simple fix.
however, if the sequence of the product in the expression ((uint64_t) net-> mtu * (uint64_t) (srtt * srtt)) is important, then I can correct the commit to any of the options:
1. ((uint64_t) srtt * srtt * net-> mtu)
2. ((uint64_t) net-> mtu * ((uint64_t) srtt * srtt))

I would also pay attention to the comparison if (srtt> 0), given the unsigned nature of srtt, I would suggest replacing it with if (srtt != 0).