### PR TITLE
Add configure option to disable upcalls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,15 @@ AC_ARG_ENABLE(programs,
     enable_programs=$enableval,enable_programs=yes)
 AM_CONDITIONAL([COND_PROGRAMS], [test "$enable_programs" = yes])
 
+AC_ARG_ENABLE(upcalls,
+  AC_HELP_STRING( [--enable-upcalls],
+                  [enable socket upcall support  @<:@default=yes@:>@]),
+   enable_upcalls=$enableval,enable_upcalls=yes)
+if test x$enable_upcalls = xno; then
+         APPCFLAGS="$APPCFLAGS -DDISABLE_UPCALLS"
+         AC_DEFINE(DISABLE_UPCALLS, 1, [Disable upcall support])
+fi
+
 AC_CHECK_TYPE(size_t)
 AC_CHECK_TYPE(ssize_t)
 

--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -554,22 +554,7 @@ sctp_ctlinput(int cmd, struct sockaddr *sa, void *vip)
 			            inner_ip->ip_len,
 			            (uint32_t)ntohs(icmp->icmp_nextmtu));
 #if defined(__Userspace__)
-			if (((stcb->sctp_ep->sctp_flags & SCTP_PCB_FLAGS_SOCKET_GONE) == 0) &&
-			    (stcb->sctp_socket != NULL)) {
-				struct socket *upcall_socket;
-
-				upcall_socket = stcb->sctp_socket;
-				SOCK_LOCK(upcall_socket);
-				soref(upcall_socket);
-				SOCK_UNLOCK(upcall_socket);
-				if ((upcall_socket->so_upcall != NULL) &&
-				    (upcall_socket->so_error != 0)) {
-					(*upcall_socket->so_upcall)(upcall_socket, upcall_socket->so_upcallarg, M_NOWAIT);
-				}
-				ACCEPT_LOCK();
-				SOCK_LOCK(upcall_socket);
-				sorele(upcall_socket);
-			}
+			stcp_upcall_socket_if_error(stcb);
 #endif
 		} else {
 			if ((stcb == NULL) && (inp != NULL)) {

--- a/usrsctplib/netinet/sctputil.c
+++ b/usrsctplib/netinet/sctputil.c
@@ -8682,6 +8682,9 @@ sctp_add_substate(struct sctp_tcb *stcb, int substate)
 #if defined(__Userspace__)
 struct socket* sctp_get_upcall_socket(struct sctp_tcb * stcb)
 {
+#ifdef DISABLE_UPCALLS
+	return NULL;
+#else
 	struct socket* upcall_socket = NULL;
 	if ((stcb != NULL) &&
 	    ((stcb->sctp_ep->sctp_flags & SCTP_PCB_FLAGS_SOCKET_GONE) == 0) &&
@@ -8692,10 +8695,14 @@ struct socket* sctp_get_upcall_socket(struct sctp_tcb * stcb)
 		SOCK_UNLOCK(upcall_socket);
 	}
 	return upcall_socket;
+#endif
 }
 
 struct socket* sctp_get_upcall_socket_or_accept_head(struct sctp_tcb * stcb)
 {
+#ifdef DISABLE_UPCALLS
+	return NULL;
+#else
 	struct socket* upcall_socket = NULL;
 	if ((stcb != NULL) &&
 	    ((stcb->sctp_ep->sctp_flags & SCTP_PCB_FLAGS_SOCKET_GONE) == 0) &&
@@ -8712,11 +8719,13 @@ struct socket* sctp_get_upcall_socket_or_accept_head(struct sctp_tcb * stcb)
 		ACCEPT_UNLOCK();
 	}
 	return upcall_socket;
+#endif
 }
 
 
 void sctp_do_upcall_socket_if_error(struct socket *upcall_socket)
 {
+#ifndef DISABLE_UPCALLS
 	if (upcall_socket != NULL) {
 		if ((upcall_socket->so_upcall != NULL) &&
 		    (upcall_socket->so_error != 0)) {
@@ -8726,10 +8735,12 @@ void sctp_do_upcall_socket_if_error(struct socket *upcall_socket)
 		SOCK_LOCK(upcall_socket);
 		sorele(upcall_socket);
 	}
+#endif
 }
 
 void sctp_do_upcall_socket_if_readable_writeable_or_error(struct socket *upcall_socket)
 {
+#ifndef DISABLE_UPCALLS
 	if (upcall_socket != NULL) {
 		if (upcall_socket->so_upcall != NULL) {
 			if (soreadable(upcall_socket) ||
@@ -8742,6 +8753,7 @@ void sctp_do_upcall_socket_if_readable_writeable_or_error(struct socket *upcall_
 		SOCK_LOCK(upcall_socket);
 		sorele(upcall_socket);
 	}
+#endif
 }
 
 void sctp_upcall_socket_if_error(struct sctp_tcb *stcb)

--- a/usrsctplib/netinet/sctputil.h
+++ b/usrsctplib/netinet/sctputil.h
@@ -371,5 +371,13 @@ uint32_t sctp_msecs_to_ticks(uint32_t);
 uint32_t sctp_ticks_to_secs(uint32_t);
 uint32_t sctp_secs_to_ticks(uint32_t);
 
+#if defined(__Userspace__)
+void sctp_upcall_socket_if_error(struct sctp_tcb *);
+struct socket* sctp_get_upcall_socket(struct sctp_tcb *);
+struct socket* sctp_get_upcall_socket_or_accept_head(struct sctp_tcb * stcb);
+void sctp_do_upcall_socket_if_error(struct socket *);
+void sctp_do_upcall_socket_if_readable_writeable_or_error(struct socket *);
+#endif
+
 #endif				/* _KERNEL */
 #endif

--- a/usrsctplib/netinet6/sctp6_usrreq.c
+++ b/usrsctplib/netinet6/sctp6_usrreq.c
@@ -614,22 +614,7 @@ sctp6_ctlinput(int cmd, struct sockaddr *pktdst, void *d)
 			             ip6cp->ip6c_icmp6->icmp6_code,
 			             ntohl(ip6cp->ip6c_icmp6->icmp6_mtu));
 #if defined(__Userspace__)
-			if (((stcb->sctp_ep->sctp_flags & SCTP_PCB_FLAGS_SOCKET_GONE) == 0) &&
-			    (stcb->sctp_socket != NULL)) {
-				struct socket *upcall_socket;
-
-				upcall_socket = stcb->sctp_socket;
-				SOCK_LOCK(upcall_socket);
-				soref(upcall_socket);
-				SOCK_UNLOCK(upcall_socket);
-				if ((upcall_socket->so_upcall != NULL) &&
-				    (upcall_socket->so_error != 0)) {
-					(*upcall_socket->so_upcall)(upcall_socket, upcall_socket->so_upcallarg, M_NOWAIT);
-				}
-				ACCEPT_LOCK();
-				SOCK_LOCK(upcall_socket);
-				sorele(upcall_socket);
-			}
+			stcp_upcall_socket_if_error(stcb);
 #endif
 		} else {
 			if ((stcb == NULL) && (inp != NULL)) {

--- a/usrsctplib/user_socket.c
+++ b/usrsctplib/user_socket.c
@@ -3369,6 +3369,10 @@ usrsctp_set_upcall(struct socket *so, void (*upcall)(struct socket *, void *, in
 		return (-1);
 	}
 
+#ifdef DISABLE_UPCALLS
+	errno = ENOSYS;
+	return -1;
+#else
 	SOCK_LOCK(so);
 	so->so_upcall = upcall;
 	so->so_upcallarg = arg;
@@ -3377,6 +3381,7 @@ usrsctp_set_upcall(struct socket *so, void (*upcall)(struct socket *, void *, in
 	SOCK_UNLOCK(so);
 
 	return (0);
+#endif
 }
 
 #define USRSCTP_TUNABLE_SET_DEF(__field, __prefix)   \


### PR DESCRIPTION
The code to implement the upcall API seems to have bugs (notably https://github.com/sctplab/usrsctp/issues/709) which can affect users of usrsctplib even when that API isn't used.  This PR adds a configure-time option to disable support for that API, to avoid those bugs.