### PR TITLE
Fix QNX support

### DIFF
--- a/usrsctplib/netinet/sctp_os_userspace.h
+++ b/usrsctplib/netinet/sctp_os_userspace.h
@@ -1076,6 +1076,8 @@ sctp_get_mbuf_for_msg(unsigned int space_needed, int want_header, int how, int a
 #define CMSG_ALIGN(n)   _ALIGN(n)
 #elif defined(__NetBSD__)
 #define CMSG_ALIGN(n)   (((n) + __ALIGNBYTES) & ~__ALIGNBYTES)
+#elif defined(__QNX__)
+#define CMSG_ALIGN(n)   __CMSG_ALIGN(n)
 #elif defined(__APPLE__)
 #if !defined(__DARWIN_ALIGNBYTES)
 #define	__DARWIN_ALIGNBYTES	(sizeof(__darwin_size_t) - 1)
@@ -1139,7 +1141,7 @@ sctp_get_mbuf_for_msg(unsigned int space_needed, int want_header, int how, int a
 
 #define SCTP_IS_LISTENING(inp) ((inp->sctp_flags & SCTP_PCB_FLAGS_ACCEPTING) != 0)
 
-#if defined(__APPLE__) || defined(__DragonFly__) || defined(__linux__) || defined(__native_client__) || defined(__NetBSD__) || defined(_WIN32) || defined(__Fuchsia__) || defined(__EMSCRIPTEN__)
+#if defined(__APPLE__) || defined(__DragonFly__) || defined(__linux__) || defined(__native_client__) || defined(__NetBSD__) || defined(__QNX__) || defined(_WIN32) || defined(__Fuchsia__) || defined(__EMSCRIPTEN__)
 int
 timingsafe_bcmp(const void *, const void *, size_t);
 #endif

--- a/usrsctplib/usrsctp.h
+++ b/usrsctplib/usrsctp.h
@@ -35,6 +35,11 @@
 extern "C" {
 #endif
 
+#if defined(__QNX__) && !defined(_QNX_SOURCE)
+/* Needed for sockaddr_storage */
+#define _QNX_SOURCE
+#endif
+
 #include <errno.h>
 #include <sys/types.h>
 #ifdef _WIN32
@@ -120,7 +125,8 @@ struct sctp_common_header {
  * tune with other sockaddr_* structures.
  */
 #if defined(__APPLE__) || defined(__Bitrig__) || defined(__DragonFly__) || \
-    defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+    defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || \
+    defined(__QNX__)
 struct sockaddr_conn {
 	uint8_t sconn_len;
 	uint8_t sconn_family;


### PR DESCRIPTION
- Revive QNX parts of sctp_os_userspace.h, removed in 13a3b53.
- Fix the sockaddr_conn definition.