### PR TITLE
fix build error on windows

### DIFF
--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -13477,10 +13477,10 @@ sctp_lower_sosend(struct socket *so,
 #endif
 	struct timeval now;
 	struct sctp_block_entry be;
-	struct sctp_inpcb *inp;
+	struct sctp_inpcb *inp = NULL;
 	struct sctp_tcb *stcb = NULL;
 	struct sctp_nets *net;
-	struct sctp_association *asoc;
+	struct sctp_association *asoc = NULL;
 	struct sctp_inpcb *t_inp;
 	struct sctp_nonpad_sndrcvinfo *sndrcvninfo;
 	ssize_t sndlen = 0, max_len, local_add_more;


### PR DESCRIPTION
```
sctp_output.c
L:\usrsctplib\netinet\sctp_output.c(14823): error C2220: the following warning is treated as an error
L:\usrsctplib\netinet\sctp_output.c(14823): warning C4703: potentially uninitialized local pointer variable 'inp' used
L:\usrsctplib\netinet\sctp_output.c(14827): warning C4703: potentially uninitialized local pointer variable 'asoc' used
```