### PR TITLE
Add __declspec(noreturn) to terminate_non_graceful() on Windows

### DIFF
--- a/usrsctplib/user_environment.h
+++ b/usrsctplib/user_environment.h
@@ -92,7 +92,7 @@ extern u_short ip_id;
 #include <stdlib.h>
 
 #if defined(_WIN32)
-static inline void
+static inline void __declspec(noreturn)
 #else
 static inline void __attribute__((__noreturn__))
 #endif


### PR DESCRIPTION
Informs the compiler that the function never returns, which fixes a -Wsometimes-uninitialized warning.