### PR TITLE
netinet/sctp_usrreq.c: fix `gcc-16` build error

### DIFF
--- a/usrsctplib/netinet/sctp_usrreq.c
+++ b/usrsctplib/netinet/sctp_usrreq.c
@@ -5568,22 +5568,19 @@ sctp_setopt(struct socket *so, int optname, void *optval, size_t optsize,
 			break;
 		}
 		if (send_out) {
-			int cnt;
 			uint16_t strm;
 			if (strrst->srs_number_streams) {
-				for (i = 0, cnt = 0; i < strrst->srs_number_streams; i++) {
+				for (i = 0; i < strrst->srs_number_streams; i++) {
 					strm = strrst->srs_stream_list[i];
 					if (stcb->asoc.strmout[strm].state == SCTP_STREAM_OPEN) {
 						stcb->asoc.strmout[strm].state = SCTP_STREAM_RESET_PENDING;
-						cnt++;
 					}
 				}
 			} else {
 				/* Its all */
-				for (i = 0, cnt = 0; i < stcb->asoc.streamoutcnt; i++) {
+				for (i = 0; i < stcb->asoc.streamoutcnt; i++) {
 					if (stcb->asoc.strmout[i].state == SCTP_STREAM_OPEN) {
 						stcb->asoc.strmout[i].state = SCTP_STREAM_RESET_PENDING;
-						cnt++;
 					}
 				}
 			}


### PR DESCRIPTION
Upcoming `gcc-16` improved unused variable use detection and now reports unused` cnt` as:

    usrsctplib/netinet/sctp_usrreq.c: In function 'sctp_setopt':
    usrsctplib/netinet/sctp_usrreq.c:5571:29: error: variable 'cnt' set but not used [-Werror=unused-but-set-variable=]
     5571 |                         int cnt;
          |                             ^~~

The change drops unused `cnt` variable.