### PR TITLE
asconf: set last_control_chunk_from to null

### DIFF
--- a/usrsctplib/netinet/sctp_input.c
+++ b/usrsctplib/netinet/sctp_input.c
@@ -4999,6 +4999,8 @@ sctp_process_control(struct mbuf *m, int iphlen, int *offset, int length,
 				 */
 				if ((netp != NULL) && (*netp != NULL))
 					stcb->asoc.last_control_chunk_from = *netp;
+				else
+					stcb->asoc.last_control_chunk_from = NULL;
 			}
 		}
 #ifdef SCTP_AUDITING_ENABLED


### PR DESCRIPTION
If we get ASCONF from a new address, i.e, we couldn't find the net,
set last_control_chunk_from to null. This will force ASCONF processing
to find the correct net later, else ASCONF_ACK ends up being sent
to the net where the last control chunk (like COOKIE_ECHO/COOKIE_ACK)
was received from.

Encountered this problem while working on https://datatracker.ietf.org/doc/draft-porfiri-tsvwg-sctp-natsupp/, where we want to send ASCONF from secondary addresses after a single homed session is setup.