### PR TITLE
Mention OpenBSD support

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -7,7 +7,7 @@ Like TCP, SCTP provides reliable, connection oriented data delivery with congest
 In this manual the socket API for the SCTP User-land implementation will be described.  It is based on [RFC 6458](https://tools.ietf.org/html/rfc6458). The main focus of this document is on pointing out the differences to the SCTP Sockets API. For all aspects of the sockets API that are not mentioned in this document, please refer to [RFC 6458](https://tools.ietf.org/html/rfc6458). Questions about SCTP itself can hopefully be answered by [RFC 4960](https://tools.ietf.org/html/rfc4960).
 
 ## Getting Started
-The user-land stack has been tested on FreeBSD 10.0, Ubuntu 11.10, Windows 7, Mac OS X 10.6, and Mac OS X 10.7. The current version of the user-land stack is provided on [github](https://github.com/sctplab/usrsctp). Download the tarball and untar it in a folder of your choice. The tarball contains all the sources to build the libusrsctp, which has to be linked to the object file of an example program. In addition there are two applications in the folder `programs` that can be built and run.
+The user-land stack has been tested on FreeBSD 10.0, OpenBSD 7.0, Ubuntu 11.10, Windows 7, Mac OS X 10.6, and Mac OS X 10.7. The current version of the user-land stack is provided on [github](https://github.com/sctplab/usrsctp). Download the tarball and untar it in a folder of your choice. The tarball contains all the sources to build the libusrsctp, which has to be linked to the object file of an example program. In addition there are two applications in the folder `programs` that can be built and run.
 
 ### Building the Library and the Applications
 #### Unix-like Operating Systems

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![GitHub Actions Build Status (CMake-based build only)](https://github.com/sctplab/usrsctp/workflows/Build%20with%20CMake/badge.svg)
 
-This is a userland SCTP stack supporting FreeBSD, Linux, Mac OS X and Windows.
+This is a userland SCTP stack supporting FreeBSD, OpenBSD, Linux, Mac OS X and Windows.
 
 See [manual](Manual.md) for more information.
 


### PR DESCRIPTION
`usrsctp` 0.9.5.0 has been tested/used successfully on
OpenBSD/amd64 7.0 -CURRENT as of today in conjunction with
the official Telegram Desktop client.
