### PR TITLE
bugfix: nat-state-update for ipv4

### DIFF
--- a/usrsctplib/netinet/sctp_asconf.c
+++ b/usrsctplib/netinet/sctp_asconf.c
@@ -3389,7 +3389,7 @@ out:
 		aa_add->ap.addrp.ph.param_type = SCTP_IPV4_ADDRESS;
 		aa_add->ap.addrp.ph.param_length = sizeof (struct sctp_ipv4addr_param);
 		/* No need to fill the address, we are using 0.0.0.0 */
-		aa_del->ap.aph.ph.param_type = SCTP_ADD_IP_ADDRESS;
+		aa_del->ap.aph.ph.param_type = SCTP_DEL_IP_ADDRESS;
 		aa_del->ap.aph.ph.param_length = sizeof(struct sctp_asconf_addrv4_param);
 		aa_del->ap.addrp.ph.param_type = SCTP_IPV4_ADDRESS;
 		aa_del->ap.addrp.ph.param_length = sizeof (struct sctp_ipv4addr_param);


### PR DESCRIPTION
The param type looks wrong for aa_del, correcting the param type used for delete to SCTP_DEL_IP_ADDRESS.