### PR TITLE
usrsctp.pc: register pthread

### DIFF
--- a/usrsctp.pc.in
+++ b/usrsctp.pc.in
@@ -9,4 +9,5 @@ URL: https://github.com/sctplab/usrsctp
 Version: @VERSION@
 Requires: 
 Libs: -L${libdir} -lusrsctp
+Libs.private: -lpthread
 Cflags: -I${includedir} @APPCFLAGS@


### PR DESCRIPTION
Follow 40e35a7 "cmake: usrsctplib: link against threads library (#644)";
this is not in "Libs:" since programs do not need to link against
pthreads themselves.

See https://people.freedesktop.org/~dbn/pkg-config-guide.html
