### PR TITLE
RFC: Manual: Update usrsctp_init() documentation

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -96,7 +96,10 @@ All system calls start with the prefix `usrsctp_` to distinguish them from the k
 Every application has to start with `usrsctp_init()`. This function calls `sctp_init()` and reserves the memory necessary to administer the data transfer. The function prototype is
 
 ```c
-void usrsctp_init(uint16_t udp_port)
+void usrsctp_init(uint16_t udp_port,
+                  int (*conn_output)(void *addr, void *buffer,
+                                     size_t length, uint8_t tos, uint8_t set_df),
+                  void (*debug_printf)(const char *format, ...))
 ```
 
 As it is not always possible to send data directly over SCTP because not all NAT boxes can process SCTP packets, the data can be sent over UDP. To encapsulate SCTP into UDP a UDP port has to be specified, to which the datagrams can be sent. This local UDP port  is set with the parameter `udp_port`. The default value is 9899, the standard UDP encapsulation port. If UDP encapsulation is not necessary, the UDP port has to be set to 0.

--- a/Manual.tex
+++ b/Manual.tex
@@ -171,7 +171,10 @@ the memory necessary to administer the data transfer.
 The function prototype is 
 \begin{verbatim}
 void
-usrsctp_init(uint16_t udp_port)
+usrsctp_init(uint16_t udp_port,
+             int (*conn_output)(void *addr, void *buffer,
+                                size_t length, uint8_t tos, uint8_t set_df),
+	     void (*debug_printf)(const char *format, ...))
 \end{verbatim}
 As it is not always possible to send data directly over SCTP because not all NAT boxes can
 process SCTP packets, the data can be sent over UDP. To encapsulate SCTP into UDP


### PR DESCRIPTION
Hello,

so it seems this project's documentation is at least in part out of date.

Notably the function `usrsctp_init()` is lacking descriptions of two parameters. Unfortunately, it is not easy (for me) to find what they are even supposed to do in the first place.

The last one seems to be some sort of state logging mechanism, added in b724b61c4f1fcb5fc3846fd7c86a246ef4be8b73.

The first one is hidden in the history somewhere. `git blame` just delivers a white space fix when searching for when and why it was introduced.

In any case, I think we should update the documentation. Feel free to use this patch as a basis. Alternatively, I'd also be happy to write some documentation. But someone from the project first would have to tell me what the `conn_output` and `debug_printf` function pointers are precisely supposed to do and when they are allowed to be `NULL`.