### PR TITLE
Fix minimum required version to configure with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,13 @@
 #
 
 project(usrsctplib C)
-cmake_minimum_required(VERSION 3.0)
+if(${CMAKE_VERSION} VERSION_LESS 3.27.0)
+    cmake_minimum_required(VERSION 3.0)
+elseif(${CMAKE_VERSION} VERSION_LESS 3.31.0)
+    cmake_minimum_required(VERSION 3.5)
+else()
+    cmake_minimum_required(VERSION 3.10)
+endif()
 
 # Debug build type as default
 if (NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
This PR fixes configuration with CMake 4 which requires a minimum required version of 3.5 or later, and prevents deprecation warnings with CMake 3.27+ and 3.31+.

See related issue https://github.com/paullouisageneau/libdatachannel/issues/1366