### PR TITLE
Fixes to build under Xcode12 for iOS ARM64

### DIFF
--- a/usrsctplib/CMakeLists.txt
+++ b/usrsctplib/CMakeLists.txt
@@ -83,7 +83,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
 	add_definitions(-D_GNU_SOURCE)
 endif ()
 
-if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin" OR CMAKE_SYSTEM_NAME MATCHES "iOS")
 	add_definitions(-D__APPLE_USE_RFC_2292)
 endif ()
 


### PR DESCRIPTION
Typecasts
Added bundle identifiers to executables