### PR TITLE
Correct option type for UDP encapsulation port

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -364,7 +364,7 @@ SCTP_RECVRCVINFO | int | r/w
 SCTP_RECVNXTINFO | int | r/w
 SCTP_DEFAULT_SNDINFO | struct sctp_sndinfo | r/w
 SCTP_DEFAULT_PRINFO | struct sctp_default_prinfo | r/w
-SCTP_REMOTE_UDP_ENCAPS_PORT | int | r/w
+SCTP_REMOTE_UDP_ENCAPS_PORT | sctp_udpencaps | r/w
 SCTP_ENABLE_STREAM_RESET | struct sctp_assoc_value | r/w
 SCTP_STATUS | struct sctp_status | r
 SCTP_GET_PEER_ADDR_INFO | struct sctp_paddrinfo | r

--- a/Manual.md
+++ b/Manual.md
@@ -364,7 +364,7 @@ SCTP_RECVRCVINFO | int | r/w
 SCTP_RECVNXTINFO | int | r/w
 SCTP_DEFAULT_SNDINFO | struct sctp_sndinfo | r/w
 SCTP_DEFAULT_PRINFO | struct sctp_default_prinfo | r/w
-SCTP_REMOTE_UDP_ENCAPS_PORT | sctp_udpencaps | r/w
+SCTP_REMOTE_UDP_ENCAPS_PORT | struct sctp_udpencaps | r/w
 SCTP_ENABLE_STREAM_RESET | struct sctp_assoc_value | r/w
 SCTP_STATUS | struct sctp_status | r
 SCTP_GET_PEER_ADDR_INFO | struct sctp_paddrinfo | r


### PR DESCRIPTION
It seems to me that the type for SCTP_REMOTE_UDP_ENCAPS_PORT is checked as the struct, `sctp_udpencaps`, and not an `int` as described in the documentation.

https://github.com/sctplab/usrsctp/blob/279a68fd6f5b8b913bd19ca99342f5f3e285a6fe/usrsctplib/netinet/sctp_usrreq.c#L7346