### PR TITLE
cmake: usrsctplib: link against threads library

### DIFF
--- a/usrsctplib/CMakeLists.txt
+++ b/usrsctplib/CMakeLists.txt
@@ -95,6 +95,8 @@ if (sctp_build_shared_lib)
 	set(BUILD_SHARED_LIBS 1)
 endif ()
 
+find_package(Threads)
+
 #################################################
 # LIBRARY FILES
 #################################################
@@ -187,6 +189,8 @@ target_include_directories(usrsctp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 if(SCTP_USE_MBEDTLS_SHA1)
 	target_include_directories(usrsctp PRIVATE ${MBEDTLS_INCLUDE_DIRS})
 endif()
+
+target_link_libraries(usrsctp ${CMAKE_THREAD_LIBS_INIT})
 
 if (WIN32)
 	message(STATUS "link library: ws2_32")


### PR DESCRIPTION
The usrsctp library uses threads, but building it with cmake does not
link against the system's thread library.

Use cmake's "Threads" package as usual to deal with all supported
platforms.
(autoconf's configure.ac correctly adds `-pthread` to CFLAGS.)

This is needed because programs which do not use threads themselves but
link against usrsctplib will otherwise fail to link since `pthread_*`
symbols used in libusrsctp.so are not resolved.

programs/CMakeFiles.txt avoids this problem by unconditionally using the
"Threads" package for every program including those that do not use
threads themselves.