### PR TITLE
Add definition for sctp_ootb_with_zero_cksum

### DIFF
--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -3479,6 +3479,7 @@ USRSCTP_SYSCTL_SET_DEF(sctp_steady_step, SCTPCTL_RTTVAR_STEADYS)
 USRSCTP_SYSCTL_SET_DEF(sctp_use_dccc_ecn, SCTPCTL_RTTVAR_DCCCECN)
 USRSCTP_SYSCTL_SET_DEF(sctp_buffer_splitting, SCTPCTL_BUFFER_SPLITTING)
 USRSCTP_SYSCTL_SET_DEF(sctp_initial_cwnd, SCTPCTL_INITIAL_CWND)
+USRSCTP_SYSCTL_SET_DEF(sctp_ootb_with_zero_cksum, SCTPCTL_OOTB_WITH_ZERO_CKSUM)
 #ifdef SCTP_DEBUG
 USRSCTP_SYSCTL_SET_DEF(sctp_debug_on, SCTPCTL_DEBUG)
 #endif
@@ -3561,6 +3562,7 @@ USRSCTP_SYSCTL_GET_DEF(sctp_steady_step)
 USRSCTP_SYSCTL_GET_DEF(sctp_use_dccc_ecn)
 USRSCTP_SYSCTL_GET_DEF(sctp_buffer_splitting)
 USRSCTP_SYSCTL_GET_DEF(sctp_initial_cwnd)
+USRSCTP_SYSCTL_GET_DEF(sctp_ootb_with_zero_cksum)
 #ifdef SCTP_DEBUG
 USRSCTP_SYSCTL_GET_DEF(sctp_debug_on)
 #endif


### PR DESCRIPTION
The declarations for `usrsctp_sysctl_set_sctp_ootb_with_zero_cksum()` and `usrsctp_sysctl_get_sctp_ootb_with_zero_cksum()` exist, but their definitions were missing, causing an error.