### PR TITLE
sctp_os_userspace.h: ensure WORDS_BIGENDIAN is defined on powerpc darwin

### DIFF
--- a/usrsctplib/netinet/sctp_os_userspace.h
+++ b/usrsctplib/netinet/sctp_os_userspace.h
@@ -275,6 +275,12 @@ typedef char* caddr_t;
 
 #define SCTP_GET_IF_INDEX_FROM_ROUTE(ro) 1 /* compiles...  TODO use routing socket to determine */
 
+#if defined(__APPLE__) && defined(__POWERPC__)
+#ifndef WORDS_BIGENDIAN
+#define WORDS_BIGENDIAN
+#endif
+#endif
+
 #define BIG_ENDIAN 1
 #define LITTLE_ENDIAN 0
 #ifdef WORDS_BIGENDIAN


### PR DESCRIPTION
Looks like `WORDS_BIGENDIAN` may not be defined, and the fallback is to little-endian. We know for sure that Darwin is BE on powerpc, always.