### PR TITLE
Change defines to type aliases for better compatibility

### DIFF
--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -64,19 +64,19 @@ extern "C" {
 #elif defined(SCTP_STDINT_INCLUDE)
 #include SCTP_STDINT_INCLUDE
 #else
-#define uint8_t   unsigned __int8
-#define uint16_t  unsigned __int16
-#define uint32_t  unsigned __int32
-#define uint64_t  unsigned __int64
-#define int16_t   __int16
-#define int32_t   __int32
+typedef unsigned __int8  uint8_t;
+typedef unsigned __int16 uint16_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int64 uint64_t;
+typedef          __int16 int16_t;
+typedef          __int32 int32_t;
 #endif
 
 #ifndef ssize_t
 #ifdef _WIN64
-#define ssize_t __int64
+typedef __int64 ssize_t;
 #elif defined _WIN32
-#define ssize_t int
+typedef int ssize_t;
 #else
 #error "Unknown platform!"
 #endif


### PR DESCRIPTION
I do not necessarily know what I'm doing, but I think this fixes #600 and stops colliding with `std::*_t` in C++ projects.