### PR TITLE
Replace warning flags in Meson with `warning_level`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,10 @@
 # Project definition
 project('usrsctplib', 'c',
     version: '0.9.5.0',
-    default_options: ['c_std=c99'],
+    default_options: [
+        'c_std=c99',
+        'warning_level=2',
+    ],
     meson_version: '>=0.49.0')
 
 # Shared library API and ABI versions
@@ -27,8 +30,6 @@ if compiler.get_argument_syntax() == 'msvc'
 else
     compiler_args = compiler.get_supported_arguments([
         '-pedantic',
-        '-Wall',
-        '-Wextra',
         '-Wfloat-equal',
         '-Wshadow',
         '-Wpointer-arith',


### PR DESCRIPTION
This is the canonical way of doing it, `-Wall` is added with `warning_level=1`, `-Wextra` with `warning_level=2`.

Without this change recent version of Meson produces warnings:
```
usrsctp| ../subprojects/usrsctp-59bd3c2fc5a43ac60cd7817aa1ad68c9d95cf376/meson.build:42: WARNING: Consider using the built-in warning_level option instead of using "-Wall".
usrsctp| ../subprojects/usrsctp-59bd3c2fc5a43ac60cd7817aa1ad68c9d95cf376/meson.build:42: WARNING: Consider using the built-in warning_level option instead of using "-Wextra".
```