### PR TITLE
Simplify init_random() to remove QNX special-case

### DIFF
--- a/usrsctplib/user_environment.c
+++ b/usrsctplib/user_environment.c
@@ -175,18 +175,12 @@ finish_random(void)
 #elif (defined(__ANDROID__) && (__ANDROID_API__ < 28)) || defined(__QNX__) || defined(__EMSCRIPTEN__)
 #include <fcntl.h>
 
-#ifdef __QNX__
-#define SCTP_RANDOM_DEVICE "/dev/random"
-#else
-#define SCTP_RANDOM_DEVICE "/dev/urandom"
-#endif
-
 static int fd = -1;
 
 void
 init_random(void)
 {
-	fd = open(SCTP_RANDOM_DEVICE, O_RDONLY);
+	fd = open("/dev/urandom", O_RDONLY);
 	return;
 }
 


### PR DESCRIPTION
As it has both device entries and they provide the same functionality.

(I totally missed this when skimming the [documentation](http://www.qnx.com/developers/docs/7.0.0/index.html#com.qnx.doc.neutrino.utilities/topic/r/random.html), and it wasn't until today that I happened to notice the other device entry.)