### PR TITLE
Assert if soref() is called on an already-released socket.

### DIFF
--- a/usrsctplib/user_socketvar.h
+++ b/usrsctplib/user_socketvar.h
@@ -403,6 +403,7 @@ void	sofree(struct socket *so);
 
 #define	soref(so) do {							\
 	SOCK_LOCK_ASSERT(so);						\
+	KASSERT((so)->so_count > 0, ("soref"));				\
 	++(so)->so_count;						\
 } while (0)
 


### PR DESCRIPTION
If there are still lingering userspace socket double-free bugs, this should hopefully help catch them.