### PR TITLE
Extend use_zero_crc check to AF_CONN sockets

### DIFF
--- a/usrsctplib/netinet/sctp_output.c
+++ b/usrsctplib/netinet/sctp_output.c
@@ -5023,7 +5023,9 @@ sctp_lowlevel_chunk_output(struct sctp_inpcb *inp,
 		sctphdr->dest_port = dest_port;
 		sctphdr->v_tag = v_tag;
 		sctphdr->checksum = 0;
-		if (SCTP_BASE_VAR(crc32c_offloaded) == 0) {
+		if (use_zero_crc) {
+			SCTP_STAT_INCR(sctps_sendzerocrc);
+		} else if (SCTP_BASE_VAR(crc32c_offloaded) == 0) {
 			sctphdr->checksum = sctp_calculate_cksum(m, 0);
 			SCTP_STAT_INCR(sctps_sendswcrc);
 		} else {


### PR DESCRIPTION
The `use_zero_crc` flag is already considered for AF_INET address family. This commit ensures that when transmitting using sockets created with the AF_CONN address family, crc32c calculation is skipped based on this flag.